### PR TITLE
feat(server): add price override for sponsoring pack and options

### DIFF
--- a/server/.github/agents/copilot-instructions.md
+++ b/server/.github/agents/copilot-instructions.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-01-10
 
 ## Active Technologies
+- Kotlin 1.9.x, JVM 21 (Amazon Corretto) + Ktor 2.x, Exposed 0.41+, kotlinx.serialization, Koin (017-override-partnership-price)
+- PostgreSQL (prod) / H2 in-memory (tests) via Exposed ORM (017-override-partnership-price)
 
 - Kotlin 1.9.x with JVM 21 (Amazon Corretto) + Ktor 2.x, Exposed 0.41+, kotlinx.serialization, Koin DI (016-partnership-email-history)
 
@@ -22,6 +24,7 @@ tests/
 Kotlin 1.9.x with JVM 21 (Amazon Corretto): Follow standard conventions
 
 ## Recent Changes
+- 017-override-partnership-price: Added Kotlin 1.9.x, JVM 21 (Amazon Corretto) + Ktor 2.x, Exposed 0.41+, kotlinx.serialization, Koin
 
 - 016-partnership-email-history: Added Kotlin 1.9.x with JVM 21 (Amazon Corretto) + Ktor 2.x, Exposed 0.41+, kotlinx.serialization, Koin DI
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/billing/infrastructure/gateways/models/mappers/QontoInvoiceItem.mapper.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/billing/infrastructure/gateways/models/mappers/QontoInvoiceItem.mapper.kt
@@ -13,14 +13,20 @@ internal fun invoiceItems(
         QontoInvoiceItem(
             title = "Sponsoring ${pack.name}",
             quantity = "1",
-            unitPrice = QontoMoneyAmount(value = "${pack.basePrice}", currency = partnership.currency),
+            unitPrice = QontoMoneyAmount(
+                value = "${pack.packPriceOverride ?: pack.basePrice}",
+                currency = partnership.currency,
+            ),
             vatRate = "0",
         ),
         *pack.optionalOptions.map { option ->
             QontoInvoiceItem(
                 title = option.labelWithValue,
                 quantity = "${option.quantity}",
-                unitPrice = QontoMoneyAmount(value = "${option.price}", currency = partnership.currency),
+                unitPrice = QontoMoneyAmount(
+                    value = "${option.priceOverride ?: option.price}",
+                    currency = partnership.currency,
+                ),
                 vatRate = "0",
             )
         }.toTypedArray(),

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/ApplicationCall.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/ApplicationCall.ext.kt
@@ -69,6 +69,7 @@ val schemas by lazy {
         .register(readResourceFile("/schemas/decline_job_offer_promotion.schema.json"), SchemaType.DRAFT_7)
         .register(readResourceFile("/schemas/assign_organiser_request.schema.json"), SchemaType.DRAFT_7)
         .register(readResourceFile("/schemas/update_partnership_request.schema.json"), SchemaType.DRAFT_7)
+        .register(readResourceFile("/schemas/update_partnership_pricing_request.schema.json"), SchemaType.DRAFT_7)
         .register(readResourceFile("/schemas/send_partnership_email_request.schema.json"), SchemaType.DRAFT_7)
 }
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
@@ -10,6 +10,7 @@ import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddPartnershipCommunicationFieldsMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddPartnershipEmailHistoryMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddPartnershipOrganiserMigration
+import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddPartnershipPriceOverridesMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddPolymorphicSponsoringOptionsMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddProviderManagementMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddSelectableValuePricingMigration
@@ -47,6 +48,7 @@ object MigrationRegistry {
         AddPartnershipOrganiserMigration,
         MigrateNullableColumnInCompanyTableMigration,
         AddPartnershipEmailHistoryMigration,
+        AddPartnershipPriceOverridesMigration,
     )
 
     /**

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/AddPartnershipPriceOverridesMigration.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/AddPartnershipPriceOverridesMigration.kt
@@ -1,0 +1,27 @@
+package fr.devlille.partners.connect.internal.infrastructure.migrations.versions
+
+import fr.devlille.partners.connect.internal.infrastructure.migrations.Migration
+import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipOptionsTable
+import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipsTable
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+
+/**
+ * Migration to add price override capability to partnerships.
+ * Adds nullable pack_price_override column to partnerships table and
+ * nullable price_override column to partnership_options table.
+ */
+object AddPartnershipPriceOverridesMigration : Migration {
+    override val id = "20260227_add_partnership_price_overrides"
+    override val description = "Add pack_price_override to partnerships and price_override to partnership_options"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(PartnershipsTable)
+        SchemaUtils.createMissingTablesAndColumns(PartnershipOptionsTable)
+    }
+
+    override fun down() {
+        throw UnsupportedOperationException(
+            "Rollback not supported - would require dropping columns which could cause data loss",
+        )
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/mappers/PartnershipOptionEntity.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/mappers/PartnershipOptionEntity.ext.kt
@@ -39,23 +39,29 @@ internal fun PartnershipOptionEntity.toDomain(
 private fun PartnershipOptionEntity.toTextPartnershipOption(
     name: String,
     description: String,
-): TextPartnershipOption = TextPartnershipOption(
-    id = option.id.value.toString(),
-    name = name,
-    description = description,
-    // No value to append
-    labelWithValue = name,
-    price = option.price ?: 0,
-    quantity = 1,
-    totalPrice = option.price ?: 0,
-)
+): TextPartnershipOption {
+    val cataloguePrice = option.price ?: 0
+    val effectivePrice = (priceOverride ?: option.price) ?: 0
+    return TextPartnershipOption(
+        id = option.id.value.toString(),
+        name = name,
+        description = description,
+        // No value to append
+        labelWithValue = name,
+        price = cataloguePrice,
+        quantity = 1,
+        totalPrice = effectivePrice,
+        priceOverride = priceOverride,
+    )
+}
 
 private fun PartnershipOptionEntity.toQuantitativePartnershipOption(
     name: String,
     description: String,
 ): QuantitativePartnershipOption {
     val quantity = selectedQuantity ?: 0
-    val price = option.price ?: 0
+    val cataloguePrice = option.price ?: 0
+    val effectivePrice = (priceOverride ?: option.price) ?: 0
     val labelWithValue = if (quantity > 0) "$name ($quantity)" else name
 
     return QuantitativePartnershipOption(
@@ -63,10 +69,11 @@ private fun PartnershipOptionEntity.toQuantitativePartnershipOption(
         name = name,
         description = description,
         labelWithValue = labelWithValue,
-        price = price,
+        price = cataloguePrice,
         quantity = quantity,
-        totalPrice = price * quantity,
+        totalPrice = effectivePrice * quantity,
         typeDescriptor = option.quantitativeDescriptor!!,
+        priceOverride = priceOverride,
     )
 }
 
@@ -75,7 +82,8 @@ private fun PartnershipOptionEntity.toNumberPartnershipOption(
     description: String,
 ): NumberPartnershipOption {
     val fixedQty = option.fixedQuantity ?: 0
-    val price = option.price ?: 0
+    val cataloguePrice = option.price ?: 0
+    val effectivePrice = (priceOverride ?: option.price) ?: 0
     val labelWithValue = if (fixedQty > 0) "$name ($fixedQty)" else name
 
     return NumberPartnershipOption(
@@ -83,10 +91,11 @@ private fun PartnershipOptionEntity.toNumberPartnershipOption(
         name = name,
         description = description,
         labelWithValue = labelWithValue,
-        price = price,
+        price = cataloguePrice,
         quantity = fixedQty,
-        totalPrice = price * fixedQty,
+        totalPrice = effectivePrice * fixedQty,
         typeDescriptor = option.numberDescriptor!!,
+        priceOverride = priceOverride,
     )
 }
 
@@ -97,6 +106,7 @@ private fun PartnershipOptionEntity.toSelectablePartnershipOption(
     val selectedVal = selectedValue
         ?: throw ForbiddenException("Selected value not found for selectable option ${option.id}")
     val labelWithValue = "$name (${selectedVal.value})"
+    val effectivePrice = priceOverride ?: selectedVal.price
 
     return SelectablePartnershipOption(
         id = option.id.value.toString(),
@@ -105,12 +115,13 @@ private fun PartnershipOptionEntity.toSelectablePartnershipOption(
         labelWithValue = labelWithValue,
         price = selectedVal.price,
         quantity = 1,
-        totalPrice = selectedVal.price,
+        totalPrice = effectivePrice,
         typeDescriptor = option.selectableDescriptor!!,
         selectedValue = SelectedValue(
             id = selectedVal.id.value.toString(),
             value = selectedVal.value,
             price = selectedVal.price,
         ),
+        priceOverride = priceOverride,
     )
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/Partnership.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/Partnership.kt
@@ -20,11 +20,13 @@ data class Partnership(
 )
 
 @Serializable
-class PartnershipPack(
+data class PartnershipPack(
     val id: String,
     val name: String,
     @SerialName("base_price")
     val basePrice: Int,
+    @SerialName("pack_price_override")
+    val packPriceOverride: Int? = null,
     @SerialName("required_options")
     val requiredOptions: List<PartnershipOption>,
     @SerialName("optional_options")

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipOption.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipOption.kt
@@ -39,6 +39,9 @@ sealed class PartnershipOption {
     abstract val price: Int
     abstract val quantity: Int
     abstract val totalPrice: Int
+
+    @SerialName("price_override")
+    abstract val priceOverride: Int?
 }
 
 /**
@@ -71,6 +74,8 @@ data class TextPartnershipOption(
     override val quantity: Int = 1,
     @SerialName("total_price")
     override val totalPrice: Int,
+    @SerialName("price_override")
+    override val priceOverride: Int? = null,
 ) : PartnershipOption()
 
 /**
@@ -108,6 +113,8 @@ data class QuantitativePartnershipOption(
     override val totalPrice: Int,
     @SerialName("type_descriptor")
     val typeDescriptor: QuantitativeDescriptor,
+    @SerialName("price_override")
+    override val priceOverride: Int? = null,
 ) : PartnershipOption()
 
 /**
@@ -145,6 +152,8 @@ data class NumberPartnershipOption(
     override val totalPrice: Int,
     @SerialName("type_descriptor")
     val typeDescriptor: NumberDescriptor,
+    @SerialName("price_override")
+    override val priceOverride: Int? = null,
 ) : PartnershipOption()
 
 /**
@@ -190,6 +199,8 @@ data class SelectablePartnershipOption(
     val typeDescriptor: SelectableDescriptor,
     @SerialName("selected_value")
     val selectedValue: SelectedValue,
+    @SerialName("price_override")
+    override val priceOverride: Int? = null,
 ) : PartnershipOption()
 
 /**

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipRepository.kt
@@ -5,6 +5,7 @@ import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedRespons
 import fr.devlille.partners.connect.partnership.infrastructure.api.PartnershipOrganiserResponse
 import java.util.UUID
 
+@Suppress("TooManyFunctions")
 interface PartnershipRepository {
     fun register(eventSlug: String, register: RegisterPartnership): UUID
 
@@ -76,4 +77,29 @@ interface PartnershipRepository {
      *   if partnership has been finalized (validated or declined)
      */
     fun delete(partnershipId: UUID)
+
+    /**
+     * Updates price overrides for the pack and/or options of a partnership.
+     *
+     * Partial update semantics:
+     * - [UpdatePartnershipPricing.packPriceOverride] is always applied: null clears any existing
+     *   override, a non-null value sets/replaces it.
+     * - [UpdatePartnershipPricing.optionsPriceOverrides] when non-null applies overrides only to
+     *   the listed option IDs; all other option overrides are unchanged.
+     *
+     * @param eventSlug Slug of the event owning this partnership
+     * @param partnershipId UUID of the partnership to update
+     * @param pricing Pricing update payload
+     * @return UUID of the updated partnership
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.NotFoundException
+     *   if the event, partnership, or any listed option ID is not found
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ConflictException
+     *   if a non-null [UpdatePartnershipPricing.packPriceOverride] is provided but the partnership
+     *   has no validated sponsoring pack
+     */
+    fun updatePricing(
+        eventSlug: String,
+        partnershipId: UUID,
+        pricing: UpdatePartnershipPricing,
+    ): UUID
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/UpdatePartnershipPricing.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/UpdatePartnershipPricing.kt
@@ -1,0 +1,35 @@
+package fr.devlille.partners.connect.partnership.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request for updating price overrides on a partnership.
+ *
+ * Partial update semantics:
+ * - [packPriceOverride] = null → clear any existing pack override (reverts to catalogue price)
+ * - [packPriceOverride] = integer → set/replace override
+ * - [optionsPriceOverrides] absent (null) → all option overrides unchanged
+ * - [optionsPriceOverrides] present → only listed option IDs are affected; others unchanged
+ */
+@Serializable
+data class UpdatePartnershipPricing(
+    @SerialName("pack_price_override")
+    val packPriceOverride: Int? = null,
+    @SerialName("options_price_overrides")
+    val optionsPriceOverrides: List<OptionPriceOverride>? = null,
+)
+
+/**
+ * Per-option price override entry used in [UpdatePartnershipPricing].
+ *
+ * - [id] must be the UUID of an option already associated with the partnership.
+ * - [priceOverride] = null clears any existing override (revert to catalogue price).
+ * - [priceOverride] = integer sets or replaces the override.
+ */
+@Serializable
+data class OptionPriceOverride(
+    val id: String,
+    @SerialName("price_override")
+    val priceOverride: Int? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipRoutes.kt
@@ -14,6 +14,7 @@ import fr.devlille.partners.connect.partnership.domain.PartnershipRepository
 import fr.devlille.partners.connect.partnership.domain.PartnershipSpeakerRepository
 import fr.devlille.partners.connect.partnership.domain.RegisterPartnership
 import fr.devlille.partners.connect.partnership.domain.UpdatePartnershipContactInfo
+import fr.devlille.partners.connect.partnership.domain.UpdatePartnershipPricing
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
 import io.ktor.http.HttpStatusCode
@@ -46,6 +47,7 @@ fun Route.partnershipRoutes() {
     orgsPartnershipJobOfferRoutes()
     orgsPartnershipJobOfferDecisionRoutes()
     orgsPartnershipOrganiserRoutes()
+    orgsPartnershipPricingRoutes()
     partnershipEmailRoutes()
     partnershipEmailHistoryRoutes()
     orgsPartnershipWebhookRoutes()
@@ -185,6 +187,29 @@ private fun Route.orgsPartnershipOrganiserRoutes() {
             val partnershipId = call.parameters.partnershipId
             val response = repository.removeOrganiser(partnershipId)
             call.respond(HttpStatusCode.OK, response)
+        }
+    }
+}
+
+private fun Route.orgsPartnershipPricingRoutes() {
+    val repository by inject<PartnershipRepository>()
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing") {
+        install(AuthorizedOrganisationPlugin)
+
+        put {
+            val eventSlug = call.parameters.eventSlug
+            val partnershipId = call.parameters.partnershipId
+            val pricing = call.receive<UpdatePartnershipPricing>(
+                schema = "update_partnership_pricing_request.schema.json",
+            )
+            repository.updatePricing(
+                eventSlug = eventSlug,
+                partnershipId = partnershipId,
+                pricing = pricing,
+            )
+            val partnershipDetail = repository.getByIdDetailed(eventSlug, partnershipId)
+            call.respond(HttpStatusCode.OK, partnershipDetail)
         }
     }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipEntity.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipEntity.kt
@@ -97,6 +97,7 @@ class PartnershipEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var communicationPublicationDate by PartnershipsTable.communicationPublicationDate
     var communicationSupportUrl by PartnershipsTable.communicationSupportUrl
     var organiser by UserEntity optionalReferencedOn PartnershipsTable.organiserId
+    var packPriceOverride by PartnershipsTable.packPriceOverride
     var createdAt by PartnershipsTable.createdAt
 }
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipOptionEntity.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipOptionEntity.kt
@@ -80,4 +80,5 @@ class PartnershipOptionEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var option by SponsoringOptionEntity referencedOn PartnershipOptionsTable.optionId
     var selectedQuantity by PartnershipOptionsTable.selectedQuantity
     var selectedValue by SelectableValueEntity optionalReferencedOn PartnershipOptionsTable.selectedValueId
+    var priceOverride by PartnershipOptionsTable.priceOverride
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipOptionsTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipOptionsTable.kt
@@ -16,4 +16,5 @@ object PartnershipOptionsTable : UUIDTable("partnership_options") {
     // Keep for backward compatibility, will be deprecated
     val selectedValue = varchar("selected_value", length = 255).nullable()
     val selectedValueId = reference("selected_value_id", SelectableValuesTable).nullable()
+    val priceOverride = integer("price_override").nullable()
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipsTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipsTable.kt
@@ -30,6 +30,7 @@ object PartnershipsTable : UUIDTable("partnerships") {
     val communicationPublicationDate = datetime("communication_publication_date").nullable()
     val communicationSupportUrl = text("communication_support_url").nullable()
     val organiserId = reference("organiser_id", UsersTable).nullable()
+    val packPriceOverride = integer("pack_price_override").nullable()
     val createdAt = datetime("created_at").clientDefault {
         Clock.System.now().toLocalDateTime(TimeZone.UTC)
     }

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -3934,6 +3934,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing:
+    put:
+      summary: Update partnership price overrides
+      operationId: putPartnershipPricing
+      description: |
+        Update price overrides for the sponsoring pack and/or individual options on a partnership.
+        All fields are optional – omitting a key leaves the existing override unchanged.
+        Setting a field to null clears the override (reverts to catalogue price).
+        Requires organiser permission for the organization.
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Organization slug
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Event slug
+        - name: partnershipId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Partnership ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/update_partnership_pricing_request.schema'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK - Price overrides updated; returns the full updated partnership detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/partnership_detail.schema'
+        '400':
+          description: Bad Request - Invalid request body (e.g. negative price)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '401':
+          description: Unauthorized - No valid session or insufficient org permission
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Event, partnership, or option not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - Pack price override requested but partnership has no validated sponsoring pack
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
   /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/email-history:
     get:
       summary: Get email history for partnership
@@ -4665,6 +4733,8 @@ components:
       $ref: '#/components/schemas/filter_value.schema'
     PartnershipListResponse:
       $ref: '#/components/schemas/partnership_list_response.schema'
+    UpdatePartnershipPricingRequest:
+      $ref: '#/components/schemas/update_partnership_pricing_request.schema'
     user_session.schema:
       $id: user_session.schema.json
       type: object
@@ -6037,6 +6107,12 @@ components:
           type: integer
           minimum: 0
           description: Total cost for this option (same as price)
+        price_override:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+          description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
       additionalProperties: false
     QuantitativePartnershipOption:
       type: object
@@ -6088,6 +6164,12 @@ components:
           enum:
             - job_offer
           description: Quantitative descriptor for user-defined quantities
+        price_override:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+          description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
       additionalProperties: false
     NumberPartnershipOption:
       type: object
@@ -6139,6 +6221,12 @@ components:
           enum:
             - nb_ticket
           description: Number descriptor for fixed quantities
+        price_override:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+          description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
       additionalProperties: false
     SelectablePartnershipOption:
       type: object
@@ -6193,6 +6281,12 @@ components:
           description: Selectable descriptor for predefined choices
         selected_value:
           $ref: '#/components/schemas/SelectedValue'
+        price_override:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+          description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
       additionalProperties: false
     partnership_option.schema:
       $schema: https://json-schema.org/draft/2020-12/schema
@@ -6248,6 +6342,12 @@ components:
               type: integer
               minimum: 0
               description: Total cost for this option (same as price)
+            price_override:
+              type:
+                - integer
+                - 'null'
+              minimum: 0
+              description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
           additionalProperties: false
         QuantitativePartnershipOption:
           type: object
@@ -6299,6 +6399,12 @@ components:
               enum:
                 - job_offer
               description: Quantitative descriptor for user-defined quantities
+            price_override:
+              type:
+                - integer
+                - 'null'
+              minimum: 0
+              description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
           additionalProperties: false
         NumberPartnershipOption:
           type: object
@@ -6350,6 +6456,12 @@ components:
               enum:
                 - nb_ticket
               description: Number descriptor for fixed quantities
+            price_override:
+              type:
+                - integer
+                - 'null'
+              minimum: 0
+              description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
           additionalProperties: false
         SelectablePartnershipOption:
           type: object
@@ -6404,6 +6516,12 @@ components:
               description: Selectable descriptor for predefined choices
             selected_value:
               $ref: '#/components/schemas/SelectedValue'
+            price_override:
+              type:
+                - integer
+                - 'null'
+              minimum: 0
+              description: Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
           additionalProperties: false
         SelectedValue:
           type: object
@@ -6470,6 +6588,12 @@ components:
           type: integer
           minimum: 0
           description: Total price for this pack in cents (base_price + sum of optional option costs)
+        pack_price_override:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+          description: Organiser-set price override for this pack in cents. When non-null, this value replaces base_price in total price computation. Null when no override is active.
       additionalProperties: false
     partnership_process_status.schema:
       $id: partnership_process_status.schema.json
@@ -7703,6 +7827,54 @@ components:
         - partnership_id
         - organiser
       additionalProperties: false
+    update_partnership_pricing_request.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      $id: update_partnership_pricing_request.schema.json
+      title: UpdatePartnershipPricing
+      description: Request body for updating price overrides on a partnership. All fields are optional to support partial updates. Omitting a field leaves the existing override unchanged. Explicitly setting a field to null clears the override.
+      type: object
+      properties:
+        pack_price_override:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+          description: Custom price override for the validated sponsoring pack, in the same unit as the catalogue price. Omit to keep existing override. Set to null to clear the override. Set to 0 for a complimentary pack.
+        options_price_overrides:
+          type:
+            - array
+            - 'null'
+          description: List of price overrides for specific options. Only listed option IDs are affected. Option IDs not listed are left unchanged.
+          items:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                type: string
+                format: uuid
+                description: UUID of the option to override. Must belong to this partnership.
+              price_override:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+                description: Custom price override for this option. Set to null to clear the override.
+            additionalProperties: false
+          minItems: 1
+      additionalProperties: false
+      examples:
+        - pack_price_override: 150000
+        - options_price_overrides:
+            - id: 550e8400-e29b-41d4-a716-446655440001
+              price_override: 5000
+            - id: 550e8400-e29b-41d4-a716-446655440002
+              price_override: null
+        - pack_price_override: 120000
+          options_price_overrides:
+            - id: 550e8400-e29b-41d4-a716-446655440001
+              price_override: 5000
+        - pack_price_override: null
     recipient_status_response.schema:
       $id: recipient_status_response.schema.json
       type: object

--- a/server/application/src/main/resources/openapi/openapi.yaml
+++ b/server/application/src/main/resources/openapi/openapi.yaml
@@ -3901,6 +3901,74 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PartnershipOrganiserResponse"
+  /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing:
+    put:
+      summary: "Update partnership price overrides"
+      operationId: "putPartnershipPricing"
+      description: |
+        Update price overrides for the sponsoring pack and/or individual options on a partnership.
+        All fields are optional – omitting a key leaves the existing override unchanged.
+        Setting a field to null clears the override (reverts to catalogue price).
+        Requires organiser permission for the organization.
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "Organization slug"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "Event slug"
+        - name: "partnershipId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+          description: "Partnership ID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePartnershipPricingRequest"
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: "OK - Price overrides updated; returns the full updated partnership detail"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PartnershipDetail"
+        "400":
+          description: "Bad Request - Invalid request body (e.g. negative price)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: "Unauthorized - No valid session or insufficient org permission"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Event, partnership, or option not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - Pack price override requested but partnership has no validated sponsoring pack"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/email-history:
     get:
       summary: "Get email history for partnership"
@@ -4632,3 +4700,5 @@ components:
       $ref: "../schemas/filter_value.schema.json"
     PartnershipListResponse:
       $ref: "../schemas/partnership_list_response.schema.json"
+    UpdatePartnershipPricingRequest:
+      $ref: "../schemas/update_partnership_pricing_request.schema.json"

--- a/server/application/src/main/resources/schemas/partnership_option.schema.json
+++ b/server/application/src/main/resources/schemas/partnership_option.schema.json
@@ -52,6 +52,11 @@
           "type": "integer",
           "minimum": 0,
           "description": "Total cost for this option (same as price)"
+        },
+        "price_override": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing."
         }
       },
       "additionalProperties": false
@@ -104,6 +109,11 @@
           "type": "string",
           "enum": ["job_offer"],
           "description": "Quantitative descriptor for user-defined quantities"
+        },
+        "price_override": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing."
         }
       },
       "additionalProperties": false
@@ -156,6 +166,11 @@
           "type": "string",
           "enum": ["nb_ticket"],
           "description": "Number descriptor for fixed quantities"
+        },
+        "price_override": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing."
         }
       },
       "additionalProperties": false
@@ -211,6 +226,11 @@
         },
         "selected_value": {
           "$ref": "#/$defs/SelectedValue"
+        },
+        "price_override": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing."
         }
       },
       "additionalProperties": false

--- a/server/application/src/main/resources/schemas/partnership_pack.schema.json
+++ b/server/application/src/main/resources/schemas/partnership_pack.schema.json
@@ -43,6 +43,11 @@
       "type": "integer",
       "minimum": 0,
       "description": "Total price for this pack in cents (base_price + sum of optional option costs)"
+    },
+    "pack_price_override": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Organiser-set price override for this pack in cents. When non-null, this value replaces base_price in total price computation. Null when no override is active."
     }
   },
   "additionalProperties": false

--- a/server/application/src/main/resources/schemas/update_partnership_pricing_request.schema.json
+++ b/server/application/src/main/resources/schemas/update_partnership_pricing_request.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "update_partnership_pricing_request.schema.json",
+  "title": "UpdatePartnershipPricing",
+  "description": "Request body for updating price overrides on a partnership. All fields are optional to support partial updates. Omitting a field leaves the existing override unchanged. Explicitly setting a field to null clears the override.",
+  "type": "object",
+  "properties": {
+    "pack_price_override": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Custom price override for the validated sponsoring pack, in the same unit as the catalogue price. Omit to keep existing override. Set to null to clear the override. Set to 0 for a complimentary pack."
+    },
+    "options_price_overrides": {
+      "type": ["array", "null"],
+      "description": "List of price overrides for specific options. Only listed option IDs are affected. Option IDs not listed are left unchanged.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the option to override. Must belong to this partnership."
+          },
+          "price_override": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "description": "Custom price override for this option. Set to null to clear the override."
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "pack_price_override": 150000
+    },
+    {
+      "options_price_overrides": [
+        { "id": "550e8400-e29b-41d4-a716-446655440001", "price_override": 5000 },
+        { "id": "550e8400-e29b-41d4-a716-446655440002", "price_override": null }
+      ]
+    },
+    {
+      "pack_price_override": 120000,
+      "options_price_overrides": [
+        { "id": "550e8400-e29b-41d4-a716-446655440001", "price_override": 5000 }
+      ]
+    },
+    {
+      "pack_price_override": null
+    }
+  ]
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipPricingRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipPricingRoutesTest.kt
@@ -1,0 +1,409 @@
+package fr.devlille.partners.connect.partnership
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.factories.insertMockedOptionPartnership
+import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
+import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipOptionEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipOptionsTable
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedPackOptions
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringOption
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the partnership pricing endpoint.
+ *
+ * Verifies end-to-end pricing override workflows including DB persistence,
+ * response payload correctness, and partial-update semantics.
+ */
+class PartnershipPricingRoutesTest {
+    @Test
+    fun `SET pack override - response includes pack_price_override and adjusted total_price`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId, basePrice = 200000)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"pack_price_override": 150000}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(
+            body.contains("\"pack_price_override\": 150000") || body.contains("\"pack_price_override\":150000"),
+            "Response must include the override value",
+        )
+        // Verify DB state persisted
+        transaction {
+            val entity = PartnershipEntity.findById(partnershipId)
+            assertNotNull(entity)
+            assertEquals(150000, entity.packPriceOverride)
+        }
+    }
+
+    @Test
+    fun `CLEAR pack override - pack_price_override is null in response and DB`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId, basePrice = 200000)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                    packPriceOverride = 150000,
+                )
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"pack_price_override": null}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val entity = PartnershipEntity.findById(partnershipId)
+            assertNotNull(entity)
+            assertNull(entity.packPriceOverride)
+        }
+    }
+
+    @Test
+    fun `SET option override - price_override is persisted and returned`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId, price = 10000)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                insertMockedOptionPartnership(partnershipId, packId, optionId)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"options_price_overrides": [{"id": "$optionId", "price_override": 7500}]}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(
+            body.contains("\"price_override\": 7500") || body.contains("\"price_override\":7500"),
+            "Response must include the option price override",
+        )
+        // Verify DB state
+        transaction {
+            val optionEntity = PartnershipOptionEntity
+                .find {
+                    (PartnershipOptionsTable.partnershipId eq partnershipId) and
+                        (PartnershipOptionsTable.optionId eq optionId)
+                }
+                .singleOrNull()
+            assertNotNull(optionEntity)
+            assertEquals(7500, optionEntity.priceOverride)
+        }
+    }
+
+    @Test
+    fun `SET and CLEAR option override in two sequential requests`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId, price = 10000)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                insertMockedOptionPartnership(partnershipId, packId, optionId)
+            }
+        }
+
+        // First: set an override
+        val setResponse = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"options_price_overrides": [{"id": "$optionId", "price_override": 5000}]}""")
+        }
+        assertEquals(HttpStatusCode.OK, setResponse.status)
+
+        // Second: clear the override
+        val clearResponse = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"options_price_overrides": [{"id": "$optionId", "price_override": null}]}""")
+        }
+        assertEquals(HttpStatusCode.OK, clearResponse.status)
+
+        transaction {
+            val optionEntity = PartnershipOptionEntity
+                .find {
+                    (PartnershipOptionsTable.partnershipId eq partnershipId) and
+                        (PartnershipOptionsTable.optionId eq optionId)
+                }
+                .singleOrNull()
+            assertNotNull(optionEntity)
+            assertNull(optionEntity.priceOverride, "Override must be cleared after null assignment")
+        }
+    }
+
+    @Test
+    fun `COMBINED pack and option overrides are applied atomically`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId, price = 10000)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                insertMockedOptionPartnership(partnershipId, packId, optionId)
+            }
+        }
+
+        val body = """{"pack_price_override": 120000,
+            "options_price_overrides": [{"id": "$optionId", "price_override": 5000}]}"""
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(body)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val partnership = PartnershipEntity.findById(partnershipId)
+            assertNotNull(partnership)
+            assertEquals(120000, partnership.packPriceOverride)
+
+            val optionEntity = PartnershipOptionEntity
+                .find {
+                    (PartnershipOptionsTable.partnershipId eq partnershipId) and
+                        (PartnershipOptionsTable.optionId eq optionId)
+                }
+                .singleOrNull()
+            assertNotNull(optionEntity)
+            assertEquals(5000, optionEntity.priceOverride)
+        }
+    }
+
+    @Test
+    fun `ATOMICITY - invalid option ID rolls back all changes including valid pack override`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val unknownOptionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                // No option inserted — unknownOptionId will trigger NotFoundException
+            }
+        }
+
+        val body = """{"pack_price_override": 120000,
+            "options_price_overrides": [{"id": "$unknownOptionId", "price_override": 1000}]}"""
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(body)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        // Verify the pack override was NOT persisted (transaction rolled back)
+        transaction {
+            val entity = PartnershipEntity.findById(partnershipId)
+            assertNotNull(entity)
+            assertNull(entity.packPriceOverride, "Pack override must not be persisted when transaction rolls back")
+        }
+    }
+
+    @Test
+    fun `OMIT options_price_overrides - other option overrides remain unchanged`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId, price = 10000)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                // Pre-seed with existing override
+                insertMockedOptionPartnership(partnershipId, packId, optionId, priceOverride = 3000)
+            }
+        }
+
+        // Body omits options_price_overrides → option override must be unchanged
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val optionEntity = PartnershipOptionEntity
+                .find {
+                    (PartnershipOptionsTable.partnershipId eq partnershipId) and
+                        (PartnershipOptionsTable.optionId eq optionId)
+                }
+                .singleOrNull()
+            assertNotNull(optionEntity)
+            assertEquals(3000, optionEntity.priceOverride, "Option override must be preserved when key is absent")
+        }
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/factories/Partnership.factory.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/factories/Partnership.factory.kt
@@ -32,6 +32,7 @@ fun insertMockedPartnership(
     communicationPublicationDate: LocalDateTime? = null,
     communicationSupportUrl: String? = null,
     organiserId: UUID? = null,
+    packPriceOverride: Int? = null,
 ): PartnershipEntity = PartnershipEntity.new(id) {
     this.event = EventEntity[eventId]
     this.company = CompanyEntity[companyId]
@@ -51,16 +52,19 @@ fun insertMockedPartnership(
     this.communicationPublicationDate = communicationPublicationDate
     this.communicationSupportUrl = communicationSupportUrl
     this.organiser = organiserId?.let { UserEntity[it] }
+    this.packPriceOverride = packPriceOverride
 }
 
 fun insertMockedOptionPartnership(
     partnershipId: UUID,
     packId: UUID,
     optionId: UUID,
+    priceOverride: Int? = null,
 ) = PartnershipOptionEntity.new {
     this.partnership = PartnershipEntity[partnershipId]
     this.option = SponsoringOptionEntity[optionId]
     this.pack = SponsoringPackEntity[packId]
+    this.priceOverride = priceOverride
 }
 
 fun insertMockedPartnershipEmail(

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipPricingRoutePutTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipPricingRoutePutTest.kt
@@ -1,0 +1,516 @@
+package fr.devlille.partners.connect.partnership.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.factories.insertMockedOptionPartnership
+import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedPackOptions
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringOption
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Contract tests for PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing
+ *
+ * Covers: US1 (pack price override) and US2 (option price overrides)
+ * Validates all HTTP status codes without asserting full business logic.
+ */
+class PartnershipPricingRoutePutTest {
+    // --- US1: Pack price overrides ---
+
+    @Test
+    fun `PUT returns 200 when setting a valid pack price override`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"pack_price_override": 150000}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("pack_price_override"))
+    }
+
+    @Test
+    fun `PUT returns 200 when clearing a pack price override with null`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                    packPriceOverride = 100000,
+                )
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"pack_price_override": null}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `PUT returns 200 for a pending partnership (status must not block override)`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                // Pending = selectedPack set but not validatedAt
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                )
+            }
+        }
+
+        // An empty body is valid — pack_price_override absent means null → clears any existing override
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `PUT returns 400 for negative pack price`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                )
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"pack_price_override": -1}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `PUT returns 409 when setting pack override on partnership with no validated pack`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                // Partnership has no pack at all
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                )
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"pack_price_override": 80000}""")
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+
+    @Test
+    fun `PUT returns 401 without Authorization header`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedPartnership(id = partnershipId, eventId = eventId, companyId = companyId)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PUT returns 401 when user has no permission for the org`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val otherOrgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                // userId only has permission for otherOrgId, not orgId
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrganisationEntity(otherOrgId)
+                insertMockedOrgaPermission(otherOrgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedPartnership(id = partnershipId, eventId = eventId, companyId = companyId)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 for non-existent event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 for non-existent partnership`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    // --- US2: Option price overrides ---
+
+    @Test
+    fun `PUT returns 200 OK for valid single option override`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                insertMockedOptionPartnership(partnershipId, packId, optionId)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(
+                """{"options_price_overrides": [{"id": "$optionId", "price_override": 5000}]}""",
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `PUT returns 200 OK when overriding multiple options simultaneously`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId1 = UUID.randomUUID()
+        val optionId2 = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId1, eventId)
+                insertMockedSponsoringOption(optionId2, eventId)
+                insertMockedPackOptions(packId, optionId1, required = false)
+                insertMockedPackOptions(packId, optionId2, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                insertMockedOptionPartnership(partnershipId, packId, optionId1)
+                insertMockedOptionPartnership(partnershipId, packId, optionId2)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(
+                """{"options_price_overrides": [
+                    {"id": "$optionId1", "price_override": 5000},
+                    {"id": "$optionId2", "price_override": 7500}
+                ]}""",
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `PUT returns 200 OK when clearing an existing option override`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                // Pre-seed an existing override
+                insertMockedOptionPartnership(partnershipId, packId, optionId, priceOverride = 5000)
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(
+                """{"options_price_overrides": [{"id": "$optionId", "price_override": null}]}""",
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 for an option not associated with the partnership`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val nonExistentOptionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                    validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+                // No option entity inserted — nonExistentOptionId is not associated
+            }
+        }
+
+        val response = client.put("/orgs/$orgId/events/$eventId/partnerships/$partnershipId/pricing") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(
+                """{"options_price_overrides": [{"id": "$nonExistentOptionId", "price_override": 1000}]}""",
+            )
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+}

--- a/server/specs/017-override-partnership-price/checklists/requirements.md
+++ b/server/specs/017-override-partnership-price/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Override Partnership Pricing
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass — specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Assumptions documented: currency unchanged, zero price valid, existing update endpoint extended, existing auth mechanism reused

--- a/server/specs/017-override-partnership-price/contracts/openapi-put-pricing.yaml
+++ b/server/specs/017-override-partnership-price/contracts/openapi-put-pricing.yaml
@@ -1,0 +1,187 @@
+# OpenAPI Specification Addition
+
+**Feature**: Override Partnership Pricing  
+**Endpoint**: `PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing`  
+**Auth**: `AuthorizedOrganisationPlugin` (organiser must belong to the organisation)
+
+---
+
+## New Endpoint
+
+Add this operation to the existing `openapi.yaml` under path  
+`/orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing`:
+
+```yaml
+paths:
+  /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing:
+    put:
+      summary: Override partnership pricing
+      description: |
+        Sets optional price overrides for the validated sponsoring pack and/or
+        one or more options on an existing partnership.
+
+        Only authenticated organisers belonging to the owning organisation may
+        call this endpoint.
+
+        Partial update semantics apply:
+        - Omitting `pack_price_override` from the request body leaves the
+          existing pack override unchanged.
+        - Setting `pack_price_override` to `null` explicitly clears the override
+          (catalogue price is used again).
+        - Setting `pack_price_override` to a non-negative integer sets or
+          replaces the override.
+        - Omitting `options_price_overrides` leaves all option overrides unchanged.
+        - Including `options_price_overrides` only affects the listed option IDs.
+        - Setting an option's `price_override` to `null` clears that option's override.
+
+        No notification is sent to the partner when pricing is updated.
+      operationId: updatePartnershipPricing
+      tags:
+        - Partnerships
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          description: Organisation slug
+          schema:
+            type: string
+          example: "devlille"
+        - name: eventSlug
+          in: path
+          required: true
+          description: Unique slug identifier for the event
+          schema:
+            type: string
+          example: "devlille-2025"
+        - name: partnershipId
+          in: path
+          required: true
+          description: UUID of the partnership to update
+          schema:
+            type: string
+            format: uuid
+          example: "550e8400-e29b-41d4-a716-446655440000"
+      requestBody:
+        required: true
+        description: Price override fields to update (all optional for partial updates)
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePartnershipPricing"
+            examples:
+              overridePackOnly:
+                summary: Override pack price only
+                value:
+                  pack_price_override: 150000
+              overrideOptionsOnly:
+                summary: Override two option prices
+                value:
+                  options_price_overrides:
+                    - id: "550e8400-e29b-41d4-a716-446655440001"
+                      price_override: 5000
+                    - id: "550e8400-e29b-41d4-a716-446655440002"
+                      price_override: 10000
+              overrideBoth:
+                summary: Override pack and one option
+                value:
+                  pack_price_override: 120000
+                  options_price_overrides:
+                    - id: "550e8400-e29b-41d4-a716-446655440001"
+                      price_override: 5000
+              clearPackOverride:
+                summary: Clear pack override (revert to catalogue price)
+                value:
+                  pack_price_override: null
+      responses:
+        "200":
+          description: Pricing updated. Returns the updated partnership detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PartnershipDetail"
+        "400":
+          description: |
+            Validation failed. Possible causes:
+            - Override price is negative
+            - Option ID is not associated with this partnership
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "401":
+          description: Not authenticated
+        "403":
+          description: Authenticated user does not belong to the owning organisation
+        "404":
+          description: Event or partnership not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "409":
+          description: |
+            Conflict. Possible causes:
+            - `pack_price_override` provided but partnership has no validated sponsoring pack
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+```
+
+---
+
+## Schema Components to Add / Update
+
+### New component: `UpdatePartnershipPricing`
+
+Add to `components/schemas` in `openapi.yaml`:
+
+```yaml
+UpdatePartnershipPricing:
+  $ref: "schemas/update_partnership_pricing_request.schema.json"
+```
+
+---
+
+### Updated component: `PartnershipPack`
+
+Add `pack_price_override` field to the existing `PartnershipPack` schema:
+
+```yaml
+pack_price_override:
+  type: integer
+  nullable: true
+  minimum: 0
+  description: >
+    Organiser-set price override for this pack, in the same unit as base_price.
+    Null when no override is active. When present, this supersedes base_price for
+    billing purposes. total_price is computed using this value when set.
+```
+
+---
+
+### Updated component: `PartnershipOption` (all subtypes)
+
+Add `price_override` field to all four `PartnershipOption` subtypes (text, typed_quantitative, typed_number, typed_selectable):
+
+```yaml
+price_override:
+  type: integer
+  nullable: true
+  minimum: 0
+  description: >
+    Organiser-set price override for this option, in the same unit as price.
+    Null when no override is active. When present, this supersedes price for
+    billing purposes. total_price is computed using this value when set.
+```

--- a/server/specs/017-override-partnership-price/contracts/update_partnership_pricing_request.schema.json
+++ b/server/specs/017-override-partnership-price/contracts/update_partnership_pricing_request.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "update_partnership_pricing_request.schema.json",
+  "title": "UpdatePartnershipPricing",
+  "description": "Request body for updating price overrides on a partnership. All fields are optional to support partial updates. Omitting a field leaves the existing override unchanged. Explicitly setting a field to null clears the override.",
+  "type": "object",
+  "properties": {
+    "pack_price_override": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Custom price override for the validated sponsoring pack, in the same unit as the catalogue price. Omit to keep existing override. Set to null to clear the override. Set to 0 for a complimentary pack."
+    },
+    "options_price_overrides": {
+      "type": ["array", "null"],
+      "description": "List of price overrides for specific options. Only listed option IDs are affected. Option IDs not listed are left unchanged.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the option to override. Must belong to this partnership."
+          },
+          "price_override": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "description": "Custom price override for this option. Set to null to clear the override."
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "pack_price_override": 150000
+    },
+    {
+      "options_price_overrides": [
+        { "id": "550e8400-e29b-41d4-a716-446655440001", "price_override": 5000 },
+        { "id": "550e8400-e29b-41d4-a716-446655440002", "price_override": null }
+      ]
+    },
+    {
+      "pack_price_override": 120000,
+      "options_price_overrides": [
+        { "id": "550e8400-e29b-41d4-a716-446655440001", "price_override": 5000 }
+      ]
+    },
+    {
+      "pack_price_override": null
+    }
+  ]
+}

--- a/server/specs/017-override-partnership-price/data-model.md
+++ b/server/specs/017-override-partnership-price/data-model.md
@@ -1,0 +1,217 @@
+# Data Model: Override Partnership Pricing
+
+**Feature**: `017-override-partnership-price`  
+**Date**: 2026-02-27
+
+---
+
+## Database Schema Changes
+
+### `PartnershipsTable` — new column
+
+```kotlin
+val packPriceOverride = integer("pack_price_override").nullable()
+```
+
+| Column | Type | Nullable | Default | Constraint |
+|---|---|---|---|---|
+| `pack_price_override` | `INTEGER` | ✅ | `NULL` | `CHECK (pack_price_override >= 0)` |
+
+`NULL` → no override active; catalogue `base_price` is used.  
+`0` → valid override (complimentary pack).
+
+---
+
+### `PartnershipOptionsTable` — new column
+
+```kotlin
+val priceOverride = integer("price_override").nullable()
+```
+
+| Column | Type | Nullable | Default | Constraint |
+|---|---|---|---|---|
+| `price_override` | `INTEGER` | ✅ | `NULL` | `CHECK (price_override >= 0)` |
+
+`NULL` → no override active; catalogue `option.price` is used.
+
+---
+
+## Entity Changes
+
+### `PartnershipEntity` — new property
+
+```kotlin
+var packPriceOverride by PartnershipsTable.packPriceOverride
+```
+
+### `PartnershipOptionEntity` — new property
+
+```kotlin
+var priceOverride by PartnershipOptionsTable.priceOverride
+```
+
+---
+
+## Domain Model Changes
+
+### `PartnershipPack` — new field + effective `totalPrice`
+
+```kotlin
+@Serializable
+class PartnershipPack(
+    val id: String,
+    val name: String,
+    @SerialName("base_price")
+    val basePrice: Int,                          // catalogue price (never mutated)
+    @SerialName("pack_price_override")
+    val packPriceOverride: Int? = null,          // NEW – null if no override active
+    @SerialName("required_options")
+    val requiredOptions: List<PartnershipOption>,
+    @SerialName("optional_options")
+    val optionalOptions: List<PartnershipOption>,
+    @SerialName("total_price")
+    val totalPrice: Int,                         // (packPriceOverride ?: basePrice) + Σ optionalOptions.totalPrice
+)
+```
+
+**Effective pack price** = `packPriceOverride ?: basePrice`
+
+---
+
+### `PartnershipOption` sealed class — new abstract field + effective `totalPrice`
+
+New abstract field added to the sealed class:
+
+```kotlin
+@SerialName("price_override")
+abstract val priceOverride: Int?          // NEW – null if no override active
+```
+
+Added to all four concrete subtypes:
+- `TextPartnershipOption`
+- `QuantitativePartnershipOption`
+- `NumberPartnershipOption`
+- `SelectablePartnershipOption`
+
+**Effective option price** = `priceOverride ?: price`
+
+`totalPrice` for each subtype is recomputed:
+
+| Subtype | Old `totalPrice` | New `totalPrice` |
+|---|---|---|
+| `TextPartnershipOption` | `option.price ?: 0` | `(priceOverride ?: option.price) ?: 0` |
+| `QuantitativePartnershipOption` | `price * quantity` | `(priceOverride ?: price) * quantity` |
+| `NumberPartnershipOption` | `price * fixedQty` | `(priceOverride ?: price) * fixedQty` |
+| `SelectablePartnershipOption` | `selectedValue.price` | `priceOverride ?: selectedValue.price` |
+
+---
+
+### New domain request: `UpdatePartnershipPricing`
+
+```kotlin
+@Serializable
+data class UpdatePartnershipPricing(
+    @SerialName("pack_price_override")
+    val packPriceOverride: Int? = null,           // omit = no change; null = clear; integer = set
+    @SerialName("options_price_overrides")
+    val optionsPriceOverrides: List<OptionPriceOverride>? = null,  // omit = no change
+)
+
+@Serializable
+data class OptionPriceOverride(
+    val id: String,                               // option UUID (must belong to this partnership)
+    @SerialName("price_override")
+    val priceOverride: Int? = null,               // null = clear this option's override
+)
+```
+
+**Partial-update logic in repository:**
+- `packPriceOverride` field in request JSON → set/clear pack override.  
+  Absent from JSON (default `null` used) → **no change** to existing value — handled via an explicit "was the field present in the request?" sentinel. (Implementation uses a wrapper type or JSON element inspection, see quickstart.md.)
+- `optionsPriceOverrides` absent → no change to any option override.  
+  Present but empty list → no changes.  
+  Present with entries → only listed option IDs are updated.
+
+---
+
+## Mapper Changes
+
+### `SponsoringPackEntity.ext.kt` — accept override parameter
+
+New signature:
+
+```kotlin
+internal fun SponsoringPackEntity.toDomain(
+    language: String,
+    partnershipId: UUID,
+    packPriceOverride: Int? = null,       // NEW
+): PartnershipPack
+```
+
+`totalPrice` computation:
+
+```kotlin
+val effectiveBasePrice = packPriceOverride ?: basePrice
+val totalPrice = effectiveBasePrice + optionalOptions.sumOf { it.totalPrice }
+```
+
+### `PartnershipOptionEntity.ext.kt` — use effective price
+
+All private mapping functions updated to derive price as:
+
+```kotlin
+val price = (priceOverride ?: option.price) ?: 0
+```
+
+`totalPrice` uses `price` (the effective value) everywhere.
+
+---
+
+## Billing Integration
+
+### `QontoInvoiceItem.mapper.kt` — `invoiceItems()`
+
+Before:
+```kotlin
+unitPrice = QontoMoneyAmount(value = "${pack.basePrice}", ...)
+// option:
+unitPrice = QontoMoneyAmount(value = "${option.price}", ...)
+```
+
+After:
+```kotlin
+unitPrice = QontoMoneyAmount(value = "${pack.packPriceOverride ?: pack.basePrice}", ...)
+// option:
+unitPrice = QontoMoneyAmount(value = "${option.priceOverride ?: option.price}", ...)
+```
+
+No changes required elsewhere in the billing pipeline.
+
+---
+
+## Validation Rules
+
+| Field | Rule |
+|---|---|
+| `packPriceOverride` | Non-negative integer when present (`>= 0`) |
+| `optionsPriceOverrides[].id` | Valid UUID; must correspond to an option belonging to this partnership |
+| `optionsPriceOverrides[].priceOverride` | Non-negative integer OR null (clear override) |
+| Pack must exist | If `packPriceOverride` is set and partnership has no validated pack → 409 Conflict |
+
+---
+
+## State Transitions
+
+```
+PartnershipOption.priceOverride
+  NULL ──[set override]──► Integer
+  Integer ──[clear override]──► NULL
+  Integer ──[update override]──► new Integer
+
+PartnershipsTable.pack_price_override
+  NULL ──[set override]──► Integer
+  Integer ──[clear override]──► NULL
+  Integer ──[update override]──► new Integer
+```
+
+No partnership lifecycle status constraint (FR-014: overrides allowed regardless of status).

--- a/server/specs/017-override-partnership-price/plan.md
+++ b/server/specs/017-override-partnership-price/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Override Partnership Pricing
+
+**Branch**: `017-override-partnership-price` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/017-override-partnership-price/spec.md`
+
+## Summary
+
+Organisers need to negotiate custom prices for sponsoring packs and individual options on a per-partnership basis, without mutating shared catalogue data. The implementation extends `PartnershipsTable` and `PartnershipOptionsTable` with nullable `pack_price_override` / `price_override` columns, propagates effective prices through the existing domain mappers, exposes a new org-authenticated `PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing` endpoint, and updates the Qonto billing mapper to use effective (overridden) prices.
+
+## Technical Context
+
+**Language/Version**: Kotlin 1.9.x, JVM 21 (Amazon Corretto)  
+**Primary Dependencies**: Ktor 2.x, Exposed 0.41+, kotlinx.serialization, Koin  
+**Storage**: PostgreSQL (prod) / H2 in-memory (tests) via Exposed ORM  
+**Testing**: JUnit 5 via `./gradlew test --no-daemon`; H2 shared-DB pattern (`moduleSharedDb`)  
+**Target Platform**: Linux server (JVM)  
+**Project Type**: Single project (server only)  
+**Performance Goals**: Same as existing endpoints — no special performance constraints  
+**Constraints**: Zero ktlint violations; zero detekt violations; ≥ 80% test coverage for new code  
+**Scale/Scope**: Affects `partnership` domain only; 2 new DB columns, 1 new endpoint, mapper updates, billing mapper update
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate | Status | Notes |
+|---|---|---|---|
+| I. Code Quality Standards | Zero ktlint + detekt violations | ✅ PASS | All new code follows existing patterns; `ktlintFormat` run before commit |
+| II. Comprehensive Testing | ≥ 80% coverage, contract + integration tests, HTTP route testing | ✅ PASS | `PartnershipPricingRoutePutTest` (contract) + `PartnershipPricingRoutesTest` (integration) planned |
+| II. Test Architecture | `moduleSharedDb` pattern, UUID-based factory defaults | ✅ PASS | Tests follow shared-DB pattern per constitution |
+| II. Contract Tests | Written BEFORE implementation (TDD), all status codes covered | ✅ PASS | Planned as first step per quickstart.md Step 8 |
+
+No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-override-partnership-price/
+├── plan.md              ← this file
+├── research.md          ← pricing flow analysis, storage and API design decisions
+├── data-model.md        ← DB schema, domain model, mapper changes, billing changes
+├── quickstart.md        ← step-by-step implementation guide
+├── checklists/
+│   └── requirements.md
+└── contracts/
+    ├── openapi-put-pricing.yaml                    ← new endpoint OpenAPI fragment
+    └── update_partnership_pricing_request.schema.json  ← JSON schema for request body
+```
+
+### Source Code (affected files)
+
+```text
+application/src/main/kotlin/fr/devlille/partners/connect/
+│
+├── partnership/
+│   ├── domain/
+│   │   ├── PartnershipOption.kt                    ← add priceOverride field to sealed class + subtypes
+│   │   ├── PartnershipPack.kt                      ← add packPriceOverride field
+│   │   └── UpdatePartnershipPricing.kt             ← NEW: request domain model
+│   │   └── PartnershipRepository.kt                ← add updatePricing() method
+│   │
+│   ├── application/
+│   │   ├── PartnershipRepositoryExposed.kt         ← implement updatePricing(); pass packPriceOverride to mappers
+│   │   └── mappers/
+│   │       ├── PartnershipOptionEntity.ext.kt      ← use (priceOverride ?: option.price) in all price calculations
+│   │       └── SponsoringPackEntity.ext.kt         ← accept packPriceOverride param; use effective price for totalPrice
+│   │
+│   └── infrastructure/
+│       ├── api/
+│       │   └── PartnershipRoutes.kt                ← add orgsPartnershipPricingRoutes() and register it
+│       └── db/
+│           ├── PartnershipsTable.kt                ← add pack_price_override column
+│           ├── PartnershipEntity.kt                ← add packPriceOverride property
+│           ├── PartnershipOptionsTable.kt          ← add price_override column
+│           └── PartnershipOptionEntity.kt          ← add priceOverride property
+│
+└── billing/
+    └── infrastructure/
+        └── gateways/
+            └── models/
+                └── mappers/
+                    └── QontoInvoiceItem.mapper.kt  ← use effective prices (override ?: catalogue)
+
+application/src/main/resources/
+├── schemas/
+│   ├── update_partnership_pricing_request.schema.json  ← NEW
+│   ├── partnership_pack.schema.json                    ← add pack_price_override field
+│   └── partnership_option.schema.json                  ← add price_override field
+
+application/src/test/kotlin/fr/devlille/partners/connect/
+└── partnership/
+    ├── infrastructure/api/
+    │   └── PartnershipPricingRoutePutTest.kt       ← NEW contract test
+    └── PartnershipPricingRoutesTest.kt             ← NEW integration test
+```
+
+**Structure Decision**: Single project — server only. All changes are within `application/src/main/kotlin` and corresponding test paths.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification required.

--- a/server/specs/017-override-partnership-price/quickstart.md
+++ b/server/specs/017-override-partnership-price/quickstart.md
@@ -1,0 +1,380 @@
+# Quickstart: Override Partnership Pricing
+
+**Feature**: `017-override-partnership-price`  
+**Branch**: `017-override-partnership-price`
+
+> Implement in the order shown below. Each step is independently buildable.
+
+---
+
+## Prerequisites
+
+```bash
+cd server
+git checkout 017-override-partnership-price
+./gradlew build --no-daemon   # verify baseline compiles
+```
+
+---
+
+## Step 1 — DB columns (Table + Entity)
+
+### `PartnershipsTable.kt`
+Add **after** `organiserId`:
+```kotlin
+val packPriceOverride = integer("pack_price_override").nullable()
+```
+
+### `PartnershipOptionsTable.kt`
+Add **after** `selectedValueId`:
+```kotlin
+val priceOverride = integer("price_override").nullable()
+```
+
+### `PartnershipEntity.kt`
+Add property delegation (alongside the other `var` fields):
+```kotlin
+var packPriceOverride by PartnershipsTable.packPriceOverride
+```
+
+### `PartnershipOptionEntity.kt`
+Add property delegation (alongside the other `var` properties):
+```kotlin
+var priceOverride by PartnershipOptionsTable.priceOverride
+```
+
+---
+
+## Step 2 — Domain models
+
+### `PartnershipPack.kt` — add `packPriceOverride` field
+
+Before `requiredOptions`:
+```kotlin
+@SerialName("pack_price_override")
+val packPriceOverride: Int? = null,
+```
+
+### `PartnershipOption.kt` — add abstract `priceOverride` + update all subtypes
+
+In the sealed class, **after** `abstract val totalPrice`:
+```kotlin
+@SerialName("price_override")
+abstract val priceOverride: Int?
+```
+
+Add concrete field to all four subtypes (`TextPartnershipOption`, `QuantitativePartnershipOption`, `NumberPartnershipOption`, `SelectablePartnershipOption`):
+```kotlin
+@SerialName("price_override")
+override val priceOverride: Int? = null,
+```
+
+### New file: `UpdatePartnershipPricing.kt`
+
+```kotlin
+package fr.devlille.partners.connect.partnership.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request for updating price overrides on a partnership.
+ *
+ * Partial update semantics:
+ * - [packPriceOverride] absent from JSON → existing pack override unchanged
+ * - [packPriceOverride] = null → clear existing pack override
+ * - [packPriceOverride] = integer → set/replace pack override
+ * - [optionsPriceOverrides] absent → all option overrides unchanged
+ * - [optionsPriceOverrides] present → only listed option IDs are affected
+ */
+@Serializable
+data class UpdatePartnershipPricing(
+    @SerialName("pack_price_override")
+    val packPriceOverride: Int? = null,
+    @SerialName("options_price_overrides")
+    val optionsPriceOverrides: List<OptionPriceOverride>? = null,
+)
+
+@Serializable
+data class OptionPriceOverride(
+    /** UUID of the option — must belong to this partnership. */
+    val id: String,
+    @SerialName("price_override")
+    val priceOverride: Int? = null,
+)
+```
+
+> ⚠️ **Partial-update note for `packPriceOverride`**: With `kotlinx.serialization`,
+> there is no built-in way to distinguish "field omitted" from "field = null".
+> For this endpoint the JSON schema validation (`call.receive<T>(schema)`) is the
+> primary validation gate. The repository implementation should treat an absent
+> `packPriceOverride` (resulting in Kotlin `null`) as "**do not update**" when
+> the JSON body contains no `pack_price_override` key.
+>
+> The recommended approach is to parse the raw request body as `JsonObject` first,
+> check for key presence, then deserialize selectively. See the repository step
+> for implementation details.
+
+---
+
+## Step 3 — Update mappers
+
+### `PartnershipOptionEntity.ext.kt`
+
+In each `toX` private function, replace every occurrence of:
+```kotlin
+val price = option.price ?: 0
+```
+with:
+```kotlin
+val price = (priceOverride ?: option.price) ?: 0
+```
+
+For `SelectablePartnershipOption` (`toSelectablePartnershipOption`), replace:
+```kotlin
+totalPrice = selectedVal.price,
+```
+with:
+```kotlin
+totalPrice = priceOverride ?: selectedVal.price,
+```
+
+Pass `priceOverride = priceOverride` to each subtype constructor.
+
+### `SponsoringPackEntity.ext.kt`
+
+Update function signature:
+```kotlin
+internal fun SponsoringPackEntity.toDomain(
+    language: String,
+    partnershipId: UUID,
+    packPriceOverride: Int? = null,   // NEW
+): PartnershipPack
+```
+
+Update `totalPrice` computation:
+```kotlin
+val effectiveBasePrice = packPriceOverride ?: basePrice
+val totalPrice = effectiveBasePrice + optionalOptions.sumOf { it.totalPrice }
+```
+
+Pass `packPriceOverride = packPriceOverride` to `PartnershipPack(...)`.
+
+### `PartnershipRepositoryExposed.kt`
+
+In each call to `pack.toDomain(...)` (4 locations — `getById`, `getByIdDetailed`, and wherever else it's called), add:
+```kotlin
+packPriceOverride = partnership.packPriceOverride,
+```
+
+---
+
+## Step 4 — Repository interface + implementation
+
+### `PartnershipRepository.kt` — add method
+
+```kotlin
+/**
+ * Updates price overrides for the pack and/or options of a partnership.
+ *
+ * Partial update: only fields present in [pricing] are applied.
+ *
+ * @throws NotFoundException if event or partnership not found
+ * @throws NotFoundException if any option ID in [pricing] does not belong to
+ *   this partnership
+ * @throws ConflictException if [pricing.packPriceOverride] is set but partnership
+ *   has no validated sponsoring pack
+ */
+fun updatePricing(
+    eventSlug: String,
+    partnershipId: UUID,
+    pricing: UpdatePartnershipPricing,
+    packOverridePresent: Boolean,
+): UUID
+```
+
+> The `packOverridePresent: Boolean` parameter distinguishes "field was in the
+> JSON body" (true) from "field was absent" (false), enabling true partial-update
+> semantics for the pack override.
+
+### `PartnershipRepositoryExposed.kt` — implement
+
+```kotlin
+override fun updatePricing(
+    eventSlug: String,
+    partnershipId: UUID,
+    pricing: UpdatePartnershipPricing,
+    packOverridePresent: Boolean,
+): UUID = transaction {
+    val event = EventEntity.findBySlug(eventSlug)
+        ?: throw NotFoundException("Event with slug $eventSlug not found")
+    val partnership = PartnershipEntity.singleByEventAndPartnership(event.id.value, partnershipId)
+        ?: throw NotFoundException("Partnership not found")
+
+    // Pack override — only update if key was present in request JSON
+    if (packOverridePresent) {
+        if (pricing.packPriceOverride != null && partnership.validatedPack() == null) {
+            throw ConflictException(
+                "Cannot set pack price override: partnership has no validated sponsoring pack",
+            )
+        }
+        partnership.packPriceOverride = pricing.packPriceOverride
+    }
+
+    // Option overrides — update only the listed option IDs
+    pricing.optionsPriceOverrides?.forEach { override ->
+        val optionId = override.id.toUUID()
+        val optionEntity = PartnershipOptionEntity
+            .find {
+                (PartnershipOptionsTable.partnershipId eq partnershipId) and
+                    (PartnershipOptionsTable.optionId eq optionId)
+            }
+            .singleOrNull()
+            ?: throw NotFoundException(
+                "Option $optionId is not associated with partnership $partnershipId",
+            )
+        optionEntity.priceOverride = override.priceOverride
+    }
+
+    partnership.id.value
+}
+```
+
+---
+
+## Step 5 — Route
+
+In `PartnershipRoutes.kt`, add inside `orgsPartnershipRoutes()` or as a new private function. Recommended: new private function `orgsPartnershipPricingRoutes()`, registered in `partnershipRoutes()`.
+
+```kotlin
+private fun Route.orgsPartnershipPricingRoutes() {
+    val repository by inject<PartnershipRepository>()
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing") {
+        install(AuthorizedOrganisationPlugin)
+
+        put {
+            val eventSlug = call.parameters.eventSlug
+            val partnershipId = call.parameters.partnershipId
+
+            // Parse raw JSON to detect key presence for partial-update semantics
+            val jsonBody = call.receiveText()
+            val jsonObject = Json.parseToJsonElement(jsonBody).jsonObject
+            val packOverridePresent = jsonObject.containsKey("pack_price_override")
+
+            // Validate against schema then deserialize
+            val pricing = call.receive<UpdatePartnershipPricing>(
+                schema = "update_partnership_pricing_request.schema.json",
+            )
+
+            // Note: receive() above consumes the body; use jsonBody for detection
+            // Alternative: use a custom schema validation step on jsonBody first,
+            // then deserialize from jsonBody directly.
+
+            repository.updatePricing(
+                eventSlug = eventSlug,
+                partnershipId = partnershipId.toUUID(),
+                pricing = pricing,
+                packOverridePresent = packOverridePresent,
+            )
+
+            val partnershipDetail = repository.getByIdDetailed(eventSlug, partnershipId.toUUID())
+            call.respond(HttpStatusCode.OK, partnershipDetail)
+        }
+    }
+}
+```
+
+> **Body double-read note**: `call.receiveText()` and `call.receive<T>()` both
+> consume the body. Use `receiveText()` once, parse manually with
+> `Json.decodeFromString<UpdatePartnershipPricing>(jsonBody)` after schema
+> validation, rather than calling both `receiveText()` and `receive<T>()`.
+
+Also register in `partnershipRoutes()`:
+```kotlin
+orgsPartnershipPricingRoutes()
+```
+
+---
+
+## Step 6 — Billing integration
+
+In `QontoInvoiceItem.mapper.kt`, update `invoiceItems()`:
+
+```kotlin
+// Pack line item
+unitPrice = QontoMoneyAmount(
+    value = "${pack.packPriceOverride ?: pack.basePrice}",
+    currency = partnership.currency,
+),
+
+// Option line items
+unitPrice = QontoMoneyAmount(
+    value = "${option.priceOverride ?: option.price}",
+    currency = partnership.currency,
+),
+```
+
+---
+
+## Step 7 — Schema files
+
+Copy `contracts/update_partnership_pricing_request.schema.json` to:
+```
+application/src/main/resources/schemas/update_partnership_pricing_request.schema.json
+```
+
+Add `pack_price_override` to `partnership_pack.schema.json`:
+```json
+"pack_price_override": {
+  "type": ["integer", "null"],
+  "minimum": 0,
+  "description": "Organiser-set price override for this pack. Null when no override is active."
+}
+```
+
+Add `price_override` to `partnership_option.schema.json` (in the base/shared properties):
+```json
+"price_override": {
+  "type": ["integer", "null"],
+  "minimum": 0,
+  "description": "Organiser-set price override for this option. Null when no override is active."
+}
+```
+
+---
+
+## Step 8 — Tests
+
+### Contract test (write FIRST per TDD):
+`application/src/test/kotlin/.../partnership/infrastructure/api/PartnershipPricingRoutePutTest.kt`
+
+Tests to cover:
+- `PUT` with valid pack override → 200 with updated `pack_price_override` in response
+- `PUT` with invalid (negative) price → 400
+- `PUT` with unknown option ID → 404
+- `PUT` without auth → 401
+- `PUT` with wrong org → 403
+- `PUT` with pack override when no validated pack → 409
+
+### Integration test:
+`application/src/test/kotlin/.../partnership/PartnershipPricingRoutesTest.kt`
+
+Tests to cover:
+- Set pack override → billing invoice uses override price
+- Set option override → billing invoice uses override price
+- Clear pack override → billing uses catalogue price again
+- Omit pack override field → existing override preserved
+
+---
+
+## Verification
+
+```bash
+cd server
+./gradlew ktlintFormat --no-daemon
+./gradlew detekt --no-daemon
+./gradlew test --no-daemon
+npm install && npm run validate
+./gradlew build --no-daemon
+```

--- a/server/specs/017-override-partnership-price/research.md
+++ b/server/specs/017-override-partnership-price/research.md
@@ -1,0 +1,135 @@
+# Research: Override Partnership Pricing
+
+**Feature**: `017-override-partnership-price`  
+**Date**: 2026-02-27
+
+---
+
+## 1. Existing Price Flow (as-is)
+
+### Decision
+Catalogue prices live exclusively in the sponsoring domain (`SponsoringPacksTable`, `SponsoringOptionsTable`). They are read-only from the partnership domain's perspective.
+
+### Rationale
+The two places where prices enter the partnership domain are:
+
+1. **Mapper `SponsoringPackEntity.ext.kt`** — builds `PartnershipPack` using `entity.basePrice` and delegates to option mappers for option prices. `totalPrice` = `basePrice + sum(optionalOptions.totalPrice)`.  
+2. **Mapper `PartnershipOptionEntity.ext.kt`** — builds each `PartnershipOption` subtype using `option.price ?: 0`. `totalPrice` = `price * quantity` (or `price * fixedQuantity`, or `selectedValue.price` for selectable).
+
+### Billing touchpoint
+`QontoInvoiceItem.mapper.kt` (`invoiceItems()`) reads prices from the `PartnershipDetail.validatedPack` domain object:
+- Pack line item uses `pack.basePrice`
+- Each optional option line item uses `option.price`
+
+These are the **only two places** that emit prices to Qonto.
+
+---
+
+## 2. Storage Strategy for Overrides
+
+### Decision
+Store overrides on the partnership side, not by mutating catalogue data:
+
+| Override type | Table | Column |
+|---|---|---|
+| Pack price override | `PartnershipsTable` | `pack_price_override INTEGER NULLABLE` |
+| Option price override | `PartnershipOptionsTable` | `price_override INTEGER NULLABLE` |
+
+### Rationale
+- **Catalogue prices are shared** across multiple partnerships; they must never be mutated.
+- Storing per-partnership overrides alongside the existing partnership rows keeps the model simple — no new junction tables required.
+- `NULL` = "no override; use catalogue price". Explicit `0` = valid free-of-charge override.
+
+### Alternatives considered
+- **New `PartnershipPriceOverride` junction table**: More normalised but adds unnecessary join complexity for what is essentially a single nullable column per entity.
+- **Stored effective price (snapshot)**: Breaks auditability and reversal capability; ruled out.
+
+---
+
+## 3. Domain Model Changes
+
+### Decision
+Both `PartnershipPack` and `PartnershipOption` (sealed class + subtypes) gain an optional `priceOverride` field exposing the raw override to front-end consumers. `totalPrice` is recomputed using the effective price.
+
+| Field added to | Kotlin field | JSON field | Nullable |
+|---|---|---|---|
+| `PartnershipPack` | `packPriceOverride: Int?` | `pack_price_override` | yes |
+| `PartnershipOption` (all subtypes) | `priceOverride: Int?` | `price_override` | yes |
+
+The **effective prices** consumed by billing are:
+- Pack: `packPriceOverride ?: basePrice`
+- Option: `priceOverride ?: price`
+
+`totalPrice` on `PartnershipPack` is updated to use effective pack price + effective option prices.  
+`totalPrice` on each `PartnershipOption` subtype is updated to use `(priceOverride ?: price) * quantity`.
+
+### Rationale
+FR-010 requires both values to be visible to front-end. FR-013 requires billing to use only the effective price. Carrying both fields in the domain model satisfies both consumers without a separate DTO.
+
+---
+
+## 4. API Endpoint Design
+
+### Decision
+New dedicated endpoint under the org-secured namespace:
+
+```
+PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing
+```
+
+Protected by `AuthorizedOrganisationPlugin`. Returns `PartnershipDetail` (same as the public GET).
+
+### Rationale
+- The existing `PUT /events/{eventSlug}/partnerships/{partnershipId}` is **public** (no authentication). Mixing organiser-only pricing fields into it would break FR-011.  
+- The existing `DELETE /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}` sets the precedent for org-scoped operations on a partnership.
+- A dedicated `/pricing` sub-resource follows the existing pattern of `/organiser`, `/billing`, `/agreement`, etc.
+
+### Alternatives considered
+- Extending the public PUT: Security violation — price overrides are organiser-only (FR-011).
+- PATCH on the existing org DELETE route: Inelegant and mixes unrelated concerns.
+
+---
+
+## 5. Partial Update Semantics for Pricing
+
+### Decision
+- **`packPriceOverride`**: Omitting the field in the request body leaves the existing DB override unchanged. Sending `null` explicitly clears the override. Sending a non-negative integer sets/replaces it.
+- **`optionsPriceOverrides`**: Omitting the list entirely leaves all option overrides unchanged. Including the list replaces overrides only for the specified option IDs. To clear a specific option's override, include that option ID with `priceOverride: null`.
+
+### Rationale
+This matches the partial-update pattern established by `UpdatePartnershipContactInfo` (FR-006).
+
+---
+
+## 6. Billing Integration (Qonto)
+
+### Decision
+Update `QontoInvoiceItem.mapper.kt` (`invoiceItems()`) to use effective prices:
+- Pack: `pack.packPriceOverride ?: pack.basePrice`
+- Option: `option.priceOverride ?: option.price`
+
+No changes to `QontoProvider`, `QontoBillingGateway`, or `BillingRepositoryExposed` — the effective price is resolved in the domain object before it reaches the mapper.
+
+### Rationale
+The billing layer already receives a fully hydrated `PartnershipDetail` from the partnership domain. Resolving effective prices in the mapper is a one-line change per line item with zero structural impact upstream. Keeps billing code oblivious to the concept of "overrides".
+
+---
+
+## 7. No Notification Required
+
+### Decision
+No Slack / Mailjet notification is triggered by price override operations.
+
+### Rationale
+Price overrides are an internal organiser operation (clarification Q5). No `NotificationVariables` subtype needs to be added.
+
+---
+
+## 8. Test Strategy
+
+| Test class | Type | Location |
+|---|---|---|
+| `PartnershipPricingRoutePutTest` | Contract | `partnership.infrastructure.api` |
+| `PartnershipPricingRoutesTest` | Integration | `partnership` (root) |
+
+Factories updated: `Partnership.factory.kt` (add `packPriceOverride` param), `PartnershipOption.factory.kt` (add `priceOverride` param).

--- a/server/specs/017-override-partnership-price/spec.md
+++ b/server/specs/017-override-partnership-price/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Override Partnership Pricing
+
+**Feature Branch**: `017-override-partnership-price`  
+**Created**: 2026-02-27  
+**Status**: Draft  
+**Input**: User description: "As an organiser, you should be able to provide an optional price parameter on an existing partnership to override the price of the sponsoring pack validated and on one or more options. This should be able to do when you want to update an existing partnership."
+
+## Clarifications
+
+### Session 2026-02-27
+
+- Q: Does the price override feed into billing/quotes, or is it informational only? → A: Override price replaces the catalogue price for billing and quote generation when set
+- Q: Can price overrides be set regardless of partnership status, or only when approved/validated? → A: Price overrides can be set regardless of partnership status
+- Q: What numeric type and precision should override prices use? → A: Integer, same type/unit as existing catalogue prices
+- Q: How should prices be exposed in API responses? → A: Front-end receives both catalogue price and override price as separate fields; billing system receives only the effective price (override when set, catalogue otherwise)
+- Q: Should setting or changing a price override trigger any notification to the partner? → A: No notification; price overrides are an internal organiser operation
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Override Sponsoring Pack Price (Priority: P1)
+
+As an organiser, I need to set a custom price on the sponsoring pack of an existing partnership so that I can accommodate negotiated deals or special pricing agreements with partners.
+
+**Why this priority**: This is the primary ask — the ability to assign a negotiated price to the validated sponsoring pack of a partnership. Without this, all other pricing overrides are irrelevant.
+
+**Independent Test**: Can be fully tested by updating an existing partnership with a custom pack price and verifying the override price is returned on subsequent queries while the original pack catalogue price remains unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am an authenticated organiser for an organisation, **When** I update an existing partnership providing a custom price for the sponsoring pack, **Then** the partnership stores the override price and returns it in subsequent responses
+2. **Given** I have previously set a custom pack price, **When** I update the partnership and omit the price override field, **Then** the existing override price is preserved unchanged
+3. **Given** I have previously set a custom pack price, **When** I update the partnership and explicitly clear the price override (set to null), **Then** the override is removed and the original catalogue pack price applies
+4. **Given** I provide a price of zero, **When** I update the partnership, **Then** the system accepts it as a valid override (free sponsoring package)
+
+---
+
+### User Story 2 - Override Prices on One or More Options (Priority: P2)
+
+As an organiser, I need to set custom prices on one or more options attached to an existing partnership so that individual option pricing can be adjusted independently from catalogue prices.
+
+**Why this priority**: Options are separate from the pack and may also be subject to individual negotiation. This extends the override capability to the option level while keeping it independent of the pack override.
+
+**Independent Test**: Can be fully tested by updating a partnership with custom prices for a subset of its options and verifying that only those specific options reflect the override, while unchanged options retain their catalogue prices.
+
+**Acceptance Scenarios**:
+
+1. **Given** a partnership has multiple options, **When** I update the partnership providing a price override for one specific option, **Then** only that option reflects the custom price; all other options retain their original prices
+2. **Given** a partnership has multiple options, **When** I provide price overrides for all options in a single update, **Then** all options reflect their respective custom prices
+3. **Given** I have previously set a custom price on an option, **When** I update the partnership and explicitly clear the override for that option, **Then** the override is removed and the original catalogue option price applies
+4. **Given** I provide an option ID that does not belong to the partnership, **When** I submit the update, **Then** the system returns an error indicating the option is not associated with the partnership
+
+---
+
+### User Story 3 - Combined Pack and Option Price Overrides (Priority: P3)
+
+As an organiser, I need to set custom prices on both the sponsoring pack and one or more options in a single update so that a complete custom pricing deal can be recorded in one operation.
+
+**Why this priority**: Organisers will often negotiate an all-in deal covering both the pack and specific options. Doing this in one request reduces friction and ensures atomicity.
+
+**Independent Test**: Can be fully tested by submitting an update that contains both a pack price override and option price overrides, then verifying all overrides are persisted and correctly returned together.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing partnership with a validated pack and options, **When** I update it with a custom pack price and custom prices for two options simultaneously, **Then** all three price overrides are saved and returned in subsequent responses
+2. **Given** I submit a combined override, **When** the pack price is valid but one option price is invalid (e.g., negative), **Then** the entire update is rejected with a clear error identifying the invalid value
+
+---
+
+### Edge Cases
+
+- What happens when the override price is negative? → The system must reject it with a validation error.
+- What happens when no price override is provided in the update payload? → No change is made to existing overrides (partial update semantics).
+- What happens if the partnership has no validated sponsoring pack yet? → Pack price override cannot be set; the system returns a clear error.
+- What happens if two concurrent updates set different price overrides on the same partnership? → Last write wins; no partial state should be persisted.
+- What happens when the override price is a non-numeric value? → The system must reject it with a validation error.
+- What happens when an organiser sets a price override on a rejected or pending partnership? → The override is accepted; partnership status does not gate the operation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow an authenticated organiser to provide an optional custom price for the validated sponsoring pack when updating an existing partnership
+- **FR-002**: System MUST allow an authenticated organiser to provide optional custom prices for one or more options when updating an existing partnership
+- **FR-003**: System MUST allow pack and option price overrides to be submitted independently or together in a single update request
+- **FR-004**: System MUST persist price overrides per partnership — overrides are stored alongside the partnership record, not modifying the catalogue pack or option prices
+- **FR-005**: System MUST support clearing a price override (restoring the original catalogue price) by explicitly setting the override to null
+- **FR-006**: System MUST apply partial update semantics — omitting a price override field in the request leaves the existing override unchanged
+- **FR-007**: System MUST validate that override prices are non-negative integers, using the same unit as catalogue prices (consistent with existing pack and option price representation)
+- **FR-008**: System MUST reject an option price override if the referenced option is not associated with the partnership
+- **FR-009**: System MUST reject a pack price override if the partnership has no validated sponsoring pack
+- **FR-010**: The partnership API response MUST include both the original catalogue price and the override price as separate nullable fields so that front-end consumers can display negotiated pricing transparently
+- **FR-011**: Only authenticated organisers with access to the organisation owning the event may set price overrides
+- **FR-012**: System MUST return appropriate error messages for all validation failures
+- **FR-013**: When a price override is active on the sponsoring pack or an option, the billing and quote generation system MUST use only the effective price (override price when set, catalogue price otherwise); billing consumers do not receive the split representation
+- **FR-014**: Price overrides MAY be set on a partnership in any lifecycle status (pending, approved, rejected); partnership status MUST NOT block the override operation
+- **FR-015**: Setting, updating, or clearing a price override MUST NOT trigger any notification to the partner company; price overrides are an internal organiser operation
+
+### Key Entities
+
+- **Partnership**: The relationship between a partner company and an event; extended with optional price overrides for the validated sponsoring pack and its selected options
+- **Sponsoring Pack**: The catalogue package chosen by the partner and validated by the organiser; has a catalogue price that may be overridden per partnership deal
+- **Option**: An individual add-on attached to a partnership; has a catalogue price that may be overridden independently per partnership deal
+- **Price Override**: An optional non-negative integer stored on a partnership (or a specific option within a partnership) that supersedes the catalogue price for that specific deal; uses the same unit as the catalogue price
+
+## Assumptions
+
+- Price values are expressed in the same currency as the original catalogue price; currency selection is out of scope for this feature
+- A price of zero is a valid override (e.g., a complimentary package or option)
+- The update endpoint for partnerships already exists; this feature extends its request payload with optional price override fields
+- Organisers are authenticated via the existing organisation authorisation mechanism; no new authentication is introduced
+- When an override price is set, it supersedes the catalogue price everywhere, including billing and quote generation; the catalogue price is never modified
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An organiser can set or update a price override on a partnership in under 30 seconds from initiating the request
+- **SC-002**: The API response always exposes both the catalogue price and the override price as distinct fields with 100% accuracy; the billing system always receives only the correct effective price
+- **SC-003**: 100% of requests with negative or otherwise invalid price values are rejected with a clear, actionable error message
+- **SC-004**: Partial update semantics work correctly 100% of the time — unspecified price fields never inadvertently clear existing overrides
+- **SC-005**: Zero impact on catalogue data integrity — original pack and option catalogue prices remain unchanged after any override operation

--- a/server/specs/017-override-partnership-price/tasks.md
+++ b/server/specs/017-override-partnership-price/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Override Partnership Pricing
+
+**Input**: Design documents from `/specs/017-override-partnership-price/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Exact file paths are included in all descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify branch and baseline
+
+- [X] T001 Verify baseline build passes on branch `017-override-partnership-price` (`./gradlew build --no-daemon`)
+- [X] T002 Copy `contracts/update_partnership_pricing_request.schema.json` to `application/src/main/resources/schemas/update_partnership_pricing_request.schema.json`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Database schema and entity changes that ALL user stories depend on. Nothing can be implemented until these columns and properties exist.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Add `val packPriceOverride = integer("pack_price_override").nullable()` to `application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipsTable.kt` (after `organiserId`)
+- [X] T004 [P] Add `val priceOverride = integer("price_override").nullable()` to `application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipOptionsTable.kt` (after `selectedValueId`)
+- [X] T005 Add `var packPriceOverride by PartnershipsTable.packPriceOverride` property to `application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipEntity.kt`
+- [X] T006 [P] Add `var priceOverride by PartnershipOptionsTable.priceOverride` property to `application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/db/PartnershipOptionEntity.kt`
+- [X] T028 [P] Update test factories to support price override fields: ensure `insertMockedPartnership()` in `application/src/test/kotlin/fr/devlille/partners/connect/partnership/factories/Partnership.factory.kt` accepts `packPriceOverride: Int? = null`; ensure `insertMockedPartnershipOption()` accepts `priceOverride: Int? = null`; follow Constitution II factory pattern: all parameters MUST have defaults, UUID-based unique defaults where applicable, NO transaction management inside factories
+
+**Checkpoint**: DB layer + test factories ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Override Sponsoring Pack Price (Priority: P1) 🎯 MVP
+
+**Goal**: Organisers can store a custom integer price on the pack field of an existing partnership. The override is returned alongside the catalogue price in API responses and replaces the catalogue price for billing.
+
+**Independent Test**: Set a pack price override on a partnership via `PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing` → verify `pack_price_override` is returned on subsequent GET; verify pack catalogue `base_price` is unchanged; verify billing `invoiceItems()` uses the override price.
+
+### Contract Tests for User Story 1 (write FIRST — TDD ⚠️)
+
+> **MUST be written and confirmed FAILING before T007–T015 implementation begins** (Constitution II)
+
+- [X] T029 [US1] Write contract tests in `application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipPricingRoutePutTest.kt` (naming: `PartnershipPricingRoutePutTest` per constitution convention); cover ALL HTTP status codes: 200 OK with valid pack override; 200 OK on a `pending` or `rejected` partnership (FR-014 — status MUST NOT block override); 400 for negative price; 409 when partnership has no validated sponsoring pack; 401 without auth; 403 with wrong org
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Verify whether `PartnershipPack` lives in `Partnership.kt` or a separate `PartnershipPack.kt` (plan.md source tree lists it as `PartnershipPack.kt`; confirm actual filename before editing); add `packPriceOverride: Int? = null` field (with `@SerialName("pack_price_override")`) to the data class; update `totalPrice` computation to `(packPriceOverride ?: basePrice) + Σ optionalOptions`
+- [X] T008 [US1] Update `SponsoringPackEntity.ext.kt` mapper (`application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/mappers/SponsoringPackEntity.ext.kt`): add `packPriceOverride: Int? = null` parameter to `toDomain()`; compute `effectiveBasePrice = packPriceOverride ?: basePrice`; pass `packPriceOverride` to `PartnershipPack` constructor
+- [X] T009 [US1] In `PartnershipRepositoryExposed.kt` (`application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipRepositoryExposed.kt`), update all 4 `pack.toDomain(...)` call sites to pass `packPriceOverride = partnership.packPriceOverride`
+- [X] T010 [US1] Create new domain file `application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/UpdatePartnershipPricing.kt` with `UpdatePartnershipPricing` and `OptionPriceOverride` data classes (as specified in quickstart.md Step 2); include KDoc on both classes documenting the three-way partial-update semantics: field absent = unchanged, field = null = clear override, field = integer = set/replace override (Constitution I: all public types MUST be documented)
+- [X] T011 [US1] Add `fun updatePricing(eventSlug: String, partnershipId: UUID, pricing: UpdatePartnershipPricing, packOverridePresent: Boolean): UUID` to `PartnershipRepository` interface in `application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipRepository.kt`; include KDoc documenting the `packOverridePresent` parameter purpose, expected exceptions (`NotFoundException` for missing event/partnership/option, `ConflictException` for missing validated pack), and the partial-update contract (Constitution I)
+- [X] T012 [US1] Implement `updatePricing()` in `PartnershipRepositoryExposed.kt` — pack override branch only (validate `packOverridePresent`, check validated pack exists when non-null, set `partnership.packPriceOverride`); when `pricing.optionsPriceOverrides` is non-null at this stage, skip it with an inline comment `// option overrides handled in T018` — this is intentional progressive implementation, not a silent data loss
+- [X] T013 [US1] Add `pack_price_override` nullable integer field to `application/src/main/resources/schemas/partnership_pack.schema.json`
+- [X] T014 [US1] Add `private fun Route.orgsPartnershipPricingRoutes()` function to `application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipRoutes.kt` with `PUT` handler; register it in `partnershipRoutes()`; call `receiveText()` ONCE to get raw body, then: **(1)** validate it against the JSON schema (`Schema.from(schema).validate(jsonBody)`) to satisfy Constitution IV requirement for schema-based validation and get automatic 400 on invalid payloads, **(2)** parse `Json.parseToJsonElement(jsonBody).jsonObject` and call `.containsKey("pack_price_override")` for partial-update detection, **(3)** deserialize with `Json.decodeFromString<UpdatePartnershipPricing>(jsonBody)` — do NOT call both `receiveText()` and `receive<T>()` as both consume the request body
+- [X] T015 [US1] Update `QontoInvoiceItem.mapper.kt` (`application/src/main/kotlin/fr/devlille/partners/connect/billing/infrastructure/gateways/models/mappers/QontoInvoiceItem.mapper.kt`): replace `pack.basePrice` with `pack.packPriceOverride ?: pack.basePrice` in the pack line item
+- [X] T030 [US1] Merge `contracts/openapi-put-pricing.yaml` into `application/src/main/resources/openapi/openapi.yaml`: add `PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing` operation with unique `operationId`, `summary`, `security: - bearerAuth: []`, requestBody referencing `UpdatePartnershipPricingRequest` component, and 200/400/401/403/404/409 responses; register `UpdatePartnershipPricingRequest` in `components/schemas` using `$ref: "schemas/update_partnership_pricing_request.schema.json"` (Constitution IV MUST: all endpoints in openapi.yaml); run `npm run validate`
+
+**Checkpoint**: User Story 1 is fully functional — organisers can set, update, and clear a pack price override; billing uses effective price; OpenAPI spec updated and validated
+
+---
+
+## Phase 4: User Story 2 — Override Prices on One or More Options (Priority: P2)
+
+**Goal**: Organisers can store a custom integer price on individual options attached to an existing partnership. Overrides apply per-option and are independent of the pack override.
+
+**Independent Test**: Set a price override on one option via the pricing endpoint → verify only that option reflects the custom price; other options retain catalogue prices; verify billing uses the override price for that option only.
+
+### Contract Tests for User Story 2 (write FIRST — TDD ⚠️)
+
+> **MUST be written and confirmed FAILING before T016–T020 implementation begins** (Constitution II)
+
+- [X] T031 [US2] Extend `PartnershipPricingRoutePutTest.kt` with US2 contract test cases: 200 OK for valid single option override; 200 OK when overriding multiple options simultaneously; 404 for an option ID not associated with the partnership; 200 OK when clearing an existing option override (set to null)
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Add `abstract val priceOverride: Int?` (with `@SerialName("price_override")`) to the `PartnershipOption` sealed class in `application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipOption.kt`; add `override val priceOverride: Int? = null` concrete field to all 4 subtypes (`TextPartnershipOption`, `QuantitativePartnershipOption`, `NumberPartnershipOption`, `SelectablePartnershipOption`)
+- [X] T017 [US2] Update `PartnershipOptionEntity.ext.kt` (`application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/mappers/PartnershipOptionEntity.ext.kt`): replace `option.price ?: 0` with `(priceOverride ?: option.price) ?: 0` in all `toX` private functions; for `toSelectablePartnershipOption` replace `totalPrice = selectedVal.price` with `totalPrice = priceOverride ?: selectedVal.price`; pass `priceOverride = priceOverride` to all subtype constructors
+- [X] T018 [US2] Complete the option-override branch of `updatePricing()` in `PartnershipRepositoryExposed.kt` (depends on T012 skeleton): remove the `// option overrides handled in T018` placeholder; iterate `pricing.optionsPriceOverrides`, look up each option entity by `(partnershipId, optionId)`, throw `NotFoundException` for unknown options, set `optionEntity.priceOverride`
+- [X] T019 [US2] Add `price_override` nullable integer field to `application/src/main/resources/schemas/partnership_option.schema.json`
+- [X] T020 [US2] Update `QontoInvoiceItem.mapper.kt` (same file edited in T015 — ensure T015 pack change is already present before applying): replace `option.price` with `option.priceOverride ?: option.price` in the option line item
+
+**Checkpoint**: User Story 2 is fully functional — organisers can set, update, and clear option price overrides independently; billing uses effective option prices
+
+---
+
+## Phase 5: User Story 3 — Combined Pack and Option Price Overrides (Priority: P3)
+
+**Goal**: The pricing endpoint accepts pack and option overrides simultaneously in a single atomic request. This is largely already enabled by the work in US1 + US2; this phase validates atomicity and integration.
+
+**Independent Test**: Submit a `PUT` body containing both `pack_price_override` and `options_price_overrides` for two options → verify all three overrides are persisted in a single transaction; verify a partial failure (invalid option ID) rolls back the entire update.
+
+### Implementation for User Story 3
+
+- [X] T021 [US3] Confirm `updatePricing()` in `PartnershipRepositoryExposed.kt` wraps both the pack update and all option updates inside a single `transaction {}` block (SC-004 + FR-006); if they are in separate transactions, consolidate them; **acceptance criterion**: submitting a body with a valid `pack_price_override` and an invalid option ID must roll back completely — zero DB changes on any failure
+- [X] T022 [US3] Add combined-override integration test: submit `PUT` with both `pack_price_override` and `options_price_overrides` with two option entries → assert all three values are stored and returned in `PartnershipDetail`
+
+**Checkpoint**: All three user stories are independently functional and atomicity is guaranteed
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates, integration tests, and final validation
+
+- [X] T023 [P] Run `./gradlew ktlintFormat --no-daemon` and fix any remaining formatting violations
+- [X] T024 [P] Run `./gradlew detekt --no-daemon` and resolve any static analysis violations
+- [X] T025 Write integration tests in `application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipPricingRoutesTest.kt` (naming convention: `PartnershipPricingRoutesTest`) covering end-to-end workflows: set pack override → billing `invoiceItems()` uses override price; set option override → billing uses override price; clear pack override → billing reverts to catalogue price; omit `pack_price_override` key in body → existing override unchanged (FR-006); set then clear an option override in two sequential requests; **verify no Slack or email notification is triggered for any pricing update** — mock `NotificationRepository` and assert zero calls (FR-015)
+- [X] T026 Run full validation: `npm install && npm run validate` (OpenAPI schema), then `./gradlew check --no-daemon`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Setup — **blocks all user stories**
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2)
+- **User Story 2 (Phase 4)**: Depends on Foundational (Phase 2) — independent of US1 except for `UpdatePartnershipPricing.kt` (T010) and `PartnershipRepository.kt` (T011) created in US1
+- **User Story 3 (Phase 5)**: Depends on US1 (Phase 3) and US2 (Phase 4)
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+| Story | Depends on | Blocks |
+|---|---|---|
+| US1 (P1) | Phase 2 complete; T029 written + confirmed failing first | US3 |
+| US2 (P2) | Phase 2 complete + T010 + T011 + T012 from US1; T031 written + confirmed failing first | US3 |
+| US3 (P3) | US1 + US2 complete | — |
+
+### Within Each User Story (sequential order)
+
+1. Domain model changes (data classes, sealed class, interfaces)
+2. Mapper updates (entity → domain)
+3. Repository implementation
+4. Schema files
+5. Route handler
+6. Billing mapper
+
+---
+
+## Parallel Opportunities
+
+### Within Phase 2 (Foundational)
+
+```
+T003 (PartnershipsTable)      T004 (PartnershipOptionsTable)
+T005 (PartnershipEntity)      T006 (PartnershipOptionEntity)
+```
+T003 + T005 must be sequential (entity references table).  
+T004 + T006 must be sequential.  
+But T003/T005 pair and T004/T006 pair can run in parallel.
+
+### Within Phase 3 (US1)
+
+```
+T029 (contract test, US1)          ← write FIRST, must FAIL initially
+T007 (PartnershipPack domain)      ← start implementation here (blocks T008, T009)
+T010 (UpdatePartnershipPricing)    ← independent, can run parallel with T007
+T008 (SponsoringPackEntity mapper) ← after T007
+T009 (RepositoryExposed mappers)   ← after T008
+T011 (Repository interface)        ← after T010
+T012 (Repository implementation)   ← after T011
+T013 (partnership_pack schema)     ← independent [P]
+T014 (Route)                       ← after T012
+T015 (QontoInvoiceItem mapper)     ← independent [P], after T007
+T030 (OpenAPI update)              ← after T014
+```
+
+### Within Phase 4 (US2)
+
+```
+T031 (contract test, US2)          ← write FIRST, must FAIL initially
+T016 (PartnershipOption domain)    ← start implementation here (blocks T017)
+T017 (OptionEntity mapper)         ← after T016
+T018 (Repository option branch)    ← after T012 (from US1) + T016
+T019 (partnership_option schema)   ← independent [P]
+T020 (QontoInvoiceItem option)     ← independent [P], after T016
+```
+
+---
+
+## Implementation Strategy
+
+**MVP scope**: Complete Phase 1 + Phase 2 + Phase 3 (US1 only) to deliver the minimal viable feature — organisers can override the pack price. This covers the P1 user story with end-to-end billing integration.
+
+**Incremental delivery**:
+1. Phase 1 + 2: DB columns (5 minutes, compile-safe)
+2. Phase 3 (US1): Pack price override end-to-end (~60 minutes)
+3. Phase 4 (US2): Option price overrides (~45 minutes)
+4. Phase 5 (US3): Atomicity validation + combined test (~15 minutes)
+5. Phase 6: Tests + quality gates (~45 minutes)
+
+**Total task count**: 31 tasks  
+**Tasks per user story**: US1 → 11 tasks (T029, T007–T015, T030), US2 → 6 tasks (T031, T016–T020), US3 → 2 tasks (T021–T022)  
+**Shared infrastructure**: T028 (test factories in Phase 2)  
+**Quality gates**: T023, T024, T025, T026


### PR DESCRIPTION
Organisers can now override the price of a partnership's validated pack and/or any of its selected options via:

  PUT /orgs/{orgSlug}/events/{eventSlug}/partnerships/{partnershipId}/pricing

Key behaviours:
- null clears an existing override (reverts to catalogue price)
- omitting a field leaves it unchanged (partial update)
- pack + option overrides are applied atomically in a single transaction
- billing (Qonto invoice items) uses the effective price automatically
- setting a non-null pack override on a partnership with no validated pack returns 409

Changes:
- DB: pack_price_override (partnerships), price_override (partnership_options)
- Migration: AddPartnershipPriceOverridesMigration
- Domain: UpdatePartnershipPricing, OptionPriceOverride, PartnershipRepository#updatePricing
- API: PartnershipPack#packPriceOverride, PartnershipOption#priceOverride
- Billing: QontoInvoiceItem uses effective (overridden) price
- Schemas: partnership_pack, partnership_option, update_partnership_pricing_request
- OpenAPI: PUT pricing endpoint documented