### PR TITLE
Add job offers to morning organiser digest & fix job_title placeholder

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/application/DigestRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/application/DigestRepositoryExposed.kt
@@ -1,5 +1,6 @@
 package fr.devlille.partners.connect.digest.application
 
+import fr.devlille.partners.connect.companies.infrastructure.db.CompanyJobOfferPromotionEntity
 import fr.devlille.partners.connect.companies.infrastructure.db.hasCompleteAddress
 import fr.devlille.partners.connect.digest.domain.DigestEntry
 import fr.devlille.partners.connect.digest.domain.DigestRepository
@@ -9,6 +10,7 @@ import fr.devlille.partners.connect.events.domain.EventDisplay
 import fr.devlille.partners.connect.events.domain.EventWithOrganisation
 import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
 import fr.devlille.partners.connect.events.infrastructure.db.findBySlug
+import fr.devlille.partners.connect.internal.infrastructure.db.PromotionStatus
 import fr.devlille.partners.connect.internal.infrastructure.system.SystemVarEnv
 import fr.devlille.partners.connect.organisations.application.mappers.toItemDomain
 import fr.devlille.partners.connect.partnership.infrastructure.db.BillingEntity
@@ -38,6 +40,7 @@ class DigestRepositoryExposed : DigestRepository {
             agreementItems = queryAgreementReady(eventEntity.id.value, eventSlug),
             billingItems = queryBillingReady(eventEntity.id.value, eventSlug),
             socialMediaItems = querySocialMediaDue(eventEntity.id.value, today, eventSlug),
+            jobOfferItems = queryPendingJobOffers(eventEntity.id.value, eventSlug),
         )
     }
 
@@ -96,4 +99,8 @@ class DigestRepositoryExposed : DigestRepository {
         return PartnershipEntity.findSocialMediaDue(eventId, startOfDay, endOfDay)
             .map { DigestEntry(it.company.name, buildLink(eventSlug, it.id.value)) }
     }
+
+    private fun queryPendingJobOffers(eventId: UUID, eventSlug: String): List<DigestEntry> =
+        CompanyJobOfferPromotionEntity.listByEventAndStatus(eventId, PromotionStatus.PENDING)
+            .map { DigestEntry(it.jobOffer.title, buildLink(eventSlug, it.partnership.id.value)) }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/domain/EventDigest.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/domain/EventDigest.kt
@@ -18,8 +18,10 @@ data class EventDigest(
     val agreementItems: List<DigestEntry>,
     val billingItems: List<DigestEntry>,
     val socialMediaItems: List<DigestEntry>,
+    val jobOfferItems: List<DigestEntry>,
 ) {
     /** `true` when at least one section has items; used by the route to gate Slack dispatch. */
     val hasItems: Boolean
-        get() = agreementItems.isNotEmpty() || billingItems.isNotEmpty() || socialMediaItems.isNotEmpty()
+        get() = agreementItems.isNotEmpty() || billingItems.isNotEmpty() ||
+            socialMediaItems.isNotEmpty() || jobOfferItems.isNotEmpty()
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/infrastructure/api/DigestRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/infrastructure/api/DigestRoutes.kt
@@ -31,6 +31,7 @@ fun Application.digestRoutes() {
                     agreementItems = digest.agreementItems,
                     billingItems = digest.billingItems,
                     socialMediaItems = digest.socialMediaItems,
+                    jobOfferItems = digest.jobOfferItems,
                 )
                 notificationRepository.sendMessageFromMessaging(variables)
             }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
@@ -300,6 +300,7 @@ sealed interface NotificationVariables {
         val agreementItems: List<DigestEntry>,
         val billingItems: List<DigestEntry>,
         val socialMediaItems: List<DigestEntry>,
+        val jobOfferItems: List<DigestEntry>,
     ) : NotificationVariables {
         override val usageName: String = "digest"
 
@@ -319,6 +320,7 @@ sealed interface NotificationVariables {
                 .replace("{{agreement_section}}", formatSection(agreementItems, "n/a"))
                 .replace("{{billing_section}}", formatSection(billingItems, "n/a"))
                 .replace("{{social_media_section}}", formatSection(socialMediaItems, "n/a"))
+                .replace("{{job_offer_section}}", formatSection(jobOfferItems, "n/a"))
         }
     }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
@@ -236,7 +236,7 @@ sealed interface NotificationVariables {
                 .replace("{{event_name}}", event.event.name)
                 .replace("{{event_contact}}", event.event.contact.email)
                 .replace("{{company_name}}", company.name)
-                .replace("{{job_offer_title}}", jobOffer.title)
+                .replace("{{job_title}}", jobOffer.title)
                 .replace("{{job_offer_url}}", jobOffer.url)
                 .replace("{{partnership_link}}", partnershipLink)
         }
@@ -257,7 +257,7 @@ sealed interface NotificationVariables {
                 .replace("{{event_name}}", event.event.name)
                 .replace("{{event_contact}}", event.event.contact.email)
                 .replace("{{company_name}}", company.name)
-                .replace("{{job_offer_title}}", jobOffer.title)
+                .replace("{{job_title}}", jobOffer.title)
                 .replace("{{job_offer_url}}", jobOffer.url)
                 .replace("{{partnership_link}}", partnershipLink)
         }
@@ -280,7 +280,7 @@ sealed interface NotificationVariables {
                 .replace("{{event_name}}", event.event.name)
                 .replace("{{event_contact}}", event.event.contact.email)
                 .replace("{{company_name}}", company.name)
-                .replace("{{job_offer_title}}", jobOffer.title)
+                .replace("{{job_title}}", jobOffer.title)
                 .replace("{{job_offer_url}}", jobOffer.url)
                 .replace("{{partnership_link}}", partnershipLink)
                 .replace("{{decline_reason}}", reasonText)

--- a/server/application/src/main/resources/notifications/slack/digest/en.md
+++ b/server/application/src/main/resources/notifications/slack/digest/en.md
@@ -8,3 +8,6 @@
 
 📢 Scheduled communication today:
 {{social_media_section}}
+
+💼 Job offers to validate:
+{{job_offer_section}}

--- a/server/application/src/main/resources/notifications/slack/digest/fr.md
+++ b/server/application/src/main/resources/notifications/slack/digest/fr.md
@@ -8,3 +8,6 @@
 
 📢 Communication prévue aujourd'hui :
 {{social_media_section}}
+
+💼 Offres d'emploi à valider :
+{{job_offer_section}}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/digest/DigestJobRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/digest/DigestJobRoutesTest.kt
@@ -5,7 +5,9 @@ import com.slack.api.Slack
 import com.slack.api.methods.MethodsClient
 import com.slack.api.methods.request.chat.ChatPostMessageRequest
 import com.slack.api.methods.response.chat.ChatPostMessageResponse
+import fr.devlille.partners.connect.companies.factories.insertMockCompanyJobOfferPromotion
 import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.companies.factories.insertMockedJobOffer
 import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
 import fr.devlille.partners.connect.integrations.factories.insertMockedIntegration
 import fr.devlille.partners.connect.integrations.factories.insertSlackIntegration
@@ -354,6 +356,52 @@ class DigestJobRoutesTest {
         verify(exactly = 0) {
             slackMethod.chatPostMessage(any<RequestConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder>>())
         }
+    }
+
+    @Test
+    fun `sends Slack notification when pending job offer promotions exist`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val jobOfferId = UUID.randomUUID()
+        val (slack, slackMethod, _) = slackMock()
+
+        application {
+            moduleSharedDb(userId = userId, slack = slack)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                val event = insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                val pack = insertMockedSponsoringPack(packId, eventId = eventId, basePrice = 1000)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    validatedAt = event.submissionStartTime,
+                    agreementUrl = "https://example.com/agreement.pdf",
+                    declinedAt = null,
+                    selectedPackId = pack.id.value,
+                )
+                insertMockedBilling(eventId = eventId, partnershipId = partnershipId, quotePdfUrl = "https://example.com/quote.pdf")
+                insertMockedJobOffer(companyId = companyId, id = jobOfferId)
+                insertMockCompanyJobOfferPromotion(
+                    jobOfferId = jobOfferId,
+                    partnershipId = partnershipId,
+                    eventId = eventId,
+                )
+                val integrationId = insertMockedIntegration(eventId = eventId)
+                insertSlackIntegration(integrationId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/events/$eventId/jobs/digest")
+        assertEquals(HttpStatusCode.NoContent, response.status)
+        verify { slackMethod.chatPostMessage(any<RequestConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder>>()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two related changes for job offer notifications:

### 1. Add pending job offers section to digest

The morning organiser digest now includes a section listing pending job offer promotions that need validation. When no pending promotions exist, the section displays "n/a".

**Changes:**
- `EventDigest` — added `jobOfferItems` field and updated `hasItems`
- `DigestRepositoryExposed` — added `queryPendingJobOffers()` querying `PENDING` promotions
- `MorningDigest` — added `jobOfferItems` parameter and `{{job_offer_section}}` replacement
- `DigestRoutes` — passes `jobOfferItems` to `MorningDigest`
- Slack templates (en/fr) — added 💼 job offers section
- `DigestJobRoutesTest` — added test for pending job offer promotions triggering notification

### 2. Fix job_title placeholder mismatch

The `populate()` methods in `JobOfferPromoted`, `JobOfferApproved`, and `JobOfferDeclined` were replacing `{{job_offer_title}}` but all templates use `{{job_title}}`, causing the title to appear as a raw placeholder.