### PR TITLE
Make PaginatedResponse metadata generic with pack counts

### DIFF
--- a/front/pages/orgs/[slug]/events/[eventSlug]/packs/index.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/packs/index.vue
@@ -38,7 +38,7 @@
             </div>
             <div class="flex items-baseline gap-2">
               <span class="text-3xl font-bold text-gray-900">
-                {{ getPackPartnershipCount(pack.id) }}
+                {{ getPackCount(pack.id) }}
               </span>
               <span v-if="pack.max_quantity" class="text-sm text-gray-500">
                 / {{ pack.max_quantity }}
@@ -49,8 +49,8 @@
               <div class="w-full bg-gray-200 rounded-full h-2">
                 <div
                   class="h-2 rounded-full transition-all"
-                  :class="getProgressBarColor(pack.id, pack.max_quantity)"
-                  :style="{ width: `${getProgressPercentage(pack.id, pack.max_quantity)}%` }"
+                  :class="getProgressBarColor(getPackCount(pack.id), pack.max_quantity)"
+                  :style="{ width: `${getProgressPercentage(getPackCount(pack.id), pack.max_quantity)}%` }"
                 />
               </div>
             </div>
@@ -163,7 +163,7 @@
 </template>
 
 <script setup lang="ts">
-import { getOrgsEventsPacks, getEventBySlug, deleteOrgsEventsPacks, getOrgsEventsPartnership, type SponsoringPack, type PartnershipItemSchema } from "~/utils/api";
+import { getOrgsEventsPacks, getEventBySlug, deleteOrgsEventsPacks, getOrgsEventsPartnership, type SponsoringPack, type PaginationMetadataSchemaPackCountsItem } from "~/utils/api";
 import authMiddleware from "~/middleware/auth";
 
 const route = useRoute();
@@ -185,7 +185,7 @@ const eventSlug = computed(() => {
 });
 
 const packs = ref<SponsoringPack[]>([]);
-const partnerships = ref<PartnershipItemSchema[]>([]);
+const packCounts = ref<PaginationMetadataSchemaPackCountsItem[]>([]);
 const loading = ref(true);
 const error = ref<string | null>(null);
 const eventName = ref<string>('');
@@ -197,20 +197,19 @@ const isDeleteModalOpen = ref(false);
 const packToDelete = ref<SponsoringPack | null>(null);
 const deletingPackId = ref<string | null>(null);
 
-// Calculer le nombre de partnerships par pack
-function getPackPartnershipCount(packId: string): number {
-  return partnerships.value.filter(p => p.selected_pack_id === packId).length;
+// Obtenir le nombre de partnerships pour un pack depuis les métadonnées
+function getPackCount(packId: string): number {
+  return packCounts.value.find(pc => pc.pack_id === packId)?.count ?? 0;
 }
 
 // Calculer le pourcentage de remplissage
-function getProgressPercentage(packId: string, maxQuantity: number): number {
-  const count = getPackPartnershipCount(packId);
+function getProgressPercentage(count: number, maxQuantity: number): number {
   return Math.min((count / maxQuantity) * 100, 100);
 }
 
 // Déterminer la couleur de la barre de progression
-function getProgressBarColor(packId: string, maxQuantity: number): string {
-  const percentage = getProgressPercentage(packId, maxQuantity);
+function getProgressBarColor(count: number, maxQuantity: number): string {
+  const percentage = getProgressPercentage(count, maxQuantity);
   if (percentage >= 90) return 'bg-red-500';
   if (percentage >= 70) return 'bg-yellow-500';
   return 'bg-green-500';
@@ -262,9 +261,9 @@ async function loadPacks() {
     eventName.value = eventResponse.data.event.name;
     packs.value = packsResponse.data;
 
-    // Extraire les items de la réponse paginée
-    const partnershipsData = partnershipsResponse.data as unknown as { items: PartnershipItemSchema[] };
-    partnerships.value = partnershipsData.items || [];
+    // Extraire les pack_counts depuis les métadonnées de la réponse paginée
+    const partnershipsData = partnershipsResponse.data as unknown as { metadata?: { pack_counts?: PaginationMetadataSchemaPackCountsItem[] } };
+    packCounts.value = partnershipsData.metadata?.pack_counts ?? [];
   } catch (err) {
     console.error('Failed to load packs:', err);
     error.value = 'Impossible de charger les packs';

--- a/front/pages/orgs/[slug]/events/[eventSlug]/sponsors/index.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/sponsors/index.vue
@@ -182,7 +182,8 @@ import { useSponsorFilters } from '~/composables/useSponsorFilters'
 import FilterPanel from '~/components/sponsors/FilterPanel.vue'
 import ActiveFilters from '~/components/sponsors/ActiveFilters.vue'
 
-import type { PartnershipsMetadata, PackCount } from '~/types/sponsors'
+import type { PartnershipsMetadata } from '~/types/sponsors'
+import type { PaginationMetadataSchemaPackCountsItem } from '~/utils/api'
 
 // Type pour la réponse paginée de l'API
 interface PaginatedPartnershipsResponse {
@@ -414,7 +415,7 @@ function handleEmailSent(recipientCount: number) {
 }
 
 // Pack stats: merge metadata pack_counts with packs max_quantity
-interface PackStat extends PackCount {
+interface PackStat extends PaginationMetadataSchemaPackCountsItem {
   max_quantity: number | null;
 }
 

--- a/front/pages/orgs/[slug]/events/[eventSlug]/sponsors/index.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/sponsors/index.vue
@@ -62,35 +62,35 @@
 
         <!-- Statistiques -->
         <div
-          v-if="packs.length > 0"
+          v-if="packStats.length > 0"
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6"
         >
           <div
-            v-for="pack in packs"
-            :key="`stat-${pack.id}`"
+            v-for="stat in packStats"
+            :key="`stat-${stat.pack_id}`"
             class="bg-white rounded-lg shadow p-6 border border-gray-200"
           >
             <div class="flex items-center justify-between mb-2">
-              <h3 class="text-sm font-medium text-gray-500">{{ pack.name }}</h3>
+              <h3 class="text-sm font-medium text-gray-500">{{ stat.pack_name }}</h3>
               <div class="text-xs text-gray-400">
-                {{ pack.max_quantity ? `Max: ${pack.max_quantity}` : 'Illimité' }}
+                {{ stat.max_quantity ? `Max: ${stat.max_quantity}` : 'Illimité' }}
               </div>
             </div>
             <div class="flex items-baseline gap-2">
               <span class="text-3xl font-bold text-gray-900">
-                {{ getPackPartnershipCount(pack.id) }}
+                {{ stat.count }}
               </span>
-              <span v-if="pack.max_quantity" class="text-sm text-gray-500">
-                / {{ pack.max_quantity }}
+              <span v-if="stat.max_quantity" class="text-sm text-gray-500">
+                / {{ stat.max_quantity }}
               </span>
               <span class="text-sm text-gray-500">sponsor(s)</span>
             </div>
-            <div v-if="pack.max_quantity" class="mt-3">
+            <div v-if="stat.max_quantity" class="mt-3">
               <div class="w-full bg-gray-200 rounded-full h-2">
                 <div
                   class="h-2 rounded-full transition-all"
-                  :class="getProgressBarColor(pack.id, pack.max_quantity)"
-                  :style="{ width: `${getProgressPercentage(pack.id, pack.max_quantity)}%` }"
+                  :class="getProgressBarColor(stat.count, stat.max_quantity)"
+                  :style="{ width: `${getProgressPercentage(stat.count, stat.max_quantity)}%` }"
                 />
               </div>
             </div>
@@ -175,14 +175,14 @@
 </template>
 
 <script setup lang="ts">
-import { getOrgsEventsPartnership, getEventBySlug, getOrgsEventsPacks, deletePartnership, type PartnershipItemSchema, type SponsoringPack, type PostPartnershipEmailParams } from "~/utils/api";
+import { getOrgsEventsPartnership, getEventBySlug, getOrgsEventsPacks, deletePartnership, type PartnershipItemSchema, type SponsoringPackSchema, type PostPartnershipEmailParams } from "~/utils/api";
 import { filterStateToApiParams } from "~/types/sponsors";
 import authMiddleware from "~/middleware/auth";
 import { useSponsorFilters } from '~/composables/useSponsorFilters'
 import FilterPanel from '~/components/sponsors/FilterPanel.vue'
 import ActiveFilters from '~/components/sponsors/ActiveFilters.vue'
 
-import type { PartnershipsMetadata } from '~/types/sponsors'
+import type { PartnershipsMetadata, PackCount } from '~/types/sponsors'
 
 // Type pour la réponse paginée de l'API
 interface PaginatedPartnershipsResponse {
@@ -295,7 +295,7 @@ const columns = [
 ];
 
 const partnerships = ref<PartnershipItemSchema[]>([]);
-const packs = ref<SponsoringPack[]>([]);
+const packs = ref<SponsoringPackSchema[]>([]);
 const filterMetadata = ref<PartnershipsMetadata | null>(null);
 const loading = ref(true);
 const error = ref<string | null>(null);
@@ -413,25 +413,30 @@ function handleEmailSent(recipientCount: number) {
   ariaAnnouncement.value = `Email envoyé à ${recipientCount} destinataires`;
 }
 
-// Calculer le nombre de partnerships par pack
-function getPackPartnershipCount(packId: string): number {
-  // Trouver le nom du pack correspondant à l'ID
-  const pack = packs.value.find(p => p.id === packId);
-  if (!pack) return 0;
-
-  // Compter les partnerships qui ont ce selected_pack_name
-  return partnerships.value.filter(p => p.selected_pack_name === pack.name).length;
+// Pack stats: merge metadata pack_counts with packs max_quantity
+interface PackStat extends PackCount {
+  max_quantity: number | null;
 }
 
+const packStats = computed<PackStat[]>(() => {
+  const counts = filterMetadata.value?.pack_counts ?? [];
+  return counts.map(pc => {
+    const pack = packs.value.find(p => p.id === pc.pack_id);
+    return {
+      ...pc,
+      max_quantity: pack?.max_quantity ?? null,
+    };
+  });
+});
+
 // Calculer le pourcentage de remplissage
-function getProgressPercentage(packId: string, maxQuantity: number): number {
-  const count = getPackPartnershipCount(packId);
+function getProgressPercentage(count: number, maxQuantity: number): number {
   return Math.min((count / maxQuantity) * 100, 100);
 }
 
 // Déterminer la couleur de la barre de progression
-function getProgressBarColor(packId: string, maxQuantity: number): string {
-  const percentage = getProgressPercentage(packId, maxQuantity);
+function getProgressBarColor(count: number, maxQuantity: number): string {
+  const percentage = getProgressPercentage(count, maxQuantity);
   if (percentage >= 90) return 'bg-red-500';
   if (percentage >= 70) return 'bg-yellow-500';
   return 'bg-green-500';

--- a/front/types/sponsors.ts
+++ b/front/types/sponsors.ts
@@ -66,6 +66,8 @@ export interface FilterValueOption {
   display_value: string;
 }
 
+import type { PaginationMetadataSchemaPackCountsItem } from "~/utils/api";
+
 /**
  * Filter metadata from API
  */
@@ -76,21 +78,12 @@ export interface FilterMetadata {
 }
 
 /**
- * Pack count from API metadata
- */
-export interface PackCount {
-  pack_id: string;
-  pack_name: string;
-  count: number;
-}
-
-/**
  * Metadata returned by the API for partnerships list
  */
 export interface PartnershipsMetadata {
   filters: FilterMetadata[];
   sorts: string[];
-  pack_counts: PackCount[];
+  pack_counts: PaginationMetadataSchemaPackCountsItem[];
 }
 
 /**

--- a/front/types/sponsors.ts
+++ b/front/types/sponsors.ts
@@ -76,11 +76,21 @@ export interface FilterMetadata {
 }
 
 /**
+ * Pack count from API metadata
+ */
+export interface PackCount {
+  pack_id: string;
+  pack_name: string;
+  count: number;
+}
+
+/**
  * Metadata returned by the API for partnerships list
  */
 export interface PartnershipsMetadata {
   filters: FilterMetadata[];
   sorts: string[];
+  pack_counts: PackCount[];
 }
 
 /**

--- a/front/utils/api.ts
+++ b/front/utils/api.ts
@@ -5,7 +5,7 @@
  * partners_connect API
  * OpenAPI spec version: 1.0.0
  */
-import { customFetch } from "../custom-instance";
+import { customFetch } from '../custom-instance';
 export interface UserSessionSchema {
   state: string;
   token: string;
@@ -40,16 +40,17 @@ export interface MediaSchema {
 
 export type Media = MediaSchema;
 
-export type SocialSchemaType = (typeof SocialSchemaType)[keyof typeof SocialSchemaType];
+export type SocialSchemaType = typeof SocialSchemaType[keyof typeof SocialSchemaType];
+
 
 export const SocialSchemaType = {
-  LINKEDIN: "LINKEDIN",
-  X: "X",
-  BLUESKY: "BLUESKY",
-  MASTODON: "MASTODON",
-  INSTAGRAM: "INSTAGRAM",
-  FACEBOOK: "FACEBOOK",
-  YOUTUBE: "YOUTUBE",
+  LINKEDIN: 'LINKEDIN',
+  X: 'X',
+  BLUESKY: 'BLUESKY',
+  MASTODON: 'MASTODON',
+  INSTAGRAM: 'INSTAGRAM',
+  FACEBOOK: 'FACEBOOK',
+  YOUTUBE: 'YOUTUBE',
 } as const;
 
 export interface SocialSchema {
@@ -292,23 +293,23 @@ export interface EventWithOrganisationSchema {
 
 export type EventWithOrganisation = EventWithOrganisationSchema;
 
-export type PartnershipOptionSelectionType =
-  (typeof PartnershipOptionSelectionType)[keyof typeof PartnershipOptionSelectionType];
+export type PartnershipOptionSelectionType = typeof PartnershipOptionSelectionType[keyof typeof PartnershipOptionSelectionType];
+
 
 export const PartnershipOptionSelectionType = {
-  text_selection: "text_selection",
-  quantitative_selection: "quantitative_selection",
-  number_selection: "number_selection",
-  selectable_selection: "selectable_selection",
+  text_selection: 'text_selection',
+  quantitative_selection: 'quantitative_selection',
+  number_selection: 'number_selection',
+  selectable_selection: 'selectable_selection',
 } as const;
 
 export interface PartnershipOptionSelection {
   type: PartnershipOptionSelectionType;
   option_id: string;
   /**
-   * Required for quantitative_selection, 0 means exclude option
-   * @minimum 0
-   */
+     * Required for quantitative_selection, 0 means exclude option
+     * @minimum 0
+     */
   selected_quantity?: number;
   /** Required for selectable_selection */
   selected_value_id?: string;
@@ -319,34 +320,34 @@ export interface RegisterPartnershipSchema {
   pack_id: string;
   option_selections?: PartnershipOptionSelection[];
   /**
-   * Partner contact person's full name
-   * @minLength 1
-   * @maxLength 255
-   */
+     * Partner contact person's full name
+     * @minLength 1
+     * @maxLength 255
+     */
   contact_name?: string;
   /**
-   * Partner contact person's role or title
-   * @minLength 1
-   * @maxLength 255
-   */
+     * Partner contact person's role or title
+     * @minLength 1
+     * @maxLength 255
+     */
   contact_role?: string;
   /**
-   * Preferred communication language using ISO 639-1 codes
-   * @minLength 2
-   * @maxLength 2
-   */
+     * Preferred communication language using ISO 639-1 codes
+     * @minLength 2
+     * @maxLength 2
+     */
   language: string;
   /**
-   * Contact phone number in free-form text (1-30 characters)
-   * @minLength 1
-   * @maxLength 30
-   * @nullable
-   */
+     * Contact phone number in free-form text (1-30 characters)
+     * @minLength 1
+     * @maxLength 30
+     * @nullable
+     */
   phone?: string | null;
   /**
-   * List of contact email addresses
-   * @minItems 0
-   */
+     * List of contact email addresses
+     * @minItems 0
+     */
   emails?: string[];
 }
 
@@ -357,38 +358,38 @@ export type RegisterPartnership = RegisterPartnershipSchema;
  */
 export interface UpdatePartnershipRequestSchema {
   /**
-   * Partner contact person's full name
-   * @minLength 1
-   * @maxLength 255
-   * @nullable
-   */
+     * Partner contact person's full name
+     * @minLength 1
+     * @maxLength 255
+     * @nullable
+     */
   contact_name?: string | null;
   /**
-   * Partner contact person's role or title
-   * @minLength 1
-   * @maxLength 255
-   * @nullable
-   */
+     * Partner contact person's role or title
+     * @minLength 1
+     * @maxLength 255
+     * @nullable
+     */
   contact_role?: string | null;
   /**
-   * Preferred communication language using ISO 639-1 codes (2 characters)
-   * @minLength 2
-   * @maxLength 2
-   * @nullable
-   */
+     * Preferred communication language using ISO 639-1 codes (2 characters)
+     * @minLength 2
+     * @maxLength 2
+     * @nullable
+     */
   language?: string | null;
   /**
-   * Contact phone number in free-form text (1-30 characters)
-   * @minLength 1
-   * @maxLength 30
-   * @nullable
-   */
+     * Contact phone number in free-form text (1-30 characters)
+     * @minLength 1
+     * @maxLength 30
+     * @nullable
+     */
   phone?: string | null;
   /**
-   * List of contact email addresses
-   * @minItems 0
-   * @nullable
-   */
+     * List of contact email addresses
+     * @minItems 0
+     * @nullable
+     */
   emails?: string[] | null;
 }
 
@@ -434,38 +435,38 @@ export interface TicketOrderSchema {
 export type TicketOrder = TicketOrderSchema;
 
 export interface Text {
-  type: "text";
+  type: 'text';
   id: string;
   name: string;
   /** @nullable */
   description?: string | null;
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
 }
 
 /**
  * Quantitative descriptor for user-defined quantities
  */
-export type TypedQuantitativeTypeDescriptor =
-  (typeof TypedQuantitativeTypeDescriptor)[keyof typeof TypedQuantitativeTypeDescriptor];
+export type TypedQuantitativeTypeDescriptor = typeof TypedQuantitativeTypeDescriptor[keyof typeof TypedQuantitativeTypeDescriptor];
+
 
 export const TypedQuantitativeTypeDescriptor = {
-  job_offer: "job_offer",
+  job_offer: 'job_offer',
 } as const;
 
 export interface TypedQuantitative {
-  type: "typed_quantitative";
+  type: 'typed_quantitative';
   id: string;
   name: string;
   /** @nullable */
   description?: string | null;
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
   /** Quantitative descriptor for user-defined quantities */
   type_descriptor: TypedQuantitativeTypeDescriptor;
@@ -474,60 +475,60 @@ export interface TypedQuantitative {
 /**
  * Number descriptor for fixed quantities
  */
-export type TypedNumberTypeDescriptor =
-  (typeof TypedNumberTypeDescriptor)[keyof typeof TypedNumberTypeDescriptor];
+export type TypedNumberTypeDescriptor = typeof TypedNumberTypeDescriptor[keyof typeof TypedNumberTypeDescriptor];
+
 
 export const TypedNumberTypeDescriptor = {
-  nb_ticket: "nb_ticket",
+  nb_ticket: 'nb_ticket',
 } as const;
 
 export interface TypedNumber {
-  type: "typed_number";
+  type: 'typed_number';
   id: string;
   name: string;
   /** @nullable */
   description?: string | null;
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
   /** Number descriptor for fixed quantities */
   type_descriptor: TypedNumberTypeDescriptor;
   /**
-   * Fixed quantity that cannot be modified by users
-   * @minimum 1
-   */
+     * Fixed quantity that cannot be modified by users
+     * @minimum 1
+     */
   fixed_quantity: number;
 }
 
 /**
  * Selectable descriptor for predefined choices
  */
-export type TypedSelectableTypeDescriptor =
-  (typeof TypedSelectableTypeDescriptor)[keyof typeof TypedSelectableTypeDescriptor];
+export type TypedSelectableTypeDescriptor = typeof TypedSelectableTypeDescriptor[keyof typeof TypedSelectableTypeDescriptor];
+
 
 export const TypedSelectableTypeDescriptor = {
-  booth: "booth",
+  booth: 'booth',
 } as const;
 
 export interface TypedSelectable {
-  type: "typed_selectable";
+  type: 'typed_selectable';
   id: string;
   name: string;
   /** @nullable */
   description?: string | null;
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
   /** Selectable descriptor for predefined choices */
   type_descriptor: TypedSelectableTypeDescriptor;
   /**
-   * Predefined values that users can select from
-   * @minItems 1
-   */
+     * Predefined values that users can select from
+     * @minItems 1
+     */
   selectable_values: string[];
 }
 
@@ -549,9 +550,9 @@ export type TranslatedLabel = TranslatedLabelSchema;
 
 export interface DefinitionsTranslatedLabel {
   /**
-   * @minLength 2
-   * @maxLength 5
-   */
+     * @minLength 2
+     * @maxLength 5
+     */
   language: string;
   /** @minLength 1 */
   name: string;
@@ -560,34 +561,34 @@ export interface DefinitionsTranslatedLabel {
 }
 
 export interface CreateText {
-  type: "text";
+  type: 'text';
   /** @minItems 1 */
   translations: DefinitionsTranslatedLabel[];
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
 }
 
 /**
  * Quantitative descriptor for user-defined quantities
  */
-export type CreateTypedQuantitativeTypeDescriptor =
-  (typeof CreateTypedQuantitativeTypeDescriptor)[keyof typeof CreateTypedQuantitativeTypeDescriptor];
+export type CreateTypedQuantitativeTypeDescriptor = typeof CreateTypedQuantitativeTypeDescriptor[keyof typeof CreateTypedQuantitativeTypeDescriptor];
+
 
 export const CreateTypedQuantitativeTypeDescriptor = {
-  job_offer: "job_offer",
+  job_offer: 'job_offer',
 } as const;
 
 export interface CreateTypedQuantitative {
-  type: "typed_quantitative";
+  type: 'typed_quantitative';
   /** @minItems 1 */
   translations: DefinitionsTranslatedLabel[];
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
   /** Quantitative descriptor for user-defined quantities */
   type_descriptor: CreateTypedQuantitativeTypeDescriptor;
@@ -596,80 +597,76 @@ export interface CreateTypedQuantitative {
 /**
  * Number descriptor for fixed quantities
  */
-export type CreateTypedNumberTypeDescriptor =
-  (typeof CreateTypedNumberTypeDescriptor)[keyof typeof CreateTypedNumberTypeDescriptor];
+export type CreateTypedNumberTypeDescriptor = typeof CreateTypedNumberTypeDescriptor[keyof typeof CreateTypedNumberTypeDescriptor];
+
 
 export const CreateTypedNumberTypeDescriptor = {
-  nb_ticket: "nb_ticket",
+  nb_ticket: 'nb_ticket',
 } as const;
 
 export interface CreateTypedNumber {
-  type: "typed_number";
+  type: 'typed_number';
   /** @minItems 1 */
   translations: DefinitionsTranslatedLabel[];
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
   /** Number descriptor for fixed quantities */
   type_descriptor: CreateTypedNumberTypeDescriptor;
   /**
-   * Fixed quantity that cannot be modified by users
-   * @minimum 1
-   */
+     * Fixed quantity that cannot be modified by users
+     * @minimum 1
+     */
   fixed_quantity: number;
 }
 
 /**
  * Selectable descriptor for predefined choices
  */
-export type CreateTypedSelectableTypeDescriptor =
-  (typeof CreateTypedSelectableTypeDescriptor)[keyof typeof CreateTypedSelectableTypeDescriptor];
+export type CreateTypedSelectableTypeDescriptor = typeof CreateTypedSelectableTypeDescriptor[keyof typeof CreateTypedSelectableTypeDescriptor];
+
 
 export const CreateTypedSelectableTypeDescriptor = {
-  booth: "booth",
+  booth: 'booth',
 } as const;
 
 export interface CreateSelectableValue {
   /**
-   * Display value for the selectable option
-   * @maxLength 255
-   */
+     * Display value for the selectable option
+     * @maxLength 255
+     */
   value: string;
   /**
-   * Individual price for this selectable value in cents
-   * @minimum 0
-   */
+     * Individual price for this selectable value in cents
+     * @minimum 0
+     */
   price: number;
 }
 
 export interface CreateTypedSelectable {
-  type: "typed_selectable";
+  type: 'typed_selectable';
   /** @minItems 1 */
   translations: DefinitionsTranslatedLabel[];
   /**
-   * @minimum 0
-   * @nullable
-   */
+     * @minimum 0
+     * @nullable
+     */
   price?: number | null;
   /** Selectable descriptor for predefined choices */
   type_descriptor: CreateTypedSelectableTypeDescriptor;
   /**
-   * Predefined values with individual pricing that users can select from
-   * @minItems 1
-   */
+     * Predefined values with individual pricing that users can select from
+     * @minItems 1
+     */
   selectable_values: CreateSelectableValue[];
 }
 
 /**
  * Polymorphic sealed class for creating sponsoring options
  */
-export type CreateSponsoringOptionSchema =
-  | CreateText
-  | CreateTypedQuantitative
-  | CreateTypedNumber
-  | CreateTypedSelectable;
+export type CreateSponsoringOptionSchema = CreateText | CreateTypedQuantitative | CreateTypedNumber | CreateTypedSelectable;
 
 export type CreateSponsoringOption = CreateSponsoringOptionSchema;
 
@@ -708,9 +705,9 @@ export interface SuggestPartnershipSchema {
   /** UUID of the sponsoring pack to suggest */
   pack_id: string;
   /**
-   * Two-letter language code (e.g., 'en', 'fr')
-   * @pattern ^[a-z]{2}$
-   */
+     * Two-letter language code (e.g., 'en', 'fr')
+     * @pattern ^[a-z]{2}$
+     */
   language: string;
   /** Array of selected sponsoring options with type-specific selections */
   option_selections?: PartnershipOptionSelection[];
@@ -738,9 +735,9 @@ export type RevokePermissionRequest = RevokePermissionRequestSchema;
  */
 export interface RevokeUsersResultSchema {
   /**
-   * Number of users whose permissions were successfully revoked
-   * @minimum 0
-   */
+     * Number of users whose permissions were successfully revoked
+     * @minimum 0
+     */
   revoked_count: number;
   /** List of email addresses that were not found in the system */
   not_found_emails: string[];
@@ -757,33 +754,33 @@ export type Provider = ProviderSchema;
  */
 export interface CreateProviderSchema {
   /**
-   * Provider name
-   * @minLength 1
-   * @maxLength 255
-   */
+     * Provider name
+     * @minLength 1
+     * @maxLength 255
+     */
   name: string;
   /**
-   * Provider type (free text)
-   * @minLength 1
-   * @maxLength 100
-   */
+     * Provider type (free text)
+     * @minLength 1
+     * @maxLength 100
+     */
   type: string;
   /**
-   * Provider website URL
-   * @nullable
-   */
+     * Provider website URL
+     * @nullable
+     */
   website?: string | null;
   /**
-   * Provider phone number
-   * @maxLength 30
-   * @nullable
-   */
+     * Provider phone number
+     * @maxLength 30
+     * @nullable
+     */
   phone?: string | null;
   /**
-   * Provider email address
-   * @maxLength 255
-   * @nullable
-   */
+     * Provider email address
+     * @maxLength 255
+     * @nullable
+     */
   email?: string | null;
 }
 
@@ -794,35 +791,35 @@ export type CreateProvider = CreateProviderSchema;
  */
 export interface UpdateProviderSchema {
   /**
-   * Provider name
-   * @minLength 1
-   * @maxLength 255
-   * @nullable
-   */
+     * Provider name
+     * @minLength 1
+     * @maxLength 255
+     * @nullable
+     */
   name?: string | null;
   /**
-   * Provider type (free text)
-   * @minLength 1
-   * @maxLength 100
-   * @nullable
-   */
+     * Provider type (free text)
+     * @minLength 1
+     * @maxLength 100
+     * @nullable
+     */
   type?: string | null;
   /**
-   * Provider website URL
-   * @nullable
-   */
+     * Provider website URL
+     * @nullable
+     */
   website?: string | null;
   /**
-   * Provider phone number
-   * @maxLength 30
-   * @nullable
-   */
+     * Provider phone number
+     * @maxLength 30
+     * @nullable
+     */
   phone?: string | null;
   /**
-   * Provider email address
-   * @maxLength 255
-   * @nullable
-   */
+     * Provider email address
+     * @maxLength 255
+     * @nullable
+     */
   email?: string | null;
 }
 
@@ -837,9 +834,9 @@ export interface ErrorResponseSchema {
   /** Optional array of additional error details (e.g., validation errors) */
   errors?: string[];
   /**
-   * Optional stack trace for debugging (only in development/debug mode)
-   * @nullable
-   */
+     * Optional stack trace for debugging (only in development/debug mode)
+     * @nullable
+     */
   stack?: string | null;
 }
 
@@ -967,34 +964,34 @@ export interface JobOfferResponseSchema {
   /** Direct link to the detailed job posting */
   url: string;
   /**
-   * Position name or job title
-   * @maxLength 255
-   */
+     * Position name or job title
+     * @maxLength 255
+     */
   title: string;
   /**
-   * Work location description
-   * @maxLength 200
-   */
+     * Work location description
+     * @maxLength 200
+     */
   location: string;
   /** When the job was posted (ISO format) */
   publication_date: string;
   /**
-   * Application deadline (ISO format, nullable)
-   * @nullable
-   */
+     * Application deadline (ISO format, nullable)
+     * @nullable
+     */
   end_date?: string | null;
   /**
-   * Minimum experience required in years (nullable)
-   * @minimum 0
-   * @maximum 20
-   * @nullable
-   */
+     * Minimum experience required in years (nullable)
+     * @minimum 0
+     * @maximum 20
+     * @nullable
+     */
   experience_years?: number | null;
   /**
-   * Salary information as free text (nullable)
-   * @maxLength 100
-   * @nullable
-   */
+     * Salary information as free text (nullable)
+     * @maxLength 100
+     * @nullable
+     */
   salary?: string | null;
   /** Timestamp when the record was created (ISO format) */
   created_at: string;
@@ -1009,20 +1006,20 @@ export interface PaginatedJobOfferSchema {
   /** Array of job offers for the current page */
   items: JobOfferResponseSchema[];
   /**
-   * Current page number
-   * @minimum 1
-   */
+     * Current page number
+     * @minimum 1
+     */
   page: number;
   /**
-   * Number of items per page
-   * @minimum 1
-   * @maximum 100
-   */
+     * Number of items per page
+     * @minimum 1
+     * @maximum 100
+     */
   page_size: number;
   /**
-   * Total number of job offers across all pages
-   * @minimum 0
-   */
+     * Total number of job offers across all pages
+     * @minimum 0
+     */
   total: number;
 }
 
@@ -1031,13 +1028,13 @@ export type PaginatedJobOffer = PaginatedJobOfferSchema;
 /**
  * Current promotion status
  */
-export type JobOfferPromotionResponseSchemaStatus =
-  (typeof JobOfferPromotionResponseSchemaStatus)[keyof typeof JobOfferPromotionResponseSchemaStatus];
+export type JobOfferPromotionResponseSchemaStatus = typeof JobOfferPromotionResponseSchemaStatus[keyof typeof JobOfferPromotionResponseSchemaStatus];
+
 
 export const JobOfferPromotionResponseSchemaStatus = {
-  pending: "pending",
-  approved: "approved",
-  declined: "declined",
+  pending: 'pending',
+  approved: 'approved',
+  declined: 'declined',
 } as const;
 
 /**
@@ -1047,9 +1044,9 @@ export type JobOfferPromotionResponseSchemaJobOffer = {
   /** Job offer identifier */
   id: string;
   /**
-   * Job offer title
-   * @maxLength 255
-   */
+     * Job offer title
+     * @maxLength 255
+     */
   title: string;
   /** External URL to the full job offer page */
   url: string;
@@ -1072,20 +1069,20 @@ export interface JobOfferPromotionResponseSchema {
   /** Timestamp when promotion was initially requested (ISO format) */
   promoted_at: string;
   /**
-   * Timestamp when organizer approved/declined (ISO format, null if pending)
-   * @nullable
-   */
+     * Timestamp when organizer approved/declined (ISO format, null if pending)
+     * @nullable
+     */
   reviewed_at?: string | null;
   /**
-   * User ID of organizer who reviewed (null if pending)
-   * @nullable
-   */
+     * User ID of organizer who reviewed (null if pending)
+     * @nullable
+     */
   reviewed_by?: string | null;
   /**
-   * Optional reason provided when declining promotion
-   * @maxLength 500
-   * @nullable
-   */
+     * Optional reason provided when declining promotion
+     * @maxLength 500
+     * @nullable
+     */
   decline_reason?: string | null;
   /** Embedded job offer entity */
   job_offer: JobOfferPromotionResponseSchemaJobOffer;
@@ -1102,20 +1099,20 @@ export interface PaginatedJobOfferPromotionSchema {
   /** Array of job offer promotions for the current page */
   items: JobOfferPromotionResponseSchema[];
   /**
-   * Current page number (1-indexed)
-   * @minimum 1
-   */
+     * Current page number (1-indexed)
+     * @minimum 1
+     */
   page: number;
   /**
-   * Number of items per page
-   * @minimum 1
-   * @maximum 100
-   */
+     * Number of items per page
+     * @minimum 1
+     * @maximum 100
+     */
   page_size: number;
   /**
-   * Total number of job offer promotions across all pages
-   * @minimum 0
-   */
+     * Total number of job offer promotions across all pages
+     * @minimum 0
+     */
   total: number;
 }
 
@@ -1125,28 +1122,28 @@ export interface CreateJobOfferSchema {
   /** @maxLength 500 */
   url: string;
   /**
-   * @minLength 1
-   * @maxLength 200
-   */
+     * @minLength 1
+     * @maxLength 200
+     */
   title: string;
   /**
-   * @minLength 1
-   * @maxLength 100
-   */
+     * @minLength 1
+     * @maxLength 100
+     */
   location: string;
   publication_date: string;
   /** @nullable */
   end_date?: string | null;
   /**
-   * @minimum 1
-   * @maximum 20
-   * @nullable
-   */
+     * @minimum 1
+     * @maximum 20
+     * @nullable
+     */
   experience_years?: number | null;
   /**
-   * @maxLength 100
-   * @nullable
-   */
+     * @maxLength 100
+     * @nullable
+     */
   salary?: string | null;
 }
 
@@ -1156,28 +1153,28 @@ export interface UpdateJobOfferSchema {
   /** @maxLength 500 */
   url?: string;
   /**
-   * @minLength 1
-   * @maxLength 200
-   */
+     * @minLength 1
+     * @maxLength 200
+     */
   title?: string;
   /**
-   * @minLength 1
-   * @maxLength 100
-   */
+     * @minLength 1
+     * @maxLength 100
+     */
   location?: string;
   publication_date?: string;
   /** @nullable */
   end_date?: string | null;
   /**
-   * @minimum 1
-   * @maximum 20
-   * @nullable
-   */
+     * @minimum 1
+     * @maximum 20
+     * @nullable
+     */
   experience_years?: number | null;
   /**
-   * @maxLength 100
-   * @nullable
-   */
+     * @maxLength 100
+     * @nullable
+     */
   salary?: string | null;
 }
 
@@ -1200,10 +1197,10 @@ export type JobOfferPromotionResponse = JobOfferPromotionResponseSchema;
 
 export interface DeclineJobOfferPromotionSchema {
   /**
-   * Optional reason for declining the job offer promotion
-   * @maxLength 500
-   * @nullable
-   */
+     * Optional reason for declining the job offer promotion
+     * @maxLength 500
+     * @nullable
+     */
   reason?: string | null;
 }
 
@@ -1214,46 +1211,46 @@ export type DeclineJobOfferRequest = DeclineJobOfferPromotionSchema;
  */
 export interface TextPartnershipOption {
   /** Discriminator field for text options */
-  type: "text";
+  type: 'text';
   /** Option unique identifier */
   id: string;
   /**
-   * Translated option name
-   * @minLength 1
-   */
+     * Translated option name
+     * @minLength 1
+     */
   name: string;
   /** Original translated description */
   description: string;
   /** Complete formatted description (same as description for text options) */
   label_with_value: string;
   /**
-   * Unit price for this option in cents
-   * @minimum 0
-   */
+     * Unit price for this option in cents
+     * @minimum 0
+     */
   price: number;
   /** Always 1 for text options */
   quantity: 1;
   /**
-   * Total cost for this option (same as price)
-   * @minimum 0
-   */
+     * Total cost for this option (same as price)
+     * @minimum 0
+     */
   total_price: number;
   /**
-   * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
-   * @minimum 0
-   * @nullable
-   */
+     * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
+     * @minimum 0
+     * @nullable
+     */
   price_override?: number | null;
 }
 
 /**
  * Quantitative descriptor for user-defined quantities
  */
-export type QuantitativePartnershipOptionTypeDescriptor =
-  (typeof QuantitativePartnershipOptionTypeDescriptor)[keyof typeof QuantitativePartnershipOptionTypeDescriptor];
+export type QuantitativePartnershipOptionTypeDescriptor = typeof QuantitativePartnershipOptionTypeDescriptor[keyof typeof QuantitativePartnershipOptionTypeDescriptor];
+
 
 export const QuantitativePartnershipOptionTypeDescriptor = {
-  job_offer: "job_offer",
+  job_offer: 'job_offer',
 } as const;
 
 /**
@@ -1261,54 +1258,54 @@ export const QuantitativePartnershipOptionTypeDescriptor = {
  */
 export interface QuantitativePartnershipOption {
   /** Discriminator field for quantitative options */
-  type: "typed_quantitative";
+  type: 'typed_quantitative';
   /** Option unique identifier */
   id: string;
   /**
-   * Translated option name
-   * @minLength 1
-   */
+     * Translated option name
+     * @minLength 1
+     */
   name: string;
   /** Original translated description */
   description: string;
   /**
-   * Formatted as '{description} ({quantity})', e.g., 'Conference passes (5)'
-   * @pattern ^.+\s\(\d+\)$
-   */
+     * Formatted as '{description} ({quantity})', e.g., 'Conference passes (5)'
+     * @pattern ^.+\s\(\d+\)$
+     */
   label_with_value: string;
   /**
-   * Unit price for this option in cents
-   * @minimum 0
-   */
+     * Unit price for this option in cents
+     * @minimum 0
+     */
   price: number;
   /**
-   * User-selected quantity for this partnership
-   * @minimum 0
-   */
+     * User-selected quantity for this partnership
+     * @minimum 0
+     */
   quantity: number;
   /**
-   * Total cost: price × quantity
-   * @minimum 0
-   */
+     * Total cost: price × quantity
+     * @minimum 0
+     */
   total_price: number;
   /** Quantitative descriptor for user-defined quantities */
   type_descriptor: QuantitativePartnershipOptionTypeDescriptor;
   /**
-   * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
-   * @minimum 0
-   * @nullable
-   */
+     * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
+     * @minimum 0
+     * @nullable
+     */
   price_override?: number | null;
 }
 
 /**
  * Number descriptor for fixed quantities
  */
-export type NumberPartnershipOptionTypeDescriptor =
-  (typeof NumberPartnershipOptionTypeDescriptor)[keyof typeof NumberPartnershipOptionTypeDescriptor];
+export type NumberPartnershipOptionTypeDescriptor = typeof NumberPartnershipOptionTypeDescriptor[keyof typeof NumberPartnershipOptionTypeDescriptor];
+
 
 export const NumberPartnershipOptionTypeDescriptor = {
-  nb_ticket: "nb_ticket",
+  nb_ticket: 'nb_ticket',
 } as const;
 
 /**
@@ -1316,54 +1313,54 @@ export const NumberPartnershipOptionTypeDescriptor = {
  */
 export interface NumberPartnershipOption {
   /** Discriminator field for number options */
-  type: "typed_number";
+  type: 'typed_number';
   /** Option unique identifier */
   id: string;
   /**
-   * Translated option name
-   * @minLength 1
-   */
+     * Translated option name
+     * @minLength 1
+     */
   name: string;
   /** Original translated description */
   description: string;
   /**
-   * Formatted as '{description} ({fixedQuantity})', e.g., 'Logo on website (3)'
-   * @pattern ^.+\s\(\d+\)$
-   */
+     * Formatted as '{description} ({fixedQuantity})', e.g., 'Logo on website (3)'
+     * @pattern ^.+\s\(\d+\)$
+     */
   label_with_value: string;
   /**
-   * Unit price for this option in cents
-   * @minimum 0
-   */
+     * Unit price for this option in cents
+     * @minimum 0
+     */
   price: number;
   /**
-   * Fixed quantity from option definition
-   * @minimum 0
-   */
+     * Fixed quantity from option definition
+     * @minimum 0
+     */
   quantity: number;
   /**
-   * Total cost: price × fixedQuantity
-   * @minimum 0
-   */
+     * Total cost: price × fixedQuantity
+     * @minimum 0
+     */
   total_price: number;
   /** Number descriptor for fixed quantities */
   type_descriptor: NumberPartnershipOptionTypeDescriptor;
   /**
-   * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
-   * @minimum 0
-   * @nullable
-   */
+     * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
+     * @minimum 0
+     * @nullable
+     */
   price_override?: number | null;
 }
 
 /**
  * Selectable descriptor for predefined choices
  */
-export type SelectablePartnershipOptionTypeDescriptor =
-  (typeof SelectablePartnershipOptionTypeDescriptor)[keyof typeof SelectablePartnershipOptionTypeDescriptor];
+export type SelectablePartnershipOptionTypeDescriptor = typeof SelectablePartnershipOptionTypeDescriptor[keyof typeof SelectablePartnershipOptionTypeDescriptor];
+
 
 export const SelectablePartnershipOptionTypeDescriptor = {
-  booth: "booth",
+  booth: 'booth',
 } as const;
 
 /**
@@ -1373,14 +1370,14 @@ export interface SelectedValue {
   /** Selected value unique identifier */
   id: string;
   /**
-   * Display name of the selected value (e.g., '3m x 3m', 'Gold')
-   * @minLength 1
-   */
+     * Display name of the selected value (e.g., '3m x 3m', 'Gold')
+     * @minLength 1
+     */
   value: string;
   /**
-   * Price for this specific value in cents
-   * @minimum 0
-   */
+     * Price for this specific value in cents
+     * @minimum 0
+     */
   price: number;
 }
 
@@ -1389,52 +1386,48 @@ export interface SelectedValue {
  */
 export interface SelectablePartnershipOption {
   /** Discriminator field for selectable options */
-  type: "typed_selectable";
+  type: 'typed_selectable';
   /** Option unique identifier */
   id: string;
   /**
-   * Translated option name
-   * @minLength 1
-   */
+     * Translated option name
+     * @minLength 1
+     */
   name: string;
   /** Original translated description */
   description: string;
   /**
-   * Formatted as '{description} ({selectedValue})', e.g., 'Booth size (3m x 3m)'
-   * @pattern ^.+\s\(.+\)$
-   */
+     * Formatted as '{description} ({selectedValue})', e.g., 'Booth size (3m x 3m)'
+     * @pattern ^.+\s\(.+\)$
+     */
   label_with_value: string;
   /**
-   * Unit price for this option (from selected value) in cents
-   * @minimum 0
-   */
+     * Unit price for this option (from selected value) in cents
+     * @minimum 0
+     */
   price: number;
   /** Always 1 for selectable options */
   quantity: 1;
   /**
-   * Total cost (same as price from selected value)
-   * @minimum 0
-   */
+     * Total cost (same as price from selected value)
+     * @minimum 0
+     */
   total_price: number;
   /** Selectable descriptor for predefined choices */
   type_descriptor: SelectablePartnershipOptionTypeDescriptor;
   selected_value: SelectedValue;
   /**
-   * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
-   * @minimum 0
-   * @nullable
-   */
+     * Organiser-set price override for this option in cents. When non-null, replaces the catalogue price for billing.
+     * @minimum 0
+     * @nullable
+     */
   price_override?: number | null;
 }
 
 /**
  * Polymorphic schema for partnership-specific options with complete descriptions and pricing
  */
-export type PartnershipOptionSchema =
-  | TextPartnershipOption
-  | QuantitativePartnershipOption
-  | NumberPartnershipOption
-  | SelectablePartnershipOption;
+export type PartnershipOptionSchema = TextPartnershipOption | QuantitativePartnershipOption | NumberPartnershipOption | SelectablePartnershipOption;
 
 /**
  * Enhanced partnership pack with partnership-specific options
@@ -1443,51 +1436,50 @@ export interface PartnershipPackSchema {
   /** Pack unique identifier */
   id: string;
   /**
-   * Pack name (e.g., 'Gold', 'Silver', 'Bronze')
-   * @minLength 1
-   */
+     * Pack name (e.g., 'Gold', 'Silver', 'Bronze')
+     * @minLength 1
+     */
   name: string;
   /**
-   * Base price of the pack in cents (excluding optional options)
-   * @minimum 0
-   */
+     * Base price of the pack in cents (excluding optional options)
+     * @minimum 0
+     */
   base_price: number;
   /**
-   * Options included in the base pack price
-   * @minItems 0
-   * @maxItems 100
-   */
+     * Options included in the base pack price
+     * @minItems 0
+     * @maxItems 100
+     */
   required_options: PartnershipOptionSchema[];
   /**
-   * Additional options selected by partner (cost beyond base price)
-   * @minItems 0
-   * @maxItems 100
-   */
+     * Additional options selected by partner (cost beyond base price)
+     * @minItems 0
+     * @maxItems 100
+     */
   optional_options: PartnershipOptionSchema[];
   /**
-   * Total price for this pack in cents (base_price + sum of optional option costs)
-   * @minimum 0
-   */
+     * Total price for this pack in cents (base_price + sum of optional option costs)
+     * @minimum 0
+     */
   total_price: number;
   /**
-   * Organiser-set price override for this pack in cents. When non-null, this value replaces base_price in total price computation. Null when no override is active.
-   * @minimum 0
-   * @nullable
-   */
+     * Organiser-set price override for this pack in cents. When non-null, this value replaces base_price in total price computation. Null when no override is active.
+     * @minimum 0
+     * @nullable
+     */
   pack_price_override?: number | null;
 }
 
 /**
  * @nullable
  */
-export type PartnershipProcessStatusSchemaBillingStatus =
-  | (typeof PartnershipProcessStatusSchemaBillingStatus)[keyof typeof PartnershipProcessStatusSchemaBillingStatus]
-  | null;
+export type PartnershipProcessStatusSchemaBillingStatus = typeof PartnershipProcessStatusSchemaBillingStatus[keyof typeof PartnershipProcessStatusSchemaBillingStatus] | null;
+
 
 export const PartnershipProcessStatusSchemaBillingStatus = {
-  pending: "pending",
-  sent: "sent",
-  paid: "paid",
+  pending: 'pending',
+  sent: 'sent',
+  paid: 'paid',
 } as const;
 
 export interface PartnershipProcessStatusSchema {
@@ -1517,11 +1509,11 @@ export interface PartnershipProcessStatusSchema {
   billing_status?: PartnershipProcessStatusSchemaBillingStatus;
 }
 
-export type PartnershipDetailSchemaCurrency =
-  (typeof PartnershipDetailSchemaCurrency)[keyof typeof PartnershipDetailSchemaCurrency];
+export type PartnershipDetailSchemaCurrency = typeof PartnershipDetailSchemaCurrency[keyof typeof PartnershipDetailSchemaCurrency];
+
 
 export const PartnershipDetailSchemaCurrency = {
-  EUR: "EUR",
+  EUR: 'EUR',
 } as const;
 
 export interface PartnershipDetailSchema {
@@ -1550,24 +1542,24 @@ export interface SpeakerSchema {
   /** Full name of the speaker */
   name: string;
   /**
-   * Biography or description of the speaker
-   * @nullable
-   */
+     * Biography or description of the speaker
+     * @nullable
+     */
   biography?: string | null;
   /**
-   * Professional title or job position
-   * @nullable
-   */
+     * Professional title or job position
+     * @nullable
+     */
   job_title?: string | null;
   /**
-   * URL to the speaker's photo
-   * @nullable
-   */
+     * URL to the speaker's photo
+     * @nullable
+     */
   photo_url?: string | null;
   /**
-   * Speaker's preferred pronouns
-   * @nullable
-   */
+     * Speaker's preferred pronouns
+     * @nullable
+     */
   pronouns?: string | null;
 }
 
@@ -1609,24 +1601,24 @@ export type PartnershipOrganiserResponse = PartnershipOrganiserResponseSchema;
 /**
  * Overall delivery status: SENT (all succeeded), FAILED (all failed), PARTIAL (mixed results)
  */
-export type PartnershipEmailHistoryResponseSchemaOverallStatus =
-  (typeof PartnershipEmailHistoryResponseSchemaOverallStatus)[keyof typeof PartnershipEmailHistoryResponseSchemaOverallStatus];
+export type PartnershipEmailHistoryResponseSchemaOverallStatus = typeof PartnershipEmailHistoryResponseSchemaOverallStatus[keyof typeof PartnershipEmailHistoryResponseSchemaOverallStatus];
+
 
 export const PartnershipEmailHistoryResponseSchemaOverallStatus = {
-  SENT: "SENT",
-  FAILED: "FAILED",
-  PARTIAL: "PARTIAL",
+  SENT: 'SENT',
+  FAILED: 'FAILED',
+  PARTIAL: 'PARTIAL',
 } as const;
 
 /**
  * Delivery status for this specific recipient
  */
-export type RecipientStatusResponseSchemaDeliveryStatus =
-  (typeof RecipientStatusResponseSchemaDeliveryStatus)[keyof typeof RecipientStatusResponseSchemaDeliveryStatus];
+export type RecipientStatusResponseSchemaDeliveryStatus = typeof RecipientStatusResponseSchemaDeliveryStatus[keyof typeof RecipientStatusResponseSchemaDeliveryStatus];
+
 
 export const RecipientStatusResponseSchemaDeliveryStatus = {
-  SENT: "SENT",
-  FAILED: "FAILED",
+  SENT: 'SENT',
+  FAILED: 'FAILED',
 } as const;
 
 /**
@@ -1652,9 +1644,9 @@ export interface PartnershipEmailHistoryResponseSchema {
   /** Email address used as the 'From' address */
   sender_email: string;
   /**
-   * Email subject line
-   * @maxLength 500
-   */
+     * Email subject line
+     * @maxLength 500
+     */
   subject: string;
   /** Email body content (HTML or plain text) */
   body_plain_text: string;
@@ -1663,9 +1655,9 @@ export interface PartnershipEmailHistoryResponseSchema {
   /** User who triggered the email (organiser) */
   triggered_by: UserSchema;
   /**
-   * Per-recipient delivery status details
-   * @minItems 1
-   */
+     * Per-recipient delivery status details
+     * @minItems 1
+     */
   recipients: RecipientStatusResponseSchema[];
 }
 
@@ -1697,29 +1689,29 @@ export interface SessionSchema {
   /** Session name/title */
   name: string;
   /**
-   * Session abstract/description
-   * @nullable
-   */
+     * Session abstract/description
+     * @nullable
+     */
   abstract?: string | null;
   /**
-   * Session start time (ISO 8601)
-   * @nullable
-   */
+     * Session start time (ISO 8601)
+     * @nullable
+     */
   start_time?: string | null;
   /**
-   * Session end time (ISO 8601)
-   * @nullable
-   */
+     * Session end time (ISO 8601)
+     * @nullable
+     */
   end_time?: string | null;
   /**
-   * Track or theme name
-   * @nullable
-   */
+     * Track or theme name
+     * @nullable
+     */
   track_name?: string | null;
   /**
-   * Session language code
-   * @nullable
-   */
+     * Session language code
+     * @nullable
+     */
   language?: string | null;
 }
 
@@ -1758,30 +1750,30 @@ export type SpeakerPartnership = SpeakerPartnershipSchema;
 /**
  * Integration provider type
  */
-export type IntegrationSchemaProvider =
-  (typeof IntegrationSchemaProvider)[keyof typeof IntegrationSchemaProvider];
+export type IntegrationSchemaProvider = typeof IntegrationSchemaProvider[keyof typeof IntegrationSchemaProvider];
+
 
 export const IntegrationSchemaProvider = {
-  slack: "slack",
-  mailjet: "mailjet",
-  qonto: "qonto",
-  billetweb: "billetweb",
-  webhook: "webhook",
-  openplanner: "openplanner",
+  slack: 'slack',
+  mailjet: 'mailjet',
+  qonto: 'qonto',
+  billetweb: 'billetweb',
+  webhook: 'webhook',
+  openplanner: 'openplanner',
 } as const;
 
 /**
  * Purpose of the integration
  */
-export type IntegrationSchemaUsage =
-  (typeof IntegrationSchemaUsage)[keyof typeof IntegrationSchemaUsage];
+export type IntegrationSchemaUsage = typeof IntegrationSchemaUsage[keyof typeof IntegrationSchemaUsage];
+
 
 export const IntegrationSchemaUsage = {
-  notification: "notification",
-  billing: "billing",
-  ticketing: "ticketing",
-  webhook: "webhook",
-  agenda: "agenda",
+  notification: 'notification',
+  billing: 'billing',
+  ticketing: 'ticketing',
+  webhook: 'webhook',
+  agenda: 'agenda',
 } as const;
 
 /**
@@ -1805,15 +1797,15 @@ export type Integration = IntegrationSchema;
  */
 export interface SendPartnershipEmailRequestSchema {
   /**
-   * Email subject line (will be prefixed with [event_name])
-   * @minLength 1
-   * @maxLength 500
-   */
+     * Email subject line (will be prefixed with [event_name])
+     * @minLength 1
+     * @maxLength 500
+     */
   subject: string;
   /**
-   * Email body content in HTML format
-   * @minLength 1
-   */
+     * Email body content in HTML format
+     * @minLength 1
+     */
   body: string;
 }
 
@@ -1824,9 +1816,9 @@ export type SendPartnershipEmailRequest = SendPartnershipEmailRequestSchema;
  */
 export interface SendPartnershipEmailResponseSchema {
   /**
-   * Total number of unique email recipients who received the email
-   * @minimum 1
-   */
+     * Total number of unique email recipients who received the email
+     * @minimum 1
+     */
   recipients: number;
 }
 
@@ -1835,21 +1827,21 @@ export type SendPartnershipEmailResponse = SendPartnershipEmailResponseSchema;
 /**
  * Data type of the filter parameter (enum: 'string' or 'boolean')
  */
-export type FilterDefinitionSchemaType =
-  (typeof FilterDefinitionSchemaType)[keyof typeof FilterDefinitionSchemaType];
+export type FilterDefinitionSchemaType = typeof FilterDefinitionSchemaType[keyof typeof FilterDefinitionSchemaType];
+
 
 export const FilterDefinitionSchemaType = {
-  string: "string",
-  boolean: "boolean",
+  string: 'string',
+  boolean: 'boolean',
 } as const;
 
 export interface FilterValueSchema {
   /** Filter value (e.g., email address for organiser filter) */
   value: string;
   /**
-   * Human-readable display name (e.g., full name for organiser filter)
-   * @minLength 1
-   */
+     * Human-readable display name (e.g., full name for organiser filter)
+     * @minLength 1
+     */
   display_value: string;
 }
 
@@ -1861,11 +1853,25 @@ export interface FilterDefinitionSchema {
   values?: FilterValueSchema[] | null;
 }
 
+export type PaginationMetadataSchemaPackCountsItem = {
+  /** Sponsoring pack unique identifier */
+  pack_id: string;
+  /** Display name of the sponsoring pack */
+  pack_name: string;
+  /**
+     * Number of active partnerships using this pack
+     * @minimum 0
+     */
+  count: number;
+};
+
 export interface PaginationMetadataSchema {
   /** Array of filter definitions describing all available filters for the endpoint */
   filters: FilterDefinitionSchema[];
   /** Array of field names that can be used for sorting */
   sorts: string[];
+  /** Count of active (non-declined) partnerships per sponsoring pack. Only present on partnership list endpoints. */
+  pack_counts?: PaginationMetadataSchemaPackCountsItem[];
 }
 
 export type PaginationMetadata = PaginationMetadataSchema;
@@ -1878,19 +1884,19 @@ export interface PartnershipListResponseSchema {
   /** Array of partnership items matching filter criteria */
   items: PartnershipItemSchema[];
   /**
-   * Current page number (1-based)
-   * @minimum 1
-   */
+     * Current page number (1-based)
+     * @minimum 1
+     */
   page: number;
   /**
-   * Number of items per page
-   * @minimum 1
-   */
+     * Number of items per page
+     * @minimum 1
+     */
   page_size: number;
   /**
-   * Total count of items matching all filters
-   * @minimum 0
-   */
+     * Total count of items matching all filters
+     * @minimum 0
+     */
   total: number;
   /** Pagination metadata containing available filters and sorts (always populated but nullable for backwards compatibility) */
   metadata?: PaginationMetadataSchema | null;
@@ -1902,10 +1908,10 @@ export type UpdatePartnershipPricingRequestSchemaOptionsPriceOverridesItem = {
   /** UUID of the option to override. Must belong to this partnership. */
   id: string;
   /**
-   * Custom price override for this option. Set to null to clear the override.
-   * @minimum 0
-   * @nullable
-   */
+     * Custom price override for this option. Set to null to clear the override.
+     * @minimum 0
+     * @nullable
+     */
   price_override?: number | null;
 };
 
@@ -1914,16 +1920,16 @@ export type UpdatePartnershipPricingRequestSchemaOptionsPriceOverridesItem = {
  */
 export interface UpdatePartnershipPricingRequestSchema {
   /**
-   * Custom price override for the validated sponsoring pack, in the same unit as the catalogue price. Omit to keep existing override. Set to null to clear the override. Set to 0 for a complimentary pack.
-   * @minimum 0
-   * @nullable
-   */
+     * Custom price override for the validated sponsoring pack, in the same unit as the catalogue price. Omit to keep existing override. Set to null to clear the override. Set to 0 for a complimentary pack.
+     * @minimum 0
+     * @nullable
+     */
   pack_price_override?: number | null;
   /**
-   * List of price overrides for specific options. Only listed option IDs are affected. Option IDs not listed are left unchanged.
-   * @minItems 1
-   * @nullable
-   */
+     * List of price overrides for specific options. Only listed option IDs are affected. Option IDs not listed are left unchanged.
+     * @minItems 1
+     * @nullable
+     */
   options_price_overrides?: UpdatePartnershipPricingRequestSchemaOptionsPriceOverridesItem[] | null;
 }
 
@@ -1966,33 +1972,27 @@ export interface OptionTranslationSchema {
   /** Translated option name */
   name: string;
   /**
-   * Translated option description (optional)
-   * @nullable
-   */
+     * Translated option description (optional)
+     * @nullable
+     */
   description: string | null;
 }
 
 /**
  * Map of translations keyed by language code (e.g., 'en', 'fr', 'de')
  */
-export type SponsoringOptionWithTranslationsSchemaTranslations = {
-  [key: string]: OptionTranslationSchema;
-};
+export type SponsoringOptionWithTranslationsSchemaTranslations = {[key: string]: OptionTranslationSchema};
 
 export interface SponsoringOptionWithTranslationsSchema {
   /** Unique identifier for the sponsoring option */
   id: string;
-  /** Type of the sponsoring option */
-  type: string;
   /** Map of translations keyed by language code (e.g., 'en', 'fr', 'de') */
   translations: SponsoringOptionWithTranslationsSchemaTranslations;
   /**
-   * Additional cost in cents (null for free options)
-   * @nullable
-   */
+     * Additional cost in cents (null for free options)
+     * @nullable
+     */
   price: number | null;
-  /** Fixed quantity for typed_number options */
-  fixed_quantity?: number;
 }
 
 export interface SponsoringOptionWithPartnershipsSchema {
@@ -2006,42 +2006,42 @@ export type SponsoringOptionDetailWithPartners = SponsoringOptionWithPartnership
 export interface SponsoringOptionWithCountSchema {
   option: SponsoringOptionWithTranslationsSchema;
   /**
-   * Number of validated partnerships whose validated pack contains this option
-   * @minimum 0
-   */
+     * Number of validated partnerships whose validated pack contains this option
+     * @minimum 0
+     */
   partnership_count: number;
 }
 
 export type SponsoringOptionWithCount = SponsoringOptionWithCountSchema;
 
 export type GetCompaniesParams = {
-  /**
-   * Search companies by name
-   */
-  query?: string;
-  /**
-   * Filter companies by status
-   */
-  "filter[status]"?: GetCompaniesFilterStatus;
-  /**
-   * Page number (must be >= 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (must be between 1 and 100)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Search companies by name
+ */
+query?: string;
+/**
+ * Filter companies by status
+ */
+'filter[status]'?: GetCompaniesFilterStatus;
+/**
+ * Page number (must be >= 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (must be between 1 and 100)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
-export type GetCompaniesFilterStatus =
-  (typeof GetCompaniesFilterStatus)[keyof typeof GetCompaniesFilterStatus];
+export type GetCompaniesFilterStatus = typeof GetCompaniesFilterStatus[keyof typeof GetCompaniesFilterStatus];
+
 
 export const GetCompaniesFilterStatus = {
-  active: "active",
-  inactive: "inactive",
+  active: 'active',
+  inactive: 'inactive',
 } as const;
 
 export type PostCompaniesLogoBody = {
@@ -2050,17 +2050,17 @@ export type PostCompaniesLogoBody = {
 };
 
 export type GetCompaniesJobOffersParams = {
-  /**
-   * Page number (must be >= 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (must be between 1 and 100)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Page number (must be >= 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (must be between 1 and 100)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
 export type PromoteJobOfferToPartnership201 = {
@@ -2068,21 +2068,21 @@ export type PromoteJobOfferToPartnership201 = {
 };
 
 export type ListJobOfferPromotionsParams = {
-  /**
-   * Filter by partnership ID
-   */
-  partnership_id?: string;
-  /**
-   * Page number for pagination
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Items per page
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Filter by partnership ID
+ */
+partnership_id?: string;
+/**
+ * Page number for pagination
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Items per page
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
 export type ListJobOfferPromotions200 = {
@@ -2093,17 +2093,17 @@ export type ListJobOfferPromotions200 = {
 };
 
 export type GetEventsParams = {
-  /**
-   * Page number (must be >= 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (must be between 1 and 100)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Page number (must be >= 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (must be between 1 and 100)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
 export type PostEventsPartnershipSignedAgreementBody = {
@@ -2112,77 +2112,78 @@ export type PostEventsPartnershipSignedAgreementBody = {
 };
 
 export type GetPartnershipJobOffersParams = {
-  /**
-   * Filter by promotion status
-   */
-  status?: GetPartnershipJobOffersStatus;
-  /**
-   * Page number (1-indexed)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Filter by promotion status
+ */
+status?: GetPartnershipJobOffersStatus;
+/**
+ * Page number (1-indexed)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
-export type GetPartnershipJobOffersStatus =
-  (typeof GetPartnershipJobOffersStatus)[keyof typeof GetPartnershipJobOffersStatus];
+export type GetPartnershipJobOffersStatus = typeof GetPartnershipJobOffersStatus[keyof typeof GetPartnershipJobOffersStatus];
+
 
 export const GetPartnershipJobOffersStatus = {
-  pending: "pending",
-  approved: "approved",
-  declined: "declined",
+  pending: 'pending',
+  approved: 'approved',
+  declined: 'declined',
 } as const;
 
 export type GetProvidersParams = {
-  /**
-   * Filter providers by organization slug
-   */
-  org_slug?: string;
-  /**
-   * Search providers by name (case-insensitive)
-   */
-  query?: string;
-  /**
-   * Sort by field (default: createdAt)
-   */
-  sort?: GetProvidersSort;
-  /**
-   * Sort direction (default: asc)
-   */
-  direction?: GetProvidersDirection;
-  /**
-   * Page number (must be >= 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (must be between 1 and 100)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Filter providers by organization slug
+ */
+org_slug?: string;
+/**
+ * Search providers by name (case-insensitive)
+ */
+query?: string;
+/**
+ * Sort by field (default: createdAt)
+ */
+sort?: GetProvidersSort;
+/**
+ * Sort direction (default: asc)
+ */
+direction?: GetProvidersDirection;
+/**
+ * Page number (must be >= 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (must be between 1 and 100)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
-export type GetProvidersSort = (typeof GetProvidersSort)[keyof typeof GetProvidersSort];
+export type GetProvidersSort = typeof GetProvidersSort[keyof typeof GetProvidersSort];
+
 
 export const GetProvidersSort = {
-  name: "name",
-  createdAt: "createdAt",
-  creation: "creation",
-  created: "created",
+  name: 'name',
+  createdAt: 'createdAt',
+  creation: 'creation',
+  created: 'created',
 } as const;
 
-export type GetProvidersDirection =
-  (typeof GetProvidersDirection)[keyof typeof GetProvidersDirection];
+export type GetProvidersDirection = typeof GetProvidersDirection[keyof typeof GetProvidersDirection];
+
 
 export const GetProvidersDirection = {
-  asc: "asc",
-  desc: "desc",
+  asc: 'asc',
+  desc: 'desc',
 } as const;
 
 export type PostProviders201 = {
@@ -2191,17 +2192,17 @@ export type PostProviders201 = {
 };
 
 export type GetOrgsEventsParams = {
-  /**
-   * Page number (default: 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (default: 20)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Page number (default: 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (default: 20)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
 export type PostOrgsEventsBoothPlanBody = {
@@ -2230,61 +2231,61 @@ export type DeleteOrgsEventsPacks204 = { [key: string]: unknown };
 export type DeleteOrgsEventsPacksOptions204 = { [key: string]: unknown };
 
 export type GetOrgsEventsPartnershipParams = {
-  /**
-   * Filter by sponsoring pack ID
-   */
-  "filter[pack_id]"?: string;
-  /**
-   * Filter by validation status
-   */
-  "filter[validated]"?: boolean;
-  /**
-   * Filter by suggestion status
-   */
-  "filter[suggestion]"?: boolean;
-  /**
-   * Filter by payment status
-   */
-  "filter[paid]"?: boolean;
-  /**
-   * Filter by agreement generation status
-   */
-  "filter[agreement-generated]"?: boolean;
-  /**
-   * Filter by agreement signature status
-   */
-  "filter[agreement-signed]"?: boolean;
-  /**
-   * Filter by assigned organiser email address (case-insensitive)
-   */
-  "filter[organiser]"?: string;
-  /**
-   * Filter by declined status. When absent or false (default), declined partnerships (those with a non-null declinedAt timestamp) are excluded from results. When true, declined partnerships are included alongside active ones. NOTE: This changes the default behaviour — previously declined partnerships were returned by default. Existing callers that need the old behaviour must pass filter[declined]=true.
-   */
-  "filter[declined]"?: boolean;
-  /**
-   * Sort direction
-   */
-  direction?: GetOrgsEventsPartnershipDirection;
-  /**
-   * Page number (must be >= 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (must be between 1 and 100)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Filter by sponsoring pack ID
+ */
+'filter[pack_id]'?: string;
+/**
+ * Filter by validation status
+ */
+'filter[validated]'?: boolean;
+/**
+ * Filter by suggestion status
+ */
+'filter[suggestion]'?: boolean;
+/**
+ * Filter by payment status
+ */
+'filter[paid]'?: boolean;
+/**
+ * Filter by agreement generation status
+ */
+'filter[agreement-generated]'?: boolean;
+/**
+ * Filter by agreement signature status
+ */
+'filter[agreement-signed]'?: boolean;
+/**
+ * Filter by assigned organiser email address (case-insensitive)
+ */
+'filter[organiser]'?: string;
+/**
+ * Filter by declined status. When absent or false (default), declined partnerships (those with a non-null declinedAt timestamp) are excluded from results. When true, declined partnerships are included alongside active ones. NOTE: This changes the default behaviour — previously declined partnerships were returned by default. Existing callers that need the old behaviour must pass filter[declined]=true.
+ */
+'filter[declined]'?: boolean;
+/**
+ * Sort direction
+ */
+direction?: GetOrgsEventsPartnershipDirection;
+/**
+ * Page number (must be >= 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (must be between 1 and 100)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
-export type GetOrgsEventsPartnershipDirection =
-  (typeof GetOrgsEventsPartnershipDirection)[keyof typeof GetOrgsEventsPartnershipDirection];
+export type GetOrgsEventsPartnershipDirection = typeof GetOrgsEventsPartnershipDirection[keyof typeof GetOrgsEventsPartnershipDirection];
+
 
 export const GetOrgsEventsPartnershipDirection = {
-  asc: "asc",
-  desc: "desc",
+  asc: 'asc',
+  desc: 'desc',
 } as const;
 
 export type PostOrgsEventsPartnershipAgreement200 = {
@@ -2293,30 +2294,30 @@ export type PostOrgsEventsPartnershipAgreement200 = {
 };
 
 export type ListPartnershipJobOffersParams = {
-  /**
-   * Filter by promotion status
-   */
-  status?: ListPartnershipJobOffersStatus;
-  /**
-   * Page number (1-indexed)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Filter by promotion status
+ */
+status?: ListPartnershipJobOffersStatus;
+/**
+ * Page number (1-indexed)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
-export type ListPartnershipJobOffersStatus =
-  (typeof ListPartnershipJobOffersStatus)[keyof typeof ListPartnershipJobOffersStatus];
+export type ListPartnershipJobOffersStatus = typeof ListPartnershipJobOffersStatus[keyof typeof ListPartnershipJobOffersStatus];
+
 
 export const ListPartnershipJobOffersStatus = {
-  pending: "pending",
-  approved: "approved",
-  declined: "declined",
+  pending: 'pending',
+  approved: 'approved',
+  declined: 'declined',
 } as const;
 
 export type ListPartnershipJobOffers200 = {
@@ -2332,30 +2333,30 @@ export type ListPartnershipJobOffers200 = {
 };
 
 export type ListEventJobOfferPromotionsParams = {
-  /**
-   * Filter by promotion status
-   */
-  status?: ListEventJobOfferPromotionsStatus;
-  /**
-   * Page number (1-indexed)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Filter by promotion status
+ */
+status?: ListEventJobOfferPromotionsStatus;
+/**
+ * Page number (1-indexed)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
-export type ListEventJobOfferPromotionsStatus =
-  (typeof ListEventJobOfferPromotionsStatus)[keyof typeof ListEventJobOfferPromotionsStatus];
+export type ListEventJobOfferPromotionsStatus = typeof ListEventJobOfferPromotionsStatus[keyof typeof ListEventJobOfferPromotionsStatus];
+
 
 export const ListEventJobOfferPromotionsStatus = {
-  pending: "pending",
-  approved: "approved",
-  declined: "declined",
+  pending: 'pending',
+  approved: 'approved',
+  declined: 'declined',
 } as const;
 
 export type ListEventJobOfferPromotions200 = {
@@ -2373,17 +2374,17 @@ export type ListEventJobOfferPromotions200 = {
 export type ApproveJobOfferPromotionBody = { [key: string]: unknown };
 
 export type GetPartnershipEmailHistoryParams = {
-  /**
-   * Page number (1-based)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page
-   * @minimum 1
-   * @maximum 100
-   */
-  pageSize?: number;
+/**
+ * Page number (1-based)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page
+ * @minimum 1
+ * @maximum 100
+ */
+pageSize?: number;
 };
 
 export type GetPartnershipEmailHistory200 = {
@@ -2397,413 +2398,407 @@ export type GetPartnershipEmailHistory200 = {
 };
 
 export type PostPartnershipEmailParams = {
-  /**
-   * Filter by validation status (true = validated, false = not validated)
-   */
-  "filter[validated]"?: boolean;
-  /**
-   * Filter by payment status (true = paid, false = unpaid)
-   */
-  "filter[paid]"?: boolean;
-  /**
-   * Filter by sponsoring pack UUID
-   */
-  "filter[pack_id]"?: string;
-  /**
-   * Filter by suggestion status (true = suggested by organizer)
-   */
-  "filter[suggestion]"?: boolean;
-  /**
-   * Filter by agreement generation status
-   */
-  "filter[agreement-generated]"?: boolean;
-  /**
-   * Filter by agreement signature status
-   */
-  "filter[agreement-signed]"?: boolean;
-  /**
-   * Filter by assigned organiser email address for targeted bulk emails
-   */
-  "filter[organiser]"?: string;
-  /**
-   * Filter by declined status for email recipients. When absent or false (default), declined partnerships are excluded from the email recipient list. When true, declined partnerships are included as recipients.
-   */
-  "filter[declined]"?: boolean;
+/**
+ * Filter by validation status (true = validated, false = not validated)
+ */
+'filter[validated]'?: boolean;
+/**
+ * Filter by payment status (true = paid, false = unpaid)
+ */
+'filter[paid]'?: boolean;
+/**
+ * Filter by sponsoring pack UUID
+ */
+'filter[pack_id]'?: string;
+/**
+ * Filter by suggestion status (true = suggested by organizer)
+ */
+'filter[suggestion]'?: boolean;
+/**
+ * Filter by agreement generation status
+ */
+'filter[agreement-generated]'?: boolean;
+/**
+ * Filter by agreement signature status
+ */
+'filter[agreement-signed]'?: boolean;
+/**
+ * Filter by assigned organiser email address for targeted bulk emails
+ */
+'filter[organiser]'?: string;
+/**
+ * Filter by declined status for email recipients. When absent or false (default), declined partnerships are excluded from the email recipient list. When true, declined partnerships are included as recipients.
+ */
+'filter[declined]'?: boolean;
 };
 
 export type GetOrgsEventsProvidersParams = {
-  /**
-   * Page number (must be >= 1)
-   * @minimum 1
-   */
-  page?: number;
-  /**
-   * Number of items per page (must be between 1 and 100)
-   * @minimum 1
-   * @maximum 100
-   */
-  page_size?: number;
+/**
+ * Page number (must be >= 1)
+ * @minimum 1
+ */
+page?: number;
+/**
+ * Number of items per page (must be between 1 and 100)
+ * @minimum 1
+ * @maximum 100
+ */
+page_size?: number;
 };
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
-/**
+
+  /**
  * OAuth callback endpoint
  * @summary OAuth callback endpoint
  */
 export const getAuthCallback = (
-  options?: SecondParameter<typeof customFetch<UserSessionSchema>>,
-) => {
-  return customFetch<UserSessionSchema>({ url: `/auth/callback`, method: "GET" }, options);
-};
+
+ options?: SecondParameter<typeof customFetch<UserSessionSchema>>,) => {
+      return customFetch<UserSessionSchema>(
+      {url: `/auth/callback`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Start OAuth login flow - redirects to Google OAuth
  * @summary Get resource
  */
-export const getAuthLogin = (options?: SecondParameter<typeof customFetch<string>>) => {
-  return customFetch<string>({ url: `/auth/login`, method: "GET" }, options);
-};
+export const getAuthLogin = (
+
+ options?: SecondParameter<typeof customFetch<string>>,) => {
+      return customFetch<string>(
+      {url: `/auth/login`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Logout and clear session
  * @summary Get resource
  */
-export const getAuthLogout = (options?: SecondParameter<typeof customFetch<void>>) => {
-  return customFetch<void>({ url: `/auth/logout`, method: "GET" }, options);
-};
+export const getAuthLogout = (
+
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/auth/logout`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Get current user information
  * @summary Get resource
  */
-export const getAuthMe = (options?: SecondParameter<typeof customFetch<UserInfoSchema>>) => {
-  return customFetch<UserInfoSchema>({ url: `/auth/me`, method: "GET" }, options);
-};
+export const getAuthMe = (
+
+ options?: SecondParameter<typeof customFetch<UserInfoSchema>>,) => {
+      return customFetch<UserInfoSchema>(
+      {url: `/auth/me`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * List companies with paging support
  * @summary Get resource
  */
 export const getCompanies = (
-  params?: GetCompaniesParams,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    { url: `/companies`, method: "GET", params, responseType: "blob" },
-    options,
-  );
-};
+    params?: GetCompaniesParams,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/companies`, method: 'GET',
+        params,
+        responseType: 'blob'
+    },
+      options);
+    }
 
 /**
  * Create a new company
  * @summary Create company
  */
 export const postCompanies = (
-  createCompanySchema: CreateCompanySchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/companies`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    createCompanySchema: CreateCompanySchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/companies`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: createCompanySchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Retrieve a specific company by its UUID
  * @summary Get company by ID
  */
 export const getCompanyById = (
-  companyId: string,
-  options?: SecondParameter<typeof customFetch<CompanySchema>>,
-) => {
-  return customFetch<CompanySchema>({ url: `/companies/${companyId}`, method: "GET" }, options);
-};
+    companyId: string,
+ options?: SecondParameter<typeof customFetch<CompanySchema>>,) => {
+      return customFetch<CompanySchema>(
+      {url: `/companies/${companyId}`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Update an existing company with partial or complete data
  * @summary Update company
  */
 export const putCompanyById = (
-  companyId: string,
-  updateCompanySchema: UpdateCompanySchema,
-  options?: SecondParameter<typeof customFetch<CompanySchema>>,
-) => {
-  return customFetch<CompanySchema>(
-    {
-      url: `/companies/${companyId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: updateCompanySchema,
+    companyId: string,
+    updateCompanySchema: UpdateCompanySchema,
+ options?: SecondParameter<typeof customFetch<CompanySchema>>,) => {
+      return customFetch<CompanySchema>(
+      {url: `/companies/${companyId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateCompanySchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Soft delete a company by setting its status to inactive
  * @summary Delete company (soft delete)
  */
 export const deleteCompanyById = (
-  companyId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>({ url: `/companies/${companyId}`, method: "DELETE" }, options);
-};
+    companyId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/companies/${companyId}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * Upload a logo for a company
  * @summary Create resource
  */
 export const postCompaniesLogo = (
-  companyId: string,
-  postCompaniesLogoBody: PostCompaniesLogoBody,
-  options?: SecondParameter<typeof customFetch<MediaSchema>>,
-) => {
-  const formData = new FormData();
-  if (postCompaniesLogoBody.file !== undefined) {
-    formData.append(`file`, postCompaniesLogoBody.file);
-  }
+    companyId: string,
+    postCompaniesLogoBody: PostCompaniesLogoBody,
+ options?: SecondParameter<typeof customFetch<MediaSchema>>,) => {const formData = new FormData();
+if(postCompaniesLogoBody.file !== undefined) {
+ formData.append(`file`, postCompaniesLogoBody.file);
+ }
 
-  return customFetch<MediaSchema>(
-    { url: `/companies/${companyId}/logo`, method: "POST", data: formData },
-    options,
-  );
-};
+      return customFetch<MediaSchema>(
+      {url: `/companies/${companyId}/logo`, method: 'POST',
+       data: formData
+    },
+      options);
+    }
 
 /**
  * List all partnerships for a company
  * @summary List all partnerships for a company
  */
 export const getCompaniesPartnership = (
-  companyId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    { url: `/companies/${companyId}/partnerships`, method: "GET", responseType: "blob" },
-    options,
-  );
-};
+    companyId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/companies/${companyId}/partnerships`, method: 'GET',
+        responseType: 'blob'
+    },
+      options);
+    }
 
 /**
  * Retrieve all job offers for a specific company with pagination support
  * @summary List job offers for company
  */
 export const getCompaniesJobOffers = (
-  companyId: string,
-  params?: GetCompaniesJobOffersParams,
-  options?: SecondParameter<typeof customFetch<PaginatedJobOfferSchema>>,
-) => {
-  return customFetch<PaginatedJobOfferSchema>(
-    { url: `/companies/${companyId}/job-offers`, method: "GET", params },
-    options,
-  );
-};
+    companyId: string,
+    params?: GetCompaniesJobOffersParams,
+ options?: SecondParameter<typeof customFetch<PaginatedJobOfferSchema>>,) => {
+      return customFetch<PaginatedJobOfferSchema>(
+      {url: `/companies/${companyId}/job-offers`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Create a new job offer for the specified company
  * @summary Create job offer
  */
 export const postCompaniesJobOffers = (
-  companyId: string,
-  createJobOfferSchema: CreateJobOfferSchema,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/companies/${companyId}/job-offers`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createJobOfferSchema,
+    companyId: string,
+    createJobOfferSchema: CreateJobOfferSchema,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/companies/${companyId}/job-offers`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createJobOfferSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Retrieve a specific job offer by its ID
  * @summary Get job offer by ID
  */
 export const getCompaniesJobOffersById = (
-  companyId: string,
-  jobOfferId: string,
-  options?: SecondParameter<typeof customFetch<JobOfferResponseSchema>>,
-) => {
-  return customFetch<JobOfferResponseSchema>(
-    { url: `/companies/${companyId}/job-offers/${jobOfferId}`, method: "GET" },
-    options,
-  );
-};
+    companyId: string,
+    jobOfferId: string,
+ options?: SecondParameter<typeof customFetch<JobOfferResponseSchema>>,) => {
+      return customFetch<JobOfferResponseSchema>(
+      {url: `/companies/${companyId}/job-offers/${jobOfferId}`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Update an existing job offer with partial or complete data
  * @summary Update job offer
  */
 export const putCompaniesJobOffersById = (
-  companyId: string,
-  jobOfferId: string,
-  updateJobOfferSchema: UpdateJobOfferSchema,
-  options?: SecondParameter<typeof customFetch<JobOfferResponseSchema>>,
-) => {
-  return customFetch<JobOfferResponseSchema>(
-    {
-      url: `/companies/${companyId}/job-offers/${jobOfferId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: updateJobOfferSchema,
+    companyId: string,
+    jobOfferId: string,
+    updateJobOfferSchema: UpdateJobOfferSchema,
+ options?: SecondParameter<typeof customFetch<JobOfferResponseSchema>>,) => {
+      return customFetch<JobOfferResponseSchema>(
+      {url: `/companies/${companyId}/job-offers/${jobOfferId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateJobOfferSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Delete an existing job offer
  * @summary Delete job offer
  */
 export const deleteCompaniesJobOffersById = (
-  companyId: string,
-  jobOfferId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/companies/${companyId}/job-offers/${jobOfferId}`, method: "DELETE" },
-    options,
-  );
-};
+    companyId: string,
+    jobOfferId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/companies/${companyId}/job-offers/${jobOfferId}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * Company owner promotes a job offer to an active partnership with an event
  * @summary Promote job offer to partnership
  */
 export const promoteJobOfferToPartnership = (
-  companyId: string,
-  partnershipId: string,
-  promoteJobOfferSchema: PromoteJobOfferSchema,
-  options?: SecondParameter<typeof customFetch<PromoteJobOfferToPartnership201>>,
-) => {
-  return customFetch<PromoteJobOfferToPartnership201>(
-    {
-      url: `/companies/${companyId}/partnerships/${partnershipId}/promote`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: promoteJobOfferSchema,
+    companyId: string,
+    partnershipId: string,
+    promoteJobOfferSchema: PromoteJobOfferSchema,
+ options?: SecondParameter<typeof customFetch<PromoteJobOfferToPartnership201>>,) => {
+      return customFetch<PromoteJobOfferToPartnership201>(
+      {url: `/companies/${companyId}/partnerships/${partnershipId}/promote`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: promoteJobOfferSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * List all promotions for a specific job offer across all partnerships
  * @summary List job offer promotions
  */
 export const listJobOfferPromotions = (
-  companyId: string,
-  jobOfferId: string,
-  params?: ListJobOfferPromotionsParams,
-  options?: SecondParameter<typeof customFetch<ListJobOfferPromotions200>>,
-) => {
-  return customFetch<ListJobOfferPromotions200>(
-    { url: `/companies/${companyId}/job-offers/${jobOfferId}/promotions`, method: "GET", params },
-    options,
-  );
-};
+    companyId: string,
+    jobOfferId: string,
+    params?: ListJobOfferPromotionsParams,
+ options?: SecondParameter<typeof customFetch<ListJobOfferPromotions200>>,) => {
+      return customFetch<ListJobOfferPromotions200>(
+      {url: `/companies/${companyId}/job-offers/${jobOfferId}/promotions`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * List events with paging support
  * @summary List organization events
  */
 export const getEvents = (
-  params?: GetEventsParams,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    { url: `/events`, method: "GET", params, responseType: "blob" },
-    options,
-  );
-};
+    params?: GetEventsParams,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events`, method: 'GET',
+        params,
+        responseType: 'blob'
+    },
+      options);
+    }
 
 /**
  * Get event details with organization information
  * @summary Get resource
  */
 export const getEventBySlug = (
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<EventWithOrganisationSchema>>,
-) => {
-  return customFetch<EventWithOrganisationSchema>(
-    { url: `/events/${eventSlug}`, method: "GET" },
-    options,
-  );
-};
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<EventWithOrganisationSchema>>,) => {
+      return customFetch<EventWithOrganisationSchema>(
+      {url: `/events/${eventSlug}`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Retrieve event agenda with sessions and speakers for public consumption. No authentication required.
  * @summary Get public event agenda
  */
 export const getEventAgendaPublic = (
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<AgendaResponseSchema>>,
-) => {
-  return customFetch<AgendaResponseSchema>(
-    { url: `/events/${eventSlug}/agenda`, method: "GET" },
-    options,
-  );
-};
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<AgendaResponseSchema>>,) => {
+      return customFetch<AgendaResponseSchema>(
+      {url: `/events/${eventSlug}/agenda`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * List public sponsoring packages for an event with embedded and optional options (authentication optional - publicly accessible)
  * @summary List public sponsoring packages
  */
 export const getEventsSponsoringPacks = (
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<SponsoringPackSchema[]>>,
-) => {
-  return customFetch<SponsoringPackSchema[]>(
-    { url: `/events/${eventSlug}/sponsoring/packs`, method: "GET" },
-    options,
-  );
-};
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<SponsoringPackSchema[]>>,) => {
+      return customFetch<SponsoringPackSchema[]>(
+      {url: `/events/${eventSlug}/sponsoring/packs`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * @summary Create resource
  */
 export const postEventsPartnership = (
-  eventSlug: string,
-  registerPartnershipSchema: RegisterPartnershipSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    eventSlug: string,
+    registerPartnershipSchema: RegisterPartnershipSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: registerPartnershipSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Retrieve comprehensive partnership information including company, event, and process status details
  * @summary Get detailed partnership information
  */
 export const getEventsPartnershipDetailed = (
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<DetailedPartnershipResponseSchema>>,
-) => {
-  return customFetch<DetailedPartnershipResponseSchema>(
-    { url: `/events/${eventSlug}/partnerships/${partnershipId}`, method: "GET" },
-    options,
-  );
-};
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<DetailedPartnershipResponseSchema>>,) => {
+      return customFetch<DetailedPartnershipResponseSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Updates contact information fields for an existing partnership. This is a public endpoint
@@ -2819,828 +2814,693 @@ Updatable fields:
  * @summary Update partnership contact information
  */
 export const updatePartnershipContactInfo = (
-  eventSlug: string,
-  partnershipId: string,
-  updatePartnershipRequestSchema: UpdatePartnershipRequestSchema,
-  options?: SecondParameter<typeof customFetch<DetailedPartnershipResponseSchema>>,
-) => {
-  return customFetch<DetailedPartnershipResponseSchema>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: updatePartnershipRequestSchema,
+    eventSlug: string,
+    partnershipId: string,
+    updatePartnershipRequestSchema: UpdatePartnershipRequestSchema,
+ options?: SecondParameter<typeof customFetch<DetailedPartnershipResponseSchema>>,) => {
+      return customFetch<DetailedPartnershipResponseSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updatePartnershipRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Get partnership billing information
  */
 export const getEventsPartnershipBilling = (
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/billing`,
-      method: "GET",
-      responseType: "blob",
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<CompanyBillingDataSchema>>,) => {
+      return customFetch<CompanyBillingDataSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/billing`, method: 'GET'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Create partnership billing
  */
 export const postEventsPartnershipBilling = (
-  eventSlug: string,
-  partnershipId: string,
-  companyBillingDataSchema: CompanyBillingDataSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/billing`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    eventSlug: string,
+    partnershipId: string,
+    companyBillingDataSchema: CompanyBillingDataSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/billing`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: companyBillingDataSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Update partnership billing
  */
 export const putEventsPartnershipBilling = (
-  eventSlug: string,
-  partnershipId: string,
-  companyBillingDataSchema: CompanyBillingDataSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/billing`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+    eventSlug: string,
+    partnershipId: string,
+    companyBillingDataSchema: CompanyBillingDataSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/billing`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
       data: companyBillingDataSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Generate an invoice for a partnership
  * @summary Generate partnership invoice
  */
 export const postOrgsEventsPartnershipBillingInvoice = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/billing/invoice`,
-      method: "POST",
-      responseType: "blob",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/billing/invoice`, method: 'POST',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Generate a quote for a partnership
  * @summary Generate partnership quote
  */
 export const postOrgsEventsPartnershipBillingQuote = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/billing/quote`,
-      method: "POST",
-      responseType: "blob",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/billing/quote`, method: 'POST',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Upload a signed partnership agreement
  * @summary Upload signed partnership agreement
  */
 export const postEventsPartnershipSignedAgreement = (
-  eventSlug: string,
-  partnershipId: string,
-  postEventsPartnershipSignedAgreementBody: PostEventsPartnershipSignedAgreementBody,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  const formData = new FormData();
-  if (postEventsPartnershipSignedAgreementBody.file !== undefined) {
-    formData.append(`file`, postEventsPartnershipSignedAgreementBody.file);
-  }
+    eventSlug: string,
+    partnershipId: string,
+    postEventsPartnershipSignedAgreementBody: PostEventsPartnershipSignedAgreementBody,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {const formData = new FormData();
+if(postEventsPartnershipSignedAgreementBody.file !== undefined) {
+ formData.append(`file`, postEventsPartnershipSignedAgreementBody.file);
+ }
 
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/signed-agreement`,
-      method: "POST",
-      data: formData,
+      return customFetch<IdentifierSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/signed-agreement`, method: 'POST',
+       data: formData
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Approve partnership suggestion
  */
 export const postEventsPartnershipSuggestionApprove = (
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/suggestion-approve`,
-      method: "POST",
-      responseType: "blob",
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/suggestion-approve`, method: 'POST',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Decline partnership suggestion
  */
 export const postEventsPartnershipSuggestionDecline = (
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/suggestion-decline`,
-      method: "POST",
-      responseType: "blob",
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/suggestion-decline`, method: 'POST',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Get partnership tickets
  */
 export const getEventsPartnershipTickets = (
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/tickets`,
-      method: "GET",
-      responseType: "blob",
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/tickets`, method: 'GET',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Create partnership tickets
  */
 export const postEventsPartnershipTickets = (
-  eventSlug: string,
-  partnershipId: string,
-  ticketDataSchema: TicketDataSchema[],
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/tickets`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    eventSlug: string,
+    partnershipId: string,
+    ticketDataSchema: TicketDataSchema[],
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/tickets`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: ticketDataSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Update partnership ticket
  */
 export const putEventsPartnershipTickets = (
-  eventSlug: string,
-  partnershipId: string,
-  ticketId: string,
-  ticketDataSchema: TicketDataSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/tickets/${ticketId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+    eventSlug: string,
+    partnershipId: string,
+    ticketId: string,
+    ticketDataSchema: TicketDataSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/tickets/${ticketId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
       data: ticketDataSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Get paginated list of job offer promotions for a specific partnership. Public endpoint accessible without authentication.
  * @summary List job offers for partnership
  */
 export const getPartnershipJobOffers = (
-  eventSlug: string,
-  partnershipId: string,
-  params?: GetPartnershipJobOffersParams,
-  options?: SecondParameter<typeof customFetch<PaginatedJobOfferPromotionSchema>>,
-) => {
-  return customFetch<PaginatedJobOfferPromotionSchema>(
-    { url: `/events/${eventSlug}/partnerships/${partnershipId}/job-offers`, method: "GET", params },
-    options,
-  );
-};
+    eventSlug: string,
+    partnershipId: string,
+    params?: GetPartnershipJobOffersParams,
+ options?: SecondParameter<typeof customFetch<PaginatedJobOfferPromotionSchema>>,) => {
+      return customFetch<PaginatedJobOfferPromotionSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/job-offers`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Associate a speaker with a partnership. Partnership must be validated first.
  * @summary Attach speaker to partnership
  */
 export const attachSpeakerToPartnership = (
-  eventSlug: string,
-  partnershipId: string,
-  speakerId: string,
-  options?: SecondParameter<typeof customFetch<SpeakerPartnershipSchema>>,
-) => {
-  return customFetch<SpeakerPartnershipSchema>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/speakers/${speakerId}`,
-      method: "POST",
+    eventSlug: string,
+    partnershipId: string,
+    speakerId: string,
+ options?: SecondParameter<typeof customFetch<SpeakerPartnershipSchema>>,) => {
+      return customFetch<SpeakerPartnershipSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/speakers/${speakerId}`, method: 'POST'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Remove association between a speaker and a partnership.
  * @summary Detach speaker from partnership
  */
 export const detachSpeakerFromPartnership = (
-  eventSlug: string,
-  partnershipId: string,
-  speakerId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/speakers/${speakerId}`,
-      method: "DELETE",
+    eventSlug: string,
+    partnershipId: string,
+    speakerId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/speakers/${speakerId}`, method: 'DELETE'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary List booth activities
  */
 export const listBoothActivities = (
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<BoothActivityListResponseSchema>>,
-) => {
-  return customFetch<BoothActivityListResponseSchema>(
-    { url: `/events/${eventSlug}/partnerships/${partnershipId}/activities`, method: "GET" },
-    options,
-  );
-};
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<BoothActivityListResponseSchema>>,) => {
+      return customFetch<BoothActivityListResponseSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/activities`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * @summary Create a booth activity
  */
 export const createBoothActivity = (
-  eventSlug: string,
-  partnershipId: string,
-  boothActivityRequestSchema: BoothActivityRequestSchema,
-  options?: SecondParameter<typeof customFetch<BoothActivityResponseSchema>>,
-) => {
-  return customFetch<BoothActivityResponseSchema>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/activities`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: boothActivityRequestSchema,
+    eventSlug: string,
+    partnershipId: string,
+    boothActivityRequestSchema: BoothActivityRequestSchema,
+ options?: SecondParameter<typeof customFetch<BoothActivityResponseSchema>>,) => {
+      return customFetch<BoothActivityResponseSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/activities`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: boothActivityRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Update a booth activity
  */
 export const updateBoothActivity = (
-  eventSlug: string,
-  partnershipId: string,
-  activityId: string,
-  boothActivityRequestSchema: BoothActivityRequestSchema,
-  options?: SecondParameter<typeof customFetch<BoothActivityResponseSchema>>,
-) => {
-  return customFetch<BoothActivityResponseSchema>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/activities/${activityId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: boothActivityRequestSchema,
+    eventSlug: string,
+    partnershipId: string,
+    activityId: string,
+    boothActivityRequestSchema: BoothActivityRequestSchema,
+ options?: SecondParameter<typeof customFetch<BoothActivityResponseSchema>>,) => {
+      return customFetch<BoothActivityResponseSchema>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/activities/${activityId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: boothActivityRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Delete a booth activity
  */
 export const deleteBoothActivity = (
-  eventSlug: string,
-  partnershipId: string,
-  activityId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    {
-      url: `/events/${eventSlug}/partnerships/${partnershipId}/activities/${activityId}`,
-      method: "DELETE",
+    eventSlug: string,
+    partnershipId: string,
+    activityId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/events/${eventSlug}/partnerships/${partnershipId}/activities/${activityId}`, method: 'DELETE'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * List all providers with optional filtering and sorting
  * @summary List providers
  */
 export const getProviders = (
-  params?: GetProvidersParams,
-  options?: SecondParameter<typeof customFetch<PaginatedProviderSchema>>,
-) => {
-  return customFetch<PaginatedProviderSchema>(
-    { url: `/providers`, method: "GET", params },
-    options,
-  );
-};
+    params?: GetProvidersParams,
+ options?: SecondParameter<typeof customFetch<PaginatedProviderSchema>>,) => {
+      return customFetch<PaginatedProviderSchema>(
+      {url: `/providers`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Create a new provider (requires authentication and organizer status)
  * @summary Create new provider
  */
 export const postProviders = (
-  createProviderSchema: CreateProviderSchema,
-  options?: SecondParameter<typeof customFetch<PostProviders201>>,
-) => {
-  return customFetch<PostProviders201>(
-    {
-      url: `/providers`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createProviderSchema,
+    createProviderSchema: CreateProviderSchema,
+ options?: SecondParameter<typeof customFetch<PostProviders201>>,) => {
+      return customFetch<PostProviders201>(
+      {url: `/providers`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createProviderSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Create new organization
  */
 export const postOrgs = (
-  organisationSchema: OrganisationSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    organisationSchema: OrganisationSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: organisationSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Get organization details
  */
-export const getOrgs = (orgSlug: string, options?: SecondParameter<typeof customFetch<Blob>>) => {
-  return customFetch<Blob>(
-    { url: `/orgs/${orgSlug}`, method: "GET", responseType: "blob" },
-    options,
-  );
-};
+export const getOrgs = (
+    orgSlug: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}`, method: 'GET',
+        responseType: 'blob'
+    },
+      options);
+    }
 
 /**
  * @summary Update organization
  */
 export const putOrgs = (
-  orgSlug: string,
-  organisationSchema: OrganisationSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+    orgSlug: string,
+    organisationSchema: OrganisationSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
       data: organisationSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Create a new provider within organization scope (requires organization membership)
  * @summary Create provider
  */
 export const postOrgsProviders = (
-  orgSlug: string,
-  createProviderSchema: CreateProviderSchema,
-  options?: SecondParameter<typeof customFetch<ProviderSchema>>,
-) => {
-  return customFetch<ProviderSchema>(
-    {
-      url: `/orgs/${orgSlug}/providers`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createProviderSchema,
+    orgSlug: string,
+    createProviderSchema: CreateProviderSchema,
+ options?: SecondParameter<typeof customFetch<ProviderSchema>>,) => {
+      return customFetch<ProviderSchema>(
+      {url: `/orgs/${orgSlug}/providers`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createProviderSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Update provider within organization scope (requires organization membership)
  * @summary Update provider
  */
 export const putOrgsProviders = (
-  orgSlug: string,
-  providerId: string,
-  updateProviderSchema: UpdateProviderSchema,
-  options?: SecondParameter<typeof customFetch<ProviderSchema>>,
-) => {
-  return customFetch<ProviderSchema>(
-    {
-      url: `/orgs/${orgSlug}/providers/${providerId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: updateProviderSchema,
+    orgSlug: string,
+    providerId: string,
+    updateProviderSchema: UpdateProviderSchema,
+ options?: SecondParameter<typeof customFetch<ProviderSchema>>,) => {
+      return customFetch<ProviderSchema>(
+      {url: `/orgs/${orgSlug}/providers/${providerId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateProviderSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Delete provider after detaching from all events (requires organization membership)
  * @summary Delete provider
  */
 export const deleteOrgsProviders = (
-  orgSlug: string,
-  providerId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/providers/${providerId}`, method: "DELETE" },
-    options,
-  );
-};
+    orgSlug: string,
+    providerId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/providers/${providerId}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * List events for an organization (paginated)
  * @summary Get organization details
  */
 export const getOrgsEvents = (
-  orgSlug: string,
-  params?: GetOrgsEventsParams,
-  options?: SecondParameter<typeof customFetch<PaginatedEventSummarySchema>>,
-) => {
-  return customFetch<PaginatedEventSummarySchema>(
-    { url: `/orgs/${orgSlug}/events`, method: "GET", params },
-    options,
-  );
-};
+    orgSlug: string,
+    params?: GetOrgsEventsParams,
+ options?: SecondParameter<typeof customFetch<PaginatedEventSummarySchema>>,) => {
+      return customFetch<PaginatedEventSummarySchema>(
+      {url: `/orgs/${orgSlug}/events`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Create a new event for an organization
  * @summary Create organization event
  */
 export const postOrgsEvents = (
-  orgSlug: string,
-  createEventSchema: CreateEventSchema,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createEventSchema,
+    orgSlug: string,
+    createEventSchema: CreateEventSchema,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createEventSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Update event
  */
 export const putOrgsEvents = (
-  orgSlug: string,
-  eventSlug: string,
-  createEventSchema: CreateEventSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+    orgSlug: string,
+    eventSlug: string,
+    createEventSchema: CreateEventSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
       data: createEventSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Upload booth plan image for an event
  * @summary Upload booth plan
  */
 export const postOrgsEventsBoothPlan = (
-  orgSlug: string,
-  eventSlug: string,
-  postOrgsEventsBoothPlanBody: PostOrgsEventsBoothPlanBody,
-  options?: SecondParameter<typeof customFetch<PostOrgsEventsBoothPlan201>>,
-) => {
-  const formData = new FormData();
-  if (postOrgsEventsBoothPlanBody.file !== undefined) {
-    formData.append(`file`, postOrgsEventsBoothPlanBody.file);
-  }
+    orgSlug: string,
+    eventSlug: string,
+    postOrgsEventsBoothPlanBody: PostOrgsEventsBoothPlanBody,
+ options?: SecondParameter<typeof customFetch<PostOrgsEventsBoothPlan201>>,) => {const formData = new FormData();
+if(postOrgsEventsBoothPlanBody.file !== undefined) {
+ formData.append(`file`, postOrgsEventsBoothPlanBody.file);
+ }
 
-  return customFetch<PostOrgsEventsBoothPlan201>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/booth-plan`, method: "POST", data: formData },
-    options,
-  );
-};
+      return customFetch<PostOrgsEventsBoothPlan201>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/booth-plan`, method: 'POST',
+       data: formData
+    },
+      options);
+    }
 
 /**
  * Retrieve all integrations configured for an event
  * @summary List event integrations
  */
 export const getOrgsEventsIntegrations = (
-  orgSlug: string,
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<IntegrationSchema[]>>,
-) => {
-  return customFetch<IntegrationSchema[]>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/integrations`, method: "GET" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<IntegrationSchema[]>>,) => {
+      return customFetch<IntegrationSchema[]>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/integrations`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Register an integration for an event
  * @summary Create event integration
  */
 export const postOrgsEventsIntegrations = (
-  orgSlug: string,
-  eventSlug: string,
-  provider: "mailjet" | "slack" | "qonto" | "billetweb" | "webhook" | "openplanner",
-  usage: "notification" | "billing" | "ticketing" | "webhook" | "agenda",
-  postOrgsEventsIntegrationsBody: PostOrgsEventsIntegrationsBody,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/integrations/${provider}/${usage}`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: postOrgsEventsIntegrationsBody,
+    orgSlug: string,
+    eventSlug: string,
+    provider: 'mailjet' | 'slack' | 'qonto' | 'billetweb' | 'webhook' | 'openplanner',
+    usage: 'notification' | 'billing' | 'ticketing' | 'webhook' | 'agenda',
+    postOrgsEventsIntegrationsBody: PostOrgsEventsIntegrationsBody,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/integrations/${provider}/${usage}`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: postOrgsEventsIntegrationsBody
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Remove an integration from an event
  * @summary Delete event integration
  */
 export const deleteOrgsEventsIntegrations = (
-  orgSlug: string,
-  eventSlug: string,
-  integrationId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/integrations/${integrationId}`, method: "DELETE" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    integrationId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/integrations/${integrationId}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * Get status of event integration
  * @summary get status of event integration
  */
 export const getStatusIntegration = (
-  orgSlug: string,
-  eventSlug: string,
-  integrationId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/integrations/${integrationId}/status`,
-      method: "GET",
+    orgSlug: string,
+    eventSlug: string,
+    integrationId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/integrations/${integrationId}/status`, method: 'GET'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * List sponsoring options for an event
  * @summary Get organization details
  */
 export const getOrgsEventsOptions = (
-  orgSlug: string,
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<SponsoringOptionWithCountSchema[]>>,
-) => {
-  return customFetch<SponsoringOptionWithCountSchema[]>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/options`, method: "GET" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<SponsoringOptionWithCountSchema[]>>,) => {
+      return customFetch<SponsoringOptionWithCountSchema[]>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/options`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Create a new sponsoring option
  * @summary Create sponsoring option
  */
 export const postOrgsEventsOptions = (
-  orgSlug: string,
-  eventSlug: string,
-  createSponsoringOptionSchema: CreateSponsoringOptionSchema,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/options`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createSponsoringOptionSchema,
+    orgSlug: string,
+    eventSlug: string,
+    createSponsoringOptionSchema: CreateSponsoringOptionSchema,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/options`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createSponsoringOptionSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Get a single sponsoring option with all translations and the list of validated partnerships
  * @summary Get sponsoring option detail with partnerships
  */
 export const getOrgsEventsOptionsById = (
-  orgSlug: string,
-  eventSlug: string,
-  optionId: string,
-  options?: SecondParameter<typeof customFetch<SponsoringOptionWithPartnershipsSchema>>,
-) => {
-  return customFetch<SponsoringOptionWithPartnershipsSchema>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/options/${optionId}`, method: "GET" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    optionId: string,
+ options?: SecondParameter<typeof customFetch<SponsoringOptionWithPartnershipsSchema>>,) => {
+      return customFetch<SponsoringOptionWithPartnershipsSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/options/${optionId}`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * @summary Delete sponsoring option
  */
 export const deleteOrgsEventsOptions = (
-  orgSlug: string,
-  eventSlug: string,
-  optionId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/options/${optionId}`,
-      method: "DELETE",
-      responseType: "blob",
+    orgSlug: string,
+    eventSlug: string,
+    optionId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/options/${optionId}`, method: 'DELETE',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Update sponsoring option
  */
 export const putOrgsEventsOptions = (
-  orgSlug: string,
-  eventSlug: string,
-  optionId: string,
-  createSponsoringOptionSchema: CreateSponsoringOptionSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/options/${optionId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+    orgSlug: string,
+    eventSlug: string,
+    optionId: string,
+    createSponsoringOptionSchema: CreateSponsoringOptionSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/options/${optionId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
       data: createSponsoringOptionSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * List sponsoring packs for an event
  * @summary Get organization details
  */
 export const getOrgsEventsPacks = (
-  orgSlug: string,
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<SponsoringPackSchema[]>>,
-) => {
-  return customFetch<SponsoringPackSchema[]>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/packs`, method: "GET" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<SponsoringPackSchema[]>>,) => {
+      return customFetch<SponsoringPackSchema[]>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/packs`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Create a new sponsoring pack
  * @summary Create sponsoring pack
  */
 export const postOrgsEventsPacks = (
-  orgSlug: string,
-  eventSlug: string,
-  createSponsoringPackSchema: CreateSponsoringPackSchema,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/packs`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createSponsoringPackSchema,
+    orgSlug: string,
+    eventSlug: string,
+    createSponsoringPackSchema: CreateSponsoringPackSchema,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/packs`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createSponsoringPackSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Delete sponsoring pack
  */
 export const deleteOrgsEventsPacks = (
-  orgSlug: string,
-  eventSlug: string,
-  packId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}`,
-      method: "DELETE",
-      responseType: "blob",
+    orgSlug: string,
+    eventSlug: string,
+    packId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}`, method: 'DELETE',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Update sponsoring pack
  */
 export const putOrgsEventsPacks = (
-  orgSlug: string,
-  eventSlug: string,
-  packId: string,
-  createSponsoringPackSchema: CreateSponsoringPackSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+    orgSlug: string,
+    eventSlug: string,
+    packId: string,
+    createSponsoringPackSchema: CreateSponsoringPackSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
       data: createSponsoringPackSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Synchronizes the complete set of options for a sponsoring pack.
@@ -3659,184 +3519,160 @@ Both required and optional lists can be empty to remove all options from the pac
  * @summary Synchronize sponsoring pack options
  */
 export const postOrgsEventsPacksOptions = (
-  orgSlug: string,
-  eventSlug: string,
-  packId: string,
-  attachOptionsToPackSchema: AttachOptionsToPackSchema,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}/options`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: attachOptionsToPackSchema,
+    orgSlug: string,
+    eventSlug: string,
+    packId: string,
+    attachOptionsToPackSchema: AttachOptionsToPackSchema,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}/options`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: attachOptionsToPackSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Delete sponsoring option
  */
 export const deleteOrgsEventsPacksOptions = (
-  orgSlug: string,
-  eventSlug: string,
-  packId: string,
-  optionId: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}/options/${optionId}`,
-      method: "DELETE",
-      responseType: "blob",
+    orgSlug: string,
+    eventSlug: string,
+    packId: string,
+    optionId: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/packs/${packId}/options/${optionId}`, method: 'DELETE',
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Get communication plan for all partnerships of an event, grouped by status
  * @summary Get organization details
  */
 export const getOrgsEventsCommunication = (
-  orgSlug: string,
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<CommunicationPlanSchema>>,
-) => {
-  return customFetch<CommunicationPlanSchema>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/communication`, method: "GET" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<CommunicationPlanSchema>>,) => {
+      return customFetch<CommunicationPlanSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/communication`, method: 'GET'
+    },
+      options);
+    }
 
 /**
  * Create a standalone communication plan entry for an event
  * @summary Schedule a standalone communication
  */
 export const postOrgsEventsCommunicationPlan = (
-  orgSlug: string,
-  eventSlug: string,
-  communicationPlanRequestSchema: CommunicationPlanRequestSchema,
-  options?: SecondParameter<typeof customFetch<CommunicationPlanEntrySchema>>,
-) => {
-  return customFetch<CommunicationPlanEntrySchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/communication-plan`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: communicationPlanRequestSchema,
+    orgSlug: string,
+    eventSlug: string,
+    communicationPlanRequestSchema: CommunicationPlanRequestSchema,
+ options?: SecondParameter<typeof customFetch<CommunicationPlanEntrySchema>>,) => {
+      return customFetch<CommunicationPlanEntrySchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/communication-plan`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: communicationPlanRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Update an existing communication plan entry (standalone or partnership-linked)
  * @summary Update a communication plan entry
  */
 export const putOrgsEventsCommunicationPlanById = (
-  orgSlug: string,
-  eventSlug: string,
-  id: string,
-  communicationPlanRequestSchema: CommunicationPlanRequestSchema,
-  options?: SecondParameter<typeof customFetch<CommunicationPlanEntrySchema>>,
-) => {
-  return customFetch<CommunicationPlanEntrySchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/communication-plan/${id}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: communicationPlanRequestSchema,
+    orgSlug: string,
+    eventSlug: string,
+    id: string,
+    communicationPlanRequestSchema: CommunicationPlanRequestSchema,
+ options?: SecondParameter<typeof customFetch<CommunicationPlanEntrySchema>>,) => {
+      return customFetch<CommunicationPlanEntrySchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/communication-plan/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: communicationPlanRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Delete a communication plan entry (standalone or partnership-linked)
  * @summary Delete a communication plan entry
  */
 export const deleteOrgsEventsCommunicationPlanById = (
-  orgSlug: string,
-  eventSlug: string,
-  id: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/communication-plan/${id}`, method: "DELETE" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    id: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/communication-plan/${id}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * Attach a new external link to an event
  * @summary Add external link
  */
 export const postOrgsEventsExternalLink = (
-  orgSlug: string,
-  eventSlug: string,
-  createEventExternalLinkSchema: CreateEventExternalLinkSchema,
-  options?: SecondParameter<typeof customFetch<ErrorResponseSchema>>,
-) => {
-  return customFetch<ErrorResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/external-link`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createEventExternalLinkSchema,
+    orgSlug: string,
+    eventSlug: string,
+    createEventExternalLinkSchema: CreateEventExternalLinkSchema,
+ options?: SecondParameter<typeof customFetch<ErrorResponseSchema>>,) => {
+      return customFetch<ErrorResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/external-link`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createEventExternalLinkSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Remove an external link by its ID
  * @summary Delete external link
  */
 export const deleteOrgsEventsExternalLink = (
-  orgSlug: string,
-  eventSlug: string,
-  linkId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/external-link/${linkId}`, method: "DELETE" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    linkId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/external-link/${linkId}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * Trigger fetch and storage of event agenda data from agenda integration. Requires organization write permissions.
  * @summary Fetch and update agenda from agenda integration
  */
 export const updateEventAgenda = (
-  orgSlug: string,
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/agenda`, method: "POST" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/agenda`, method: 'POST'
+    },
+      options);
+    }
 
 /**
  * List partnerships for an event with filtering options
  * @summary Get partnership list
  */
 export const getOrgsEventsPartnership = (
-  orgSlug: string,
-  eventSlug: string,
-  params?: GetOrgsEventsPartnershipParams,
-  options?: SecondParameter<typeof customFetch<PartnershipListResponseSchema>>,
-) => {
-  return customFetch<PartnershipListResponseSchema>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships`, method: "GET", params },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    params?: GetOrgsEventsPartnershipParams,
+ options?: SecondParameter<typeof customFetch<PartnershipListResponseSchema>>,) => {
+      return customFetch<PartnershipListResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Deletes a partnership that has not been finalized (validated or declined).
@@ -3847,304 +3683,251 @@ Performs a hard delete with no audit trail.
  * @summary Delete an unvalidated partnership
  */
 export const deletePartnership = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}`, method: "DELETE" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}`, method: 'DELETE'
+    },
+      options);
+    }
 
 /**
  * Generate a partnership agreement PDF
  * @summary Generate partnership agreement
  */
 export const postOrgsEventsPartnershipAgreement = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<PostOrgsEventsPartnershipAgreement200>>,
-) => {
-  return customFetch<PostOrgsEventsPartnershipAgreement200>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/agreement`,
-      method: "POST",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<PostOrgsEventsPartnershipAgreement200>>,) => {
+      return customFetch<PostOrgsEventsPartnershipAgreement200>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/agreement`, method: 'POST'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Update the billing status of a partnership.
  * @summary Update partnership billing status
  */
 export const postOrgsEventsPartnershipBilling = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  billingStatus: "pending" | "sent" | "paid",
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/billing/${billingStatus}`,
-      method: "POST",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    billingStatus: 'pending' | 'sent' | 'paid',
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/billing/${billingStatus}`, method: 'POST'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Assign booth location to a partnership
  * @summary Update organization
  */
 export const putOrgsEventsPartnershipBoothLocation = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  boothLocationRequestSchema: BoothLocationRequestSchema,
-  options?: SecondParameter<typeof customFetch<BoothLocationResponseSchema>>,
-) => {
-  return customFetch<BoothLocationResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/booth-location`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: boothLocationRequestSchema,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    boothLocationRequestSchema: BoothLocationRequestSchema,
+ options?: SecondParameter<typeof customFetch<BoothLocationResponseSchema>>,) => {
+      return customFetch<BoothLocationResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/booth-location`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: boothLocationRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Create partnership suggestion
  */
 export const postOrgsEventsPartnershipSuggestion = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  suggestPartnershipSchema: SuggestPartnershipSchema,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/suggestion`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: suggestPartnershipSchema,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    suggestPartnershipSchema: SuggestPartnershipSchema,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/suggestion`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: suggestPartnershipSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Validate a partnership request
  * @summary Validate partnership
  */
 export const postOrgsEventsPartnershipValidate = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/validate`,
-      method: "POST",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/validate`, method: 'POST'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Decline a partnership request
  * @summary Decline partnership
  */
 export const postOrgsEventsPartnershipDecline = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<IdentifierSchema>>,
-) => {
-  return customFetch<IdentifierSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/decline`,
-      method: "POST",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<IdentifierSchema>>,) => {
+      return customFetch<IdentifierSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/decline`, method: 'POST'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Schedule publication date for partnership communication
  * @summary Update organization
  */
 export const putOrgsEventsPartnershipCommunicationPublication = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  publicationDateRequestSchema: PublicationDateRequestSchema,
-  options?: SecondParameter<typeof customFetch<PublicationDateResponseSchema>>,
-) => {
-  return customFetch<PublicationDateResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/communication/publication`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: publicationDateRequestSchema,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    publicationDateRequestSchema: PublicationDateRequestSchema,
+ options?: SecondParameter<typeof customFetch<PublicationDateResponseSchema>>,) => {
+      return customFetch<PublicationDateResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/communication/publication`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: publicationDateRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Upload visual support material for partnership communication
  * @summary Update organization
  */
 export const putOrgsEventsPartnershipCommunicationSupport = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  putOrgsEventsPartnershipCommunicationSupportBody: Blob,
-  options?: SecondParameter<typeof customFetch<SupportUploadResponseSchema>>,
-) => {
-  return customFetch<SupportUploadResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/communication/support`,
-      method: "PUT",
-      headers: { "Content-Type": "image/png" },
-      data: putOrgsEventsPartnershipCommunicationSupportBody,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    putOrgsEventsPartnershipCommunicationSupportBody: Blob,
+ options?: SecondParameter<typeof customFetch<SupportUploadResponseSchema>>,) => {
+      return customFetch<SupportUploadResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/communication/support`, method: 'PUT',
+      headers: {'Content-Type': 'image/png', },
+      data: putOrgsEventsPartnershipCommunicationSupportBody
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Get paginated list of job offer promotions for a specific partnership. Public endpoint accessible without authentication.
  * @summary List job offers for partnership
  */
 export const listPartnershipJobOffers = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  params?: ListPartnershipJobOffersParams,
-  options?: SecondParameter<typeof customFetch<ListPartnershipJobOffers200>>,
-) => {
-  return customFetch<ListPartnershipJobOffers200>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/job-offers`,
-      method: "GET",
-      params,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    params?: ListPartnershipJobOffersParams,
+ options?: SecondParameter<typeof customFetch<ListPartnershipJobOffers200>>,) => {
+      return customFetch<ListPartnershipJobOffers200>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/job-offers`, method: 'GET',
+        params
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Get paginated list of all job offer promotions for an event. Requires organization edit permissions.
  * @summary List all job offers for event
  */
 export const listEventJobOfferPromotions = (
-  orgSlug: string,
-  eventSlug: string,
-  params?: ListEventJobOfferPromotionsParams,
-  options?: SecondParameter<typeof customFetch<ListEventJobOfferPromotions200>>,
-) => {
-  return customFetch<ListEventJobOfferPromotions200>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/job-offers`, method: "GET", params },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    params?: ListEventJobOfferPromotionsParams,
+ options?: SecondParameter<typeof customFetch<ListEventJobOfferPromotions200>>,) => {
+      return customFetch<ListEventJobOfferPromotions200>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/job-offers`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Approve a pending job offer promotion. Requires organization edit permissions. Sends notification to company.
  * @summary Approve job offer promotion
  */
 export const approveJobOfferPromotion = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  promotionId: string,
-  approveJobOfferPromotionBody: ApproveJobOfferPromotionBody,
-  options?: SecondParameter<typeof customFetch<JobOfferPromotionResponseSchema>>,
-) => {
-  return customFetch<JobOfferPromotionResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/job-offers/${promotionId}/approve`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: approveJobOfferPromotionBody,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    promotionId: string,
+    approveJobOfferPromotionBody: ApproveJobOfferPromotionBody,
+ options?: SecondParameter<typeof customFetch<JobOfferPromotionResponseSchema>>,) => {
+      return customFetch<JobOfferPromotionResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/job-offers/${promotionId}/approve`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: approveJobOfferPromotionBody
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Decline a pending job offer promotion with optional reason. Requires organization edit permissions. Sends notification to company.
  * @summary Decline job offer promotion
  */
 export const declineJobOfferPromotion = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  promotionId: string,
-  declineJobOfferPromotionSchema: DeclineJobOfferPromotionSchema,
-  options?: SecondParameter<typeof customFetch<JobOfferPromotionResponseSchema>>,
-) => {
-  return customFetch<JobOfferPromotionResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/job-offers/${promotionId}/decline`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: declineJobOfferPromotionSchema,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    promotionId: string,
+    declineJobOfferPromotionSchema: DeclineJobOfferPromotionSchema,
+ options?: SecondParameter<typeof customFetch<JobOfferPromotionResponseSchema>>,) => {
+      return customFetch<JobOfferPromotionResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/job-offers/${promotionId}/decline`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: declineJobOfferPromotionSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Assign an organiser to manage a specific partnership. The organiser must be a member of the organization with edit permissions.
  * @summary Assign organiser to partnership
  */
 export const postPartnershipOrganiser = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  assignOrganiserRequestSchema: AssignOrganiserRequestSchema,
-  options?: SecondParameter<typeof customFetch<PartnershipOrganiserResponseSchema>>,
-) => {
-  return customFetch<PartnershipOrganiserResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/organiser`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: assignOrganiserRequestSchema,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    assignOrganiserRequestSchema: AssignOrganiserRequestSchema,
+ options?: SecondParameter<typeof customFetch<PartnershipOrganiserResponseSchema>>,) => {
+      return customFetch<PartnershipOrganiserResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/organiser`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: assignOrganiserRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Remove the assigned organiser from a partnership
  * @summary Remove organiser from partnership
  */
 export const deletePartnershipOrganiser = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<PartnershipOrganiserResponseSchema>>,
-) => {
-  return customFetch<PartnershipOrganiserResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/organiser`,
-      method: "DELETE",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<PartnershipOrganiserResponseSchema>>,) => {
+      return customFetch<PartnershipOrganiserResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/organiser`, method: 'DELETE'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Update price overrides for the sponsoring pack and/or individual options on a partnership.
@@ -4155,22 +3938,18 @@ Requires organiser permission for the organization.
  * @summary Update partnership price overrides
  */
 export const putPartnershipPricing = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  updatePartnershipPricingRequestSchema: UpdatePartnershipPricingRequestSchema,
-  options?: SecondParameter<typeof customFetch<PartnershipDetailSchema>>,
-) => {
-  return customFetch<PartnershipDetailSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/pricing`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: updatePartnershipPricingRequestSchema,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    updatePartnershipPricingRequestSchema: UpdatePartnershipPricingRequestSchema,
+ options?: SecondParameter<typeof customFetch<PartnershipDetailSchema>>,) => {
+      return customFetch<PartnershipDetailSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/pricing`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updatePartnershipPricingRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Retrieve paginated email history for a specific partnership. Returns all emails
@@ -4181,40 +3960,32 @@ Requires organiser permission for the organization.
  * @summary Get email history for partnership
  */
 export const getPartnershipEmailHistory = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  params?: GetPartnershipEmailHistoryParams,
-  options?: SecondParameter<typeof customFetch<GetPartnershipEmailHistory200>>,
-) => {
-  return customFetch<GetPartnershipEmailHistory200>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/email-history`,
-      method: "GET",
-      params,
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+    params?: GetPartnershipEmailHistoryParams,
+ options?: SecondParameter<typeof customFetch<GetPartnershipEmailHistory200>>,) => {
+      return customFetch<GetPartnershipEmailHistory200>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/email-history`, method: 'GET',
+        params
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Manually trigger webhook for a specific partnership. Requires webhook integration to be configured.
  * @summary Trigger webhook for partnership
  */
 export const postPartnershipTriggerWebhook = (
-  orgSlug: string,
-  eventSlug: string,
-  partnershipId: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/trigger/webhook`,
-      method: "POST",
+    orgSlug: string,
+    eventSlug: string,
+    partnershipId: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/${partnershipId}/trigger/webhook`, method: 'POST'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Send an email to partnerships matching filter criteria. Each partnership receives
@@ -4225,134 +3996,114 @@ integration to be configured for the event's organization.
  * @summary Send email to filtered partnerships
  */
 export const postPartnershipEmail = (
-  orgSlug: string,
-  eventSlug: string,
-  sendPartnershipEmailRequestSchema: SendPartnershipEmailRequestSchema,
-  params?: PostPartnershipEmailParams,
-  options?: SecondParameter<typeof customFetch<SendPartnershipEmailResponseSchema>>,
-) => {
-  return customFetch<SendPartnershipEmailResponseSchema>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/email`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    orgSlug: string,
+    eventSlug: string,
+    sendPartnershipEmailRequestSchema: SendPartnershipEmailRequestSchema,
+    params?: PostPartnershipEmailParams,
+ options?: SecondParameter<typeof customFetch<SendPartnershipEmailResponseSchema>>,) => {
+      return customFetch<SendPartnershipEmailResponseSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/partnerships/email`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: sendPartnershipEmailRequestSchema,
-      params,
+        params
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * List providers attached to an event with pagination (requires organization membership)
  * @summary List event providers
  */
 export const getOrgsEventsProviders = (
-  orgSlug: string,
-  eventSlug: string,
-  params?: GetOrgsEventsProvidersParams,
-  options?: SecondParameter<typeof customFetch<PaginatedProviderSchema>>,
-) => {
-  return customFetch<PaginatedProviderSchema>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/providers`, method: "GET", params },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+    params?: GetOrgsEventsProvidersParams,
+ options?: SecondParameter<typeof customFetch<PaginatedProviderSchema>>,) => {
+      return customFetch<PaginatedProviderSchema>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/providers`, method: 'GET',
+        params
+    },
+      options);
+    }
 
 /**
  * Attach providers to an event (requires event write access)
  * @summary Create new provider
  */
 export const postOrgsEventsProviders = (
-  orgSlug: string,
-  eventSlug: string,
-  createByIdentifiersSchema: CreateByIdentifiersSchema,
-  options?: SecondParameter<typeof customFetch<string[]>>,
-) => {
-  return customFetch<string[]>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/providers`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: createByIdentifiersSchema,
+    orgSlug: string,
+    eventSlug: string,
+    createByIdentifiersSchema: CreateByIdentifiersSchema,
+ options?: SecondParameter<typeof customFetch<string[]>>,) => {
+      return customFetch<string[]>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/providers`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createByIdentifiersSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Remove providers from an event (requires event write access)
  * @summary Remove providers from event
  */
 export const deleteOrgsEventsProviders = (
-  orgSlug: string,
-  eventSlug: string,
-  createByIdentifiersSchema: CreateByIdentifiersSchema,
-  options?: SecondParameter<typeof customFetch<string[]>>,
-) => {
-  return customFetch<string[]>(
-    {
-      url: `/orgs/${orgSlug}/events/${eventSlug}/providers`,
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      data: createByIdentifiersSchema,
+    orgSlug: string,
+    eventSlug: string,
+    createByIdentifiersSchema: CreateByIdentifiersSchema,
+ options?: SecondParameter<typeof customFetch<string[]>>,) => {
+      return customFetch<string[]>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/providers`, method: 'DELETE',
+      headers: {'Content-Type': 'application/json', },
+      data: createByIdentifiersSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * @summary Get organization details
  */
 export const getOrgsUsers = (
-  orgSlug: string,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    { url: `/orgs/${orgSlug}/users`, method: "GET", responseType: "blob" },
-    options,
-  );
-};
+    orgSlug: string,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/users`, method: 'GET',
+        responseType: 'blob'
+    },
+      options);
+    }
 
 /**
  * @summary Create resource
  */
 export const postOrgsUsersGrant = (
-  orgSlug: string,
-  grantPermissionRequestSchema: GrantPermissionRequestSchema,
-  options?: SecondParameter<typeof customFetch<Blob>>,
-) => {
-  return customFetch<Blob>(
-    {
-      url: `/orgs/${orgSlug}/users/grant`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    orgSlug: string,
+    grantPermissionRequestSchema: GrantPermissionRequestSchema,
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/orgs/${orgSlug}/users/grant`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
       data: grantPermissionRequestSchema,
-      responseType: "blob",
+        responseType: 'blob'
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Revoke edit permissions for multiple users on an organisation
  * @summary Revoke user permissions
  */
 export const postOrgsUsersRevoke = (
-  orgSlug: string,
-  revokePermissionRequestSchema: RevokePermissionRequestSchema,
-  options?: SecondParameter<typeof customFetch<RevokeUsersResultSchema>>,
-) => {
-  return customFetch<RevokeUsersResultSchema>(
-    {
-      url: `/orgs/${orgSlug}/users/revoke`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: revokePermissionRequestSchema,
+    orgSlug: string,
+    revokePermissionRequestSchema: RevokePermissionRequestSchema,
+ options?: SecondParameter<typeof customFetch<RevokeUsersResultSchema>>,) => {
+      return customFetch<RevokeUsersResultSchema>(
+      {url: `/orgs/${orgSlug}/users/revoke`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: revokePermissionRequestSchema
     },
-    options,
-  );
-};
+      options);
+    }
 
 /**
  * Fire-and-forget job endpoint that queries actionable items for the given event (agreement reminders, quote reminders, social media reminders) and sends a Slack digest notification. Always returns 204 even if no items or if Slack is unavailable. No authentication required.
@@ -4360,286 +4111,144 @@ export const postOrgsUsersRevoke = (
  * @summary Trigger the morning organiser daily digest for a single event
  */
 export const postDigestJob = (
-  orgSlug: string,
-  eventSlug: string,
-  options?: SecondParameter<typeof customFetch<void>>,
-) => {
-  return customFetch<void>(
-    { url: `/orgs/${orgSlug}/events/${eventSlug}/jobs/digest`, method: "POST" },
-    options,
-  );
-};
+    orgSlug: string,
+    eventSlug: string,
+ options?: SecondParameter<typeof customFetch<void>>,) => {
+      return customFetch<void>(
+      {url: `/orgs/${orgSlug}/events/${eventSlug}/jobs/digest`, method: 'POST'
+    },
+      options);
+    }
 
 /**
  * @summary List organization events
  */
-export const getUsersMeEvents = (options?: SecondParameter<typeof customFetch<Blob>>) => {
-  return customFetch<Blob>(
-    { url: `/users/me/events`, method: "GET", responseType: "blob" },
-    options,
-  );
-};
+export const getUsersMeEvents = (
+
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/users/me/events`, method: 'GET',
+        responseType: 'blob'
+    },
+      options);
+    }
 
 /**
  * @summary Get resource
  */
-export const getUsersMeOrgs = (options?: SecondParameter<typeof customFetch<Blob>>) => {
-  return customFetch<Blob>({ url: `/users/me/orgs`, method: "GET", responseType: "blob" }, options);
-};
+export const getUsersMeOrgs = (
 
-export type GetAuthCallbackResult = NonNullable<Awaited<ReturnType<typeof getAuthCallback>>>;
-export type GetAuthLoginResult = NonNullable<Awaited<ReturnType<typeof getAuthLogin>>>;
-export type GetAuthLogoutResult = NonNullable<Awaited<ReturnType<typeof getAuthLogout>>>;
-export type GetAuthMeResult = NonNullable<Awaited<ReturnType<typeof getAuthMe>>>;
-export type GetCompaniesResult = NonNullable<Awaited<ReturnType<typeof getCompanies>>>;
-export type PostCompaniesResult = NonNullable<Awaited<ReturnType<typeof postCompanies>>>;
-export type GetCompanyByIdResult = NonNullable<Awaited<ReturnType<typeof getCompanyById>>>;
-export type PutCompanyByIdResult = NonNullable<Awaited<ReturnType<typeof putCompanyById>>>;
-export type DeleteCompanyByIdResult = NonNullable<Awaited<ReturnType<typeof deleteCompanyById>>>;
-export type PostCompaniesLogoResult = NonNullable<Awaited<ReturnType<typeof postCompaniesLogo>>>;
-export type GetCompaniesPartnershipResult = NonNullable<
-  Awaited<ReturnType<typeof getCompaniesPartnership>>
->;
-export type GetCompaniesJobOffersResult = NonNullable<
-  Awaited<ReturnType<typeof getCompaniesJobOffers>>
->;
-export type PostCompaniesJobOffersResult = NonNullable<
-  Awaited<ReturnType<typeof postCompaniesJobOffers>>
->;
-export type GetCompaniesJobOffersByIdResult = NonNullable<
-  Awaited<ReturnType<typeof getCompaniesJobOffersById>>
->;
-export type PutCompaniesJobOffersByIdResult = NonNullable<
-  Awaited<ReturnType<typeof putCompaniesJobOffersById>>
->;
-export type DeleteCompaniesJobOffersByIdResult = NonNullable<
-  Awaited<ReturnType<typeof deleteCompaniesJobOffersById>>
->;
-export type PromoteJobOfferToPartnershipResult = NonNullable<
-  Awaited<ReturnType<typeof promoteJobOfferToPartnership>>
->;
-export type ListJobOfferPromotionsResult = NonNullable<
-  Awaited<ReturnType<typeof listJobOfferPromotions>>
->;
-export type GetEventsResult = NonNullable<Awaited<ReturnType<typeof getEvents>>>;
-export type GetEventBySlugResult = NonNullable<Awaited<ReturnType<typeof getEventBySlug>>>;
-export type GetEventAgendaPublicResult = NonNullable<
-  Awaited<ReturnType<typeof getEventAgendaPublic>>
->;
-export type GetEventsSponsoringPacksResult = NonNullable<
-  Awaited<ReturnType<typeof getEventsSponsoringPacks>>
->;
-export type PostEventsPartnershipResult = NonNullable<
-  Awaited<ReturnType<typeof postEventsPartnership>>
->;
-export type GetEventsPartnershipDetailedResult = NonNullable<
-  Awaited<ReturnType<typeof getEventsPartnershipDetailed>>
->;
-export type UpdatePartnershipContactInfoResult = NonNullable<
-  Awaited<ReturnType<typeof updatePartnershipContactInfo>>
->;
-export type GetEventsPartnershipBillingResult = NonNullable<
-  Awaited<ReturnType<typeof getEventsPartnershipBilling>>
->;
-export type PostEventsPartnershipBillingResult = NonNullable<
-  Awaited<ReturnType<typeof postEventsPartnershipBilling>>
->;
-export type PutEventsPartnershipBillingResult = NonNullable<
-  Awaited<ReturnType<typeof putEventsPartnershipBilling>>
->;
-export type PostOrgsEventsPartnershipBillingInvoiceResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipBillingInvoice>>
->;
-export type PostOrgsEventsPartnershipBillingQuoteResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipBillingQuote>>
->;
-export type PostEventsPartnershipSignedAgreementResult = NonNullable<
-  Awaited<ReturnType<typeof postEventsPartnershipSignedAgreement>>
->;
-export type PostEventsPartnershipSuggestionApproveResult = NonNullable<
-  Awaited<ReturnType<typeof postEventsPartnershipSuggestionApprove>>
->;
-export type PostEventsPartnershipSuggestionDeclineResult = NonNullable<
-  Awaited<ReturnType<typeof postEventsPartnershipSuggestionDecline>>
->;
-export type GetEventsPartnershipTicketsResult = NonNullable<
-  Awaited<ReturnType<typeof getEventsPartnershipTickets>>
->;
-export type PostEventsPartnershipTicketsResult = NonNullable<
-  Awaited<ReturnType<typeof postEventsPartnershipTickets>>
->;
-export type PutEventsPartnershipTicketsResult = NonNullable<
-  Awaited<ReturnType<typeof putEventsPartnershipTickets>>
->;
-export type GetPartnershipJobOffersResult = NonNullable<
-  Awaited<ReturnType<typeof getPartnershipJobOffers>>
->;
-export type AttachSpeakerToPartnershipResult = NonNullable<
-  Awaited<ReturnType<typeof attachSpeakerToPartnership>>
->;
-export type DetachSpeakerFromPartnershipResult = NonNullable<
-  Awaited<ReturnType<typeof detachSpeakerFromPartnership>>
->;
-export type ListBoothActivitiesResult = NonNullable<
-  Awaited<ReturnType<typeof listBoothActivities>>
->;
-export type CreateBoothActivityResult = NonNullable<
-  Awaited<ReturnType<typeof createBoothActivity>>
->;
-export type UpdateBoothActivityResult = NonNullable<
-  Awaited<ReturnType<typeof updateBoothActivity>>
->;
-export type DeleteBoothActivityResult = NonNullable<
-  Awaited<ReturnType<typeof deleteBoothActivity>>
->;
-export type GetProvidersResult = NonNullable<Awaited<ReturnType<typeof getProviders>>>;
-export type PostProvidersResult = NonNullable<Awaited<ReturnType<typeof postProviders>>>;
-export type PostOrgsResult = NonNullable<Awaited<ReturnType<typeof postOrgs>>>;
-export type GetOrgsResult = NonNullable<Awaited<ReturnType<typeof getOrgs>>>;
-export type PutOrgsResult = NonNullable<Awaited<ReturnType<typeof putOrgs>>>;
-export type PostOrgsProvidersResult = NonNullable<Awaited<ReturnType<typeof postOrgsProviders>>>;
-export type PutOrgsProvidersResult = NonNullable<Awaited<ReturnType<typeof putOrgsProviders>>>;
-export type DeleteOrgsProvidersResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsProviders>>
->;
-export type GetOrgsEventsResult = NonNullable<Awaited<ReturnType<typeof getOrgsEvents>>>;
-export type PostOrgsEventsResult = NonNullable<Awaited<ReturnType<typeof postOrgsEvents>>>;
-export type PutOrgsEventsResult = NonNullable<Awaited<ReturnType<typeof putOrgsEvents>>>;
-export type PostOrgsEventsBoothPlanResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsBoothPlan>>
->;
-export type GetOrgsEventsIntegrationsResult = NonNullable<
-  Awaited<ReturnType<typeof getOrgsEventsIntegrations>>
->;
-export type PostOrgsEventsIntegrationsResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsIntegrations>>
->;
-export type DeleteOrgsEventsIntegrationsResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsIntegrations>>
->;
-export type GetStatusIntegrationResult = NonNullable<
-  Awaited<ReturnType<typeof getStatusIntegration>>
->;
-export type GetOrgsEventsOptionsResult = NonNullable<
-  Awaited<ReturnType<typeof getOrgsEventsOptions>>
->;
-export type PostOrgsEventsOptionsResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsOptions>>
->;
-export type GetOrgsEventsOptionsByIdResult = NonNullable<
-  Awaited<ReturnType<typeof getOrgsEventsOptionsById>>
->;
-export type DeleteOrgsEventsOptionsResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsOptions>>
->;
-export type PutOrgsEventsOptionsResult = NonNullable<
-  Awaited<ReturnType<typeof putOrgsEventsOptions>>
->;
-export type GetOrgsEventsPacksResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsPacks>>>;
-export type PostOrgsEventsPacksResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPacks>>
->;
-export type DeleteOrgsEventsPacksResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsPacks>>
->;
-export type PutOrgsEventsPacksResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsPacks>>>;
-export type PostOrgsEventsPacksOptionsResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPacksOptions>>
->;
-export type DeleteOrgsEventsPacksOptionsResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsPacksOptions>>
->;
-export type GetOrgsEventsCommunicationResult = NonNullable<
-  Awaited<ReturnType<typeof getOrgsEventsCommunication>>
->;
-export type PostOrgsEventsCommunicationPlanResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsCommunicationPlan>>
->;
-export type PutOrgsEventsCommunicationPlanByIdResult = NonNullable<
-  Awaited<ReturnType<typeof putOrgsEventsCommunicationPlanById>>
->;
-export type DeleteOrgsEventsCommunicationPlanByIdResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsCommunicationPlanById>>
->;
-export type PostOrgsEventsExternalLinkResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsExternalLink>>
->;
-export type DeleteOrgsEventsExternalLinkResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsExternalLink>>
->;
-export type UpdateEventAgendaResult = NonNullable<Awaited<ReturnType<typeof updateEventAgenda>>>;
-export type GetOrgsEventsPartnershipResult = NonNullable<
-  Awaited<ReturnType<typeof getOrgsEventsPartnership>>
->;
-export type DeletePartnershipResult = NonNullable<Awaited<ReturnType<typeof deletePartnership>>>;
-export type PostOrgsEventsPartnershipAgreementResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipAgreement>>
->;
-export type PostOrgsEventsPartnershipBillingResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipBilling>>
->;
-export type PutOrgsEventsPartnershipBoothLocationResult = NonNullable<
-  Awaited<ReturnType<typeof putOrgsEventsPartnershipBoothLocation>>
->;
-export type PostOrgsEventsPartnershipSuggestionResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipSuggestion>>
->;
-export type PostOrgsEventsPartnershipValidateResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipValidate>>
->;
-export type PostOrgsEventsPartnershipDeclineResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsPartnershipDecline>>
->;
-export type PutOrgsEventsPartnershipCommunicationPublicationResult = NonNullable<
-  Awaited<ReturnType<typeof putOrgsEventsPartnershipCommunicationPublication>>
->;
-export type PutOrgsEventsPartnershipCommunicationSupportResult = NonNullable<
-  Awaited<ReturnType<typeof putOrgsEventsPartnershipCommunicationSupport>>
->;
-export type ListPartnershipJobOffersResult = NonNullable<
-  Awaited<ReturnType<typeof listPartnershipJobOffers>>
->;
-export type ListEventJobOfferPromotionsResult = NonNullable<
-  Awaited<ReturnType<typeof listEventJobOfferPromotions>>
->;
-export type ApproveJobOfferPromotionResult = NonNullable<
-  Awaited<ReturnType<typeof approveJobOfferPromotion>>
->;
-export type DeclineJobOfferPromotionResult = NonNullable<
-  Awaited<ReturnType<typeof declineJobOfferPromotion>>
->;
-export type PostPartnershipOrganiserResult = NonNullable<
-  Awaited<ReturnType<typeof postPartnershipOrganiser>>
->;
-export type DeletePartnershipOrganiserResult = NonNullable<
-  Awaited<ReturnType<typeof deletePartnershipOrganiser>>
->;
-export type PutPartnershipPricingResult = NonNullable<
-  Awaited<ReturnType<typeof putPartnershipPricing>>
->;
-export type GetPartnershipEmailHistoryResult = NonNullable<
-  Awaited<ReturnType<typeof getPartnershipEmailHistory>>
->;
-export type PostPartnershipTriggerWebhookResult = NonNullable<
-  Awaited<ReturnType<typeof postPartnershipTriggerWebhook>>
->;
-export type PostPartnershipEmailResult = NonNullable<
-  Awaited<ReturnType<typeof postPartnershipEmail>>
->;
-export type GetOrgsEventsProvidersResult = NonNullable<
-  Awaited<ReturnType<typeof getOrgsEventsProviders>>
->;
-export type PostOrgsEventsProvidersResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsEventsProviders>>
->;
-export type DeleteOrgsEventsProvidersResult = NonNullable<
-  Awaited<ReturnType<typeof deleteOrgsEventsProviders>>
->;
-export type GetOrgsUsersResult = NonNullable<Awaited<ReturnType<typeof getOrgsUsers>>>;
-export type PostOrgsUsersGrantResult = NonNullable<Awaited<ReturnType<typeof postOrgsUsersGrant>>>;
-export type PostOrgsUsersRevokeResult = NonNullable<
-  Awaited<ReturnType<typeof postOrgsUsersRevoke>>
->;
-export type PostDigestJobResult = NonNullable<Awaited<ReturnType<typeof postDigestJob>>>;
-export type GetUsersMeEventsResult = NonNullable<Awaited<ReturnType<typeof getUsersMeEvents>>>;
-export type GetUsersMeOrgsResult = NonNullable<Awaited<ReturnType<typeof getUsersMeOrgs>>>;
+ options?: SecondParameter<typeof customFetch<Blob>>,) => {
+      return customFetch<Blob>(
+      {url: `/users/me/orgs`, method: 'GET',
+        responseType: 'blob'
+    },
+      options);
+    }
+
+export type GetAuthCallbackResult = NonNullable<Awaited<ReturnType<typeof getAuthCallback>>>
+export type GetAuthLoginResult = NonNullable<Awaited<ReturnType<typeof getAuthLogin>>>
+export type GetAuthLogoutResult = NonNullable<Awaited<ReturnType<typeof getAuthLogout>>>
+export type GetAuthMeResult = NonNullable<Awaited<ReturnType<typeof getAuthMe>>>
+export type GetCompaniesResult = NonNullable<Awaited<ReturnType<typeof getCompanies>>>
+export type PostCompaniesResult = NonNullable<Awaited<ReturnType<typeof postCompanies>>>
+export type GetCompanyByIdResult = NonNullable<Awaited<ReturnType<typeof getCompanyById>>>
+export type PutCompanyByIdResult = NonNullable<Awaited<ReturnType<typeof putCompanyById>>>
+export type DeleteCompanyByIdResult = NonNullable<Awaited<ReturnType<typeof deleteCompanyById>>>
+export type PostCompaniesLogoResult = NonNullable<Awaited<ReturnType<typeof postCompaniesLogo>>>
+export type GetCompaniesPartnershipResult = NonNullable<Awaited<ReturnType<typeof getCompaniesPartnership>>>
+export type GetCompaniesJobOffersResult = NonNullable<Awaited<ReturnType<typeof getCompaniesJobOffers>>>
+export type PostCompaniesJobOffersResult = NonNullable<Awaited<ReturnType<typeof postCompaniesJobOffers>>>
+export type GetCompaniesJobOffersByIdResult = NonNullable<Awaited<ReturnType<typeof getCompaniesJobOffersById>>>
+export type PutCompaniesJobOffersByIdResult = NonNullable<Awaited<ReturnType<typeof putCompaniesJobOffersById>>>
+export type DeleteCompaniesJobOffersByIdResult = NonNullable<Awaited<ReturnType<typeof deleteCompaniesJobOffersById>>>
+export type PromoteJobOfferToPartnershipResult = NonNullable<Awaited<ReturnType<typeof promoteJobOfferToPartnership>>>
+export type ListJobOfferPromotionsResult = NonNullable<Awaited<ReturnType<typeof listJobOfferPromotions>>>
+export type GetEventsResult = NonNullable<Awaited<ReturnType<typeof getEvents>>>
+export type GetEventBySlugResult = NonNullable<Awaited<ReturnType<typeof getEventBySlug>>>
+export type GetEventAgendaPublicResult = NonNullable<Awaited<ReturnType<typeof getEventAgendaPublic>>>
+export type GetEventsSponsoringPacksResult = NonNullable<Awaited<ReturnType<typeof getEventsSponsoringPacks>>>
+export type PostEventsPartnershipResult = NonNullable<Awaited<ReturnType<typeof postEventsPartnership>>>
+export type GetEventsPartnershipDetailedResult = NonNullable<Awaited<ReturnType<typeof getEventsPartnershipDetailed>>>
+export type UpdatePartnershipContactInfoResult = NonNullable<Awaited<ReturnType<typeof updatePartnershipContactInfo>>>
+export type GetEventsPartnershipBillingResult = NonNullable<Awaited<ReturnType<typeof getEventsPartnershipBilling>>>
+export type PostEventsPartnershipBillingResult = NonNullable<Awaited<ReturnType<typeof postEventsPartnershipBilling>>>
+export type PutEventsPartnershipBillingResult = NonNullable<Awaited<ReturnType<typeof putEventsPartnershipBilling>>>
+export type PostOrgsEventsPartnershipBillingInvoiceResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipBillingInvoice>>>
+export type PostOrgsEventsPartnershipBillingQuoteResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipBillingQuote>>>
+export type PostEventsPartnershipSignedAgreementResult = NonNullable<Awaited<ReturnType<typeof postEventsPartnershipSignedAgreement>>>
+export type PostEventsPartnershipSuggestionApproveResult = NonNullable<Awaited<ReturnType<typeof postEventsPartnershipSuggestionApprove>>>
+export type PostEventsPartnershipSuggestionDeclineResult = NonNullable<Awaited<ReturnType<typeof postEventsPartnershipSuggestionDecline>>>
+export type GetEventsPartnershipTicketsResult = NonNullable<Awaited<ReturnType<typeof getEventsPartnershipTickets>>>
+export type PostEventsPartnershipTicketsResult = NonNullable<Awaited<ReturnType<typeof postEventsPartnershipTickets>>>
+export type PutEventsPartnershipTicketsResult = NonNullable<Awaited<ReturnType<typeof putEventsPartnershipTickets>>>
+export type GetPartnershipJobOffersResult = NonNullable<Awaited<ReturnType<typeof getPartnershipJobOffers>>>
+export type AttachSpeakerToPartnershipResult = NonNullable<Awaited<ReturnType<typeof attachSpeakerToPartnership>>>
+export type DetachSpeakerFromPartnershipResult = NonNullable<Awaited<ReturnType<typeof detachSpeakerFromPartnership>>>
+export type ListBoothActivitiesResult = NonNullable<Awaited<ReturnType<typeof listBoothActivities>>>
+export type CreateBoothActivityResult = NonNullable<Awaited<ReturnType<typeof createBoothActivity>>>
+export type UpdateBoothActivityResult = NonNullable<Awaited<ReturnType<typeof updateBoothActivity>>>
+export type DeleteBoothActivityResult = NonNullable<Awaited<ReturnType<typeof deleteBoothActivity>>>
+export type GetProvidersResult = NonNullable<Awaited<ReturnType<typeof getProviders>>>
+export type PostProvidersResult = NonNullable<Awaited<ReturnType<typeof postProviders>>>
+export type PostOrgsResult = NonNullable<Awaited<ReturnType<typeof postOrgs>>>
+export type GetOrgsResult = NonNullable<Awaited<ReturnType<typeof getOrgs>>>
+export type PutOrgsResult = NonNullable<Awaited<ReturnType<typeof putOrgs>>>
+export type PostOrgsProvidersResult = NonNullable<Awaited<ReturnType<typeof postOrgsProviders>>>
+export type PutOrgsProvidersResult = NonNullable<Awaited<ReturnType<typeof putOrgsProviders>>>
+export type DeleteOrgsProvidersResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsProviders>>>
+export type GetOrgsEventsResult = NonNullable<Awaited<ReturnType<typeof getOrgsEvents>>>
+export type PostOrgsEventsResult = NonNullable<Awaited<ReturnType<typeof postOrgsEvents>>>
+export type PutOrgsEventsResult = NonNullable<Awaited<ReturnType<typeof putOrgsEvents>>>
+export type PostOrgsEventsBoothPlanResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsBoothPlan>>>
+export type GetOrgsEventsIntegrationsResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsIntegrations>>>
+export type PostOrgsEventsIntegrationsResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsIntegrations>>>
+export type DeleteOrgsEventsIntegrationsResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsIntegrations>>>
+export type GetStatusIntegrationResult = NonNullable<Awaited<ReturnType<typeof getStatusIntegration>>>
+export type GetOrgsEventsOptionsResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsOptions>>>
+export type PostOrgsEventsOptionsResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsOptions>>>
+export type GetOrgsEventsOptionsByIdResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsOptionsById>>>
+export type DeleteOrgsEventsOptionsResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsOptions>>>
+export type PutOrgsEventsOptionsResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsOptions>>>
+export type GetOrgsEventsPacksResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsPacks>>>
+export type PostOrgsEventsPacksResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPacks>>>
+export type DeleteOrgsEventsPacksResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsPacks>>>
+export type PutOrgsEventsPacksResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsPacks>>>
+export type PostOrgsEventsPacksOptionsResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPacksOptions>>>
+export type DeleteOrgsEventsPacksOptionsResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsPacksOptions>>>
+export type GetOrgsEventsCommunicationResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsCommunication>>>
+export type PostOrgsEventsCommunicationPlanResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsCommunicationPlan>>>
+export type PutOrgsEventsCommunicationPlanByIdResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsCommunicationPlanById>>>
+export type DeleteOrgsEventsCommunicationPlanByIdResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsCommunicationPlanById>>>
+export type PostOrgsEventsExternalLinkResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsExternalLink>>>
+export type DeleteOrgsEventsExternalLinkResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsExternalLink>>>
+export type UpdateEventAgendaResult = NonNullable<Awaited<ReturnType<typeof updateEventAgenda>>>
+export type GetOrgsEventsPartnershipResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsPartnership>>>
+export type DeletePartnershipResult = NonNullable<Awaited<ReturnType<typeof deletePartnership>>>
+export type PostOrgsEventsPartnershipAgreementResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipAgreement>>>
+export type PostOrgsEventsPartnershipBillingResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipBilling>>>
+export type PutOrgsEventsPartnershipBoothLocationResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsPartnershipBoothLocation>>>
+export type PostOrgsEventsPartnershipSuggestionResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipSuggestion>>>
+export type PostOrgsEventsPartnershipValidateResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipValidate>>>
+export type PostOrgsEventsPartnershipDeclineResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsPartnershipDecline>>>
+export type PutOrgsEventsPartnershipCommunicationPublicationResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsPartnershipCommunicationPublication>>>
+export type PutOrgsEventsPartnershipCommunicationSupportResult = NonNullable<Awaited<ReturnType<typeof putOrgsEventsPartnershipCommunicationSupport>>>
+export type ListPartnershipJobOffersResult = NonNullable<Awaited<ReturnType<typeof listPartnershipJobOffers>>>
+export type ListEventJobOfferPromotionsResult = NonNullable<Awaited<ReturnType<typeof listEventJobOfferPromotions>>>
+export type ApproveJobOfferPromotionResult = NonNullable<Awaited<ReturnType<typeof approveJobOfferPromotion>>>
+export type DeclineJobOfferPromotionResult = NonNullable<Awaited<ReturnType<typeof declineJobOfferPromotion>>>
+export type PostPartnershipOrganiserResult = NonNullable<Awaited<ReturnType<typeof postPartnershipOrganiser>>>
+export type DeletePartnershipOrganiserResult = NonNullable<Awaited<ReturnType<typeof deletePartnershipOrganiser>>>
+export type PutPartnershipPricingResult = NonNullable<Awaited<ReturnType<typeof putPartnershipPricing>>>
+export type GetPartnershipEmailHistoryResult = NonNullable<Awaited<ReturnType<typeof getPartnershipEmailHistory>>>
+export type PostPartnershipTriggerWebhookResult = NonNullable<Awaited<ReturnType<typeof postPartnershipTriggerWebhook>>>
+export type PostPartnershipEmailResult = NonNullable<Awaited<ReturnType<typeof postPartnershipEmail>>>
+export type GetOrgsEventsProvidersResult = NonNullable<Awaited<ReturnType<typeof getOrgsEventsProviders>>>
+export type PostOrgsEventsProvidersResult = NonNullable<Awaited<ReturnType<typeof postOrgsEventsProviders>>>
+export type DeleteOrgsEventsProvidersResult = NonNullable<Awaited<ReturnType<typeof deleteOrgsEventsProviders>>>
+export type GetOrgsUsersResult = NonNullable<Awaited<ReturnType<typeof getOrgsUsers>>>
+export type PostOrgsUsersGrantResult = NonNullable<Awaited<ReturnType<typeof postOrgsUsersGrant>>>
+export type PostOrgsUsersRevokeResult = NonNullable<Awaited<ReturnType<typeof postOrgsUsersRevoke>>>
+export type PostDigestJobResult = NonNullable<Awaited<ReturnType<typeof postDigestJob>>>
+export type GetUsersMeEventsResult = NonNullable<Awaited<ReturnType<typeof getUsersMeEvents>>>
+export type GetUsersMeOrgsResult = NonNullable<Awaited<ReturnType<typeof getUsersMeOrgs>>>

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyJobOfferPromotionRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyJobOfferPromotionRepositoryExposed.kt
@@ -90,7 +90,7 @@ class CompanyJobOfferPromotionRepositoryExposed : CompanyJobOfferPromotionReposi
         partnershipId: UUID?,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<JobOfferPromotionResponse> = transaction {
+    ): PaginatedResponse<JobOfferPromotionResponse, Unit> = transaction {
         CompanyJobOfferEntity.singleByCompanyAndJobOffer(companyId, jobOfferId)
             ?: throw NotFoundException("Job offer $jobOfferId not found for company $companyId")
         val baseQuery = CompanyJobOfferPromotionsTable.jobOfferId eq jobOfferId

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyJobOfferRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyJobOfferRepositoryExposed.kt
@@ -73,7 +73,7 @@ class CompanyJobOfferRepositoryExposed : CompanyJobOfferRepository {
         companyId: UUID,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<JobOfferResponse> = transaction {
+    ): PaginatedResponse<JobOfferResponse, Unit> = transaction {
         // Verify company exists
         CompanyEntity.findById(companyId)
             ?: throw NotFoundException("Company not found: $companyId")

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyRepositoryExposed.kt
@@ -25,7 +25,7 @@ class CompanyRepositoryExposed(
         status: CompanyStatus?,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<Company> = transaction {
+    ): PaginatedResponse<Company, Unit> = transaction {
         val companies = CompanyEntity.listByQueryAndStatus(query, status)
         val total = companies.count()
         companies

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/domain/CompanyJobOfferPromotionRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/domain/CompanyJobOfferPromotionRepository.kt
@@ -73,5 +73,5 @@ interface CompanyJobOfferPromotionRepository {
         partnershipId: UUID? = null,
         page: Int = 1,
         pageSize: Int = 20,
-    ): PaginatedResponse<JobOfferPromotionResponse>
+    ): PaginatedResponse<JobOfferPromotionResponse, Unit>
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/domain/CompanyJobOfferRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/domain/CompanyJobOfferRepository.kt
@@ -38,7 +38,7 @@ interface CompanyJobOfferRepository {
         companyId: UUID,
         page: Int = 1,
         pageSize: Int = 20,
-    ): PaginatedResponse<JobOfferResponse>
+    ): PaginatedResponse<JobOfferResponse, Unit>
 
     /**
      * Updates an existing job offer with partial or complete data.

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/domain/CompanyRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/domain/CompanyRepository.kt
@@ -18,7 +18,7 @@ interface CompanyRepository {
         status: CompanyStatus?,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<Company>
+    ): PaginatedResponse<Company, Unit>
 
     fun getById(id: UUID): Company
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/EventRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/EventRepositoryExposed.kt
@@ -43,7 +43,7 @@ import fr.devlille.partners.connect.organisations.infrastructure.db.findBySlug a
 class EventRepositoryExposed(
     private val entity: UUIDEntityClass<EventEntity>,
 ) : EventRepository {
-    override fun getAllEvents(page: Int, pageSize: Int): PaginatedResponse<EventSummary> = transaction {
+    override fun getAllEvents(page: Int, pageSize: Int): PaginatedResponse<EventSummary, Unit> = transaction {
         val total = entity.count()
         entity.all()
             .orderBy(EventsTable.startTime to SortOrder.ASC)
@@ -80,7 +80,7 @@ class EventRepositoryExposed(
         orgSlug: String,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<EventSummary> = transaction {
+    ): PaginatedResponse<EventSummary, Unit> = transaction {
         val organisation = OrganisationEntity.orgFindBySlug(orgSlug)
             ?: throw NotFoundException("Organisation with slug $orgSlug not found")
         val eventQuery = entity.find { EventsTable.organisationId eq organisation.id }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/EventRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/EventRepository.kt
@@ -4,13 +4,13 @@ import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedRespons
 import java.util.UUID
 
 interface EventRepository {
-    fun getAllEvents(page: Int, pageSize: Int): PaginatedResponse<EventSummary>
+    fun getAllEvents(page: Int, pageSize: Int): PaginatedResponse<EventSummary, Unit>
 
     fun getBySlug(eventSlug: String): EventWithOrganisation
 
     fun findByOrgSlug(orgSlug: String): List<EventSummary>
 
-    fun findByOrgSlugPaginated(orgSlug: String, page: Int, pageSize: Int): PaginatedResponse<EventSummary>
+    fun findByOrgSlugPaginated(orgSlug: String, page: Int, pageSize: Int): PaginatedResponse<EventSummary, Unit>
 
     fun createEvent(orgSlug: String, event: Event): String
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/api/PaginatedResponse.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/api/PaginatedResponse.kt
@@ -6,11 +6,11 @@ import kotlinx.serialization.Serializable
 const val DEFAULT_PAGE_SIZE = 20
 
 @Serializable
-data class PaginatedResponse<T>(
+data class PaginatedResponse<T, M>(
     val items: List<T>,
     val page: Int,
     @SerialName("page_size")
     val pageSize: Int,
     val total: Long,
-    val metadata: PaginationMetadata? = null,
+    val metadata: M? = null,
 )

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/api/SizedIterable.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/api/SizedIterable.ext.kt
@@ -13,9 +13,10 @@ fun <T> SizedIterable<T>.paginated(page: Int, pageSize: Int): SizedIterable<T> {
     return this.limit(count = pageSize).offset(start = offset)
 }
 
-fun <T> List<T>.toPaginatedResponse(total: Long, page: Int, pageSize: Int): PaginatedResponse<T> = PaginatedResponse(
-    items = this,
-    page = page,
-    pageSize = pageSize,
-    total = total.toLong(),
-)
+fun <T> List<T>.toPaginatedResponse(total: Long, page: Int, pageSize: Int): PaginatedResponse<T, Unit> =
+    PaginatedResponse(
+        items = this,
+        page = page,
+        pageSize = pageSize,
+        total = total,
+    )

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipEmailHistoryRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipEmailHistoryRepositoryExposed.kt
@@ -58,7 +58,7 @@ class PartnershipEmailHistoryRepositoryExposed : PartnershipEmailHistoryReposito
         partnershipId: UUID,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<PartnershipEmailHistory> = transaction {
+    ): PaginatedResponse<PartnershipEmailHistory, Unit> = transaction {
         val emailHistory = PartnershipEmailHistoryEntity
             .find { PartnershipEmailHistoryTable.partnershipId eq partnershipId }
             .orderBy(PartnershipEmailHistoryTable.sentAt to SortOrder.DESC)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipJobOfferRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipJobOfferRepositoryExposed.kt
@@ -40,7 +40,7 @@ class PartnershipJobOfferRepositoryExposed : PartnershipJobOfferRepository {
         status: PromotionStatus?,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<JobOfferPromotionResponse> = transaction {
+    ): PaginatedResponse<JobOfferPromotionResponse, Unit> = transaction {
         val event = EventEntity.findBySlug(eventSlug)
             ?: throw NotFoundException("Event with slug '$eventSlug' not found")
         PartnershipEntity.singleByEventAndPartnership(event.id.value, partnershipId)
@@ -58,7 +58,7 @@ class PartnershipJobOfferRepositoryExposed : PartnershipJobOfferRepository {
         status: PromotionStatus?,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<JobOfferPromotionResponse> = transaction {
+    ): PaginatedResponse<JobOfferPromotionResponse, Unit> = transaction {
         val org = OrganisationEntity.orgFindBySlug(orgSlug)
             ?: throw NotFoundException("Organisation with slug '$orgSlug' not found")
         val event = EventEntity

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/PartnershipRepositoryExposed.kt
@@ -12,15 +12,16 @@ import fr.devlille.partners.connect.internal.infrastructure.api.FilterType
 import fr.devlille.partners.connect.internal.infrastructure.api.FilterValue
 import fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException
 import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedResponse
-import fr.devlille.partners.connect.internal.infrastructure.api.PaginationMetadata
 import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
 import fr.devlille.partners.connect.partnership.application.mappers.toDetailedDomain
 import fr.devlille.partners.connect.partnership.application.mappers.toDomain
 import fr.devlille.partners.connect.partnership.domain.InvoiceStatus
+import fr.devlille.partners.connect.partnership.domain.PackCount
 import fr.devlille.partners.connect.partnership.domain.Partnership
 import fr.devlille.partners.connect.partnership.domain.PartnershipDetail
 import fr.devlille.partners.connect.partnership.domain.PartnershipFilters
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.domain.PartnershipRepository
 import fr.devlille.partners.connect.partnership.domain.RegisterPartnership
 import fr.devlille.partners.connect.partnership.domain.UpdatePartnershipContactInfo
@@ -255,7 +256,7 @@ class PartnershipRepositoryExposed : PartnershipRepository {
         direction: String,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<PartnershipItem> = transaction {
+    ): PaginatedResponse<PartnershipItem, PartnershipListMetadata> = transaction {
         val event = EventEntity.findBySlug(eventSlug)
             ?: throw NotFoundException("Event with slug $eventSlug not found")
         val eventId = event.id.value
@@ -305,16 +306,34 @@ class PartnershipRepositoryExposed : PartnershipRepository {
         )
     }
 
-    private fun buildMetadata(eventId: UUID, organisationId: UUID): PaginationMetadata {
+    private fun buildMetadata(eventId: UUID, organisationId: UUID): PartnershipListMetadata {
         // Query packs for filter values
-        val packValues = SponsoringPackEntity
+        val packs = SponsoringPackEntity
             .find { SponsoringPacksTable.eventId eq eventId }
-            .map { pack ->
-                FilterValue(
-                    value = pack.id.value.toString(),
-                    displayValue = pack.name,
-                )
-            }
+            .toList()
+        val packValues = packs.map { pack ->
+            FilterValue(
+                value = pack.id.value.toString(),
+                displayValue = pack.name,
+            )
+        }
+
+        // Count partnerships per pack
+        val packCounts = packs.map { pack ->
+            val count = PartnershipEntity
+                .find {
+                    (PartnershipsTable.eventId eq eventId) and
+                        (PartnershipsTable.selectedPackId eq pack.id) and
+                        PartnershipsTable.declinedAt.isNull()
+                }
+                .count()
+                .toInt()
+            PackCount(
+                packId = pack.id.value.toString(),
+                packName = pack.name,
+                count = count,
+            )
+        }
 
         // Query organisation editors for available organisers
         val editors = OrganisationPermissionEntity.listUserGrantedByOrgId(organisationId)
@@ -325,7 +344,7 @@ class PartnershipRepositoryExposed : PartnershipRepository {
             )
         }.distinctBy { it.value }
 
-        return PaginationMetadata(
+        return PartnershipListMetadata(
             filters = listOf(
                 FilterDefinition("pack_id", FilterType.STRING, packValues),
                 FilterDefinition("validated", FilterType.BOOLEAN),
@@ -337,6 +356,7 @@ class PartnershipRepositoryExposed : PartnershipRepository {
                 FilterDefinition("declined", FilterType.BOOLEAN),
             ),
             sorts = listOf("asc", "desc"),
+            packCounts = packCounts,
         )
     }
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipEmailHistoryRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipEmailHistoryRepository.kt
@@ -67,5 +67,5 @@ interface PartnershipEmailHistoryRepository {
         partnershipId: UUID,
         page: Int = 0,
         pageSize: Int = 20,
-    ): PaginatedResponse<PartnershipEmailHistory>
+    ): PaginatedResponse<PartnershipEmailHistory, Unit>
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipJobOfferRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipJobOfferRepository.kt
@@ -45,7 +45,7 @@ interface PartnershipJobOfferRepository {
         status: PromotionStatus? = null,
         page: Int = 1,
         pageSize: Int = 20,
-    ): PaginatedResponse<JobOfferPromotionResponse>
+    ): PaginatedResponse<JobOfferPromotionResponse, Unit>
 
     /**
      * Lists all promoted job offers across all partnerships for an event.
@@ -76,7 +76,7 @@ interface PartnershipJobOfferRepository {
         status: PromotionStatus? = null,
         page: Int = 1,
         pageSize: Int = 20,
-    ): PaginatedResponse<JobOfferPromotionResponse>
+    ): PaginatedResponse<JobOfferPromotionResponse, Unit>
 
     /**
      * Approves a pending job offer promotion.

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipListMetadata.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipListMetadata.kt
@@ -1,0 +1,22 @@
+package fr.devlille.partners.connect.partnership.domain
+
+import fr.devlille.partners.connect.internal.infrastructure.api.FilterDefinition
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PartnershipListMetadata(
+    val filters: List<FilterDefinition>,
+    val sorts: List<String>,
+    @SerialName("pack_counts")
+    val packCounts: List<PackCount>,
+)
+
+@Serializable
+data class PackCount(
+    @SerialName("pack_id")
+    val packId: String,
+    @SerialName("pack_name")
+    val packName: String,
+    val count: Int,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/domain/PartnershipRepository.kt
@@ -22,7 +22,7 @@ interface PartnershipRepository {
         direction: String = "asc",
         page: Int = 1,
         pageSize: Int = DEFAULT_PAGE_SIZE,
-    ): PaginatedResponse<PartnershipItem>
+    ): PaginatedResponse<PartnershipItem, PartnershipListMetadata>
 
     fun listByCompany(companyId: UUID): List<PartnershipItem>
 

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/provider/application/ProviderRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/provider/application/ProviderRepositoryExposed.kt
@@ -49,7 +49,7 @@ class ProviderRepositoryExposed : ProviderRepository {
         direction: String?,
         page: Int,
         pageSize: Int,
-    ): PaginatedResponse<Provider> = transaction {
+    ): PaginatedResponse<Provider, Unit> = transaction {
         var queryBuilder = if (orgSlug != null) {
             // Organization-scoped listing
             val organisation = OrganisationEntity.orgFindBySlug(orgSlug)
@@ -113,7 +113,11 @@ class ProviderRepositoryExposed : ProviderRepository {
             ?: throw NotFoundException("Provider not found")
     }
 
-    override fun findByEvent(eventSlug: String, page: Int, pageSize: Int): PaginatedResponse<Provider> = transaction {
+    override fun findByEvent(
+        eventSlug: String,
+        page: Int,
+        pageSize: Int,
+    ): PaginatedResponse<Provider, Unit> = transaction {
         val eventEntity = EventEntity.eventFindBySlug(eventSlug)
             ?: throw NotFoundException("Event with slug $eventSlug not found")
         val eventProviders = EventProviderEntity

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/provider/domain/ProviderRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/provider/domain/ProviderRepository.kt
@@ -31,7 +31,7 @@ interface ProviderRepository {
         direction: String? = "asc",
         page: Int = 1,
         pageSize: Int = 20,
-    ): PaginatedResponse<Provider>
+    ): PaginatedResponse<Provider, Unit>
 
     /**
      * Get a specific provider by ID within organisation scope.
@@ -51,7 +51,7 @@ interface ProviderRepository {
      * @param pageSize Number of items per page (default: 20)
      * @return Paginated response containing event's attached providers
      */
-    fun findByEvent(eventSlug: String, page: Int = 1, pageSize: Int = 20): PaginatedResponse<Provider>
+    fun findByEvent(eventSlug: String, page: Int = 1, pageSize: Int = 20): PaginatedResponse<Provider, Unit>
 
     /**
      * Create a new provider within organisation scope.

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -8332,6 +8332,28 @@ components:
               - validated
             - - name
               - created_at
+        pack_counts:
+          type: array
+          description: Count of active (non-declined) partnerships per sponsoring pack. Only present on partnership list endpoints.
+          items:
+            type: object
+            required:
+              - pack_id
+              - pack_name
+              - count
+            properties:
+              pack_id:
+                type: string
+                format: uuid
+                description: Sponsoring pack unique identifier
+              pack_name:
+                type: string
+                description: Display name of the sponsoring pack
+              count:
+                type: integer
+                minimum: 0
+                description: Number of active partnerships using this pack
+            additionalProperties: false
       additionalProperties: false
     partnership_list_response.schema:
       $schema: http://json-schema.org/draft-07/schema#

--- a/server/application/src/main/resources/schemas/pagination_metadata.schema.json
+++ b/server/application/src/main/resources/schemas/pagination_metadata.schema.json
@@ -20,6 +20,31 @@
         ["created", "validated"],
         ["name", "created_at"]
       ]
+    },
+    "pack_counts": {
+      "type": "array",
+      "description": "Count of active (non-declined) partnerships per sponsoring pack. Only present on partnership list endpoints.",
+      "items": {
+        "type": "object",
+        "required": ["pack_id", "pack_name", "count"],
+        "properties": {
+          "pack_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Sponsoring pack unique identifier"
+          },
+          "pack_name": {
+            "type": "string",
+            "description": "Display name of the sponsoring pack"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of active partnerships using this pack"
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/CompanyCreateRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/CompanyCreateRoutesTest.kt
@@ -67,7 +67,7 @@ class CompanyCreateRoutesTest {
 
         val response = client.get("/companies")
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginated = json.decodeFromString<PaginatedResponse<Company>>(response.bodyAsText())
+        val paginated = json.decodeFromString<PaginatedResponse<Company, Unit>>(response.bodyAsText())
         assertTrue(paginated.items.any { it.toString().contains(id!!) })
         assertEquals(1, paginated.items.first().socials.size)
         assertEquals(SocialType.LINKEDIN, paginated.items.first().socials.first().type)

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/CompanyJobOfferRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/CompanyJobOfferRoutesTest.kt
@@ -97,7 +97,7 @@ class CompanyJobOfferRoutesTest {
         // Verify promotion was CASCADE deleted
         val listAfterDelete = client.get("/events/$eventId/partnerships/$partnershipId/job-offers")
         assertEquals(HttpStatusCode.OK, listAfterDelete.status)
-        val offersAfterDelete = json.decodeFromString<PaginatedResponse<JobOfferPromotionResponse>>(
+        val offersAfterDelete = json.decodeFromString<PaginatedResponse<JobOfferPromotionResponse, Unit>>(
             listAfterDelete.bodyAsText(),
         )
         assertEquals(0, offersAfterDelete.items.size) // Promotion should be gone

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/infrastructure/api/CompanyStatusFilterRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/infrastructure/api/CompanyStatusFilterRouteGetTest.kt
@@ -35,7 +35,7 @@ class CompanyStatusFilterRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
 
-        val result = json.decodeFromString<PaginatedResponse<Company>>(response.bodyAsText())
+        val result = json.decodeFromString<PaginatedResponse<Company, Unit>>(response.bodyAsText())
         assertEquals(0, result.total)
         assertEquals(0, result.items.size)
     }
@@ -57,7 +57,7 @@ class CompanyStatusFilterRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
 
-        val result = json.decodeFromString<PaginatedResponse<Company>>(response.bodyAsText())
+        val result = json.decodeFromString<PaginatedResponse<Company, Unit>>(response.bodyAsText())
         assertTrue { result.total > 0 }
     }
 
@@ -78,7 +78,7 @@ class CompanyStatusFilterRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
 
-        val result = json.decodeFromString<PaginatedResponse<Company>>(response.bodyAsText())
+        val result = json.decodeFromString<PaginatedResponse<Company, Unit>>(response.bodyAsText())
         assertTrue { result.total > 0 }
         val active = result.items
             .filter { it.status == CompanyStatus.ACTIVE }
@@ -103,7 +103,7 @@ class CompanyStatusFilterRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
 
-        val result = json.decodeFromString<PaginatedResponse<Company>>(response.bodyAsText())
+        val result = json.decodeFromString<PaginatedResponse<Company, Unit>>(response.bodyAsText())
         assertTrue { result.total > 0 }
         val inactive = result.items
             .filter { it.status == CompanyStatus.INACTIVE }
@@ -150,7 +150,7 @@ class CompanyStatusFilterRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
 
-        val result = json.decodeFromString<PaginatedResponse<Company>>(response.bodyAsText())
+        val result = json.decodeFromString<PaginatedResponse<Company, Unit>>(response.bodyAsText())
         assertEquals(10, result.items.size) // Should return only 10 items per page
         assertEquals(15, result.total) // Total should be 15 active companies
         assertEquals(1, result.page)

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/infrastructure/api/ListJobOfferPromotionsRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/companies/infrastructure/api/ListJobOfferPromotionsRouteGetTest.kt
@@ -15,6 +15,7 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
@@ -85,7 +86,7 @@ class ListJobOfferPromotionsRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
         val body = json.decodeFromString(
-            PaginatedResponse.serializer(JobOfferPromotionResponse.serializer()),
+            PaginatedResponse.serializer(JobOfferPromotionResponse.serializer(), Unit.serializer()),
             response.bodyAsText(),
         )
         assertTrue { body.items.isNotEmpty() }
@@ -128,7 +129,7 @@ class ListJobOfferPromotionsRouteGetTest {
 
         assertEquals(HttpStatusCode.OK, response.status)
         val body = json.decodeFromString(
-            PaginatedResponse.serializer(JobOfferPromotionResponse.serializer()),
+            PaginatedResponse.serializer(JobOfferPromotionResponse.serializer(), Unit.serializer()),
             response.bodyAsText(),
         )
         assertTrue { body.items.isNotEmpty() }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipDeclinedFilterRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipDeclinedFilterRoutesTest.kt
@@ -7,6 +7,7 @@ import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedRespons
 import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
 import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
@@ -96,7 +97,9 @@ class PartnershipDeclinedFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.total)
         assertEquals(1, body.items.size)
         assertEquals(activePartnershipId.toString(), body.items.first().id)
@@ -146,7 +149,9 @@ class PartnershipDeclinedFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.total)
         assertEquals(1, body.items.size)
         assertEquals(activePartnershipId.toString(), body.items.first().id)
@@ -196,7 +201,9 @@ class PartnershipDeclinedFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.total)
         assertEquals(1, body.items.size)
     }
@@ -265,7 +272,9 @@ class PartnershipDeclinedFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         // Returns only the declined+validated partnership
         assertEquals(1, body.total)
         assertEquals(1, body.items.size)
@@ -316,7 +325,9 @@ class PartnershipDeclinedFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(0, body.total)
         assertTrue(body.items.isEmpty())
     }
@@ -342,7 +353,9 @@ class PartnershipDeclinedFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val metadata = body.metadata
         assertNotNull(metadata)
         val declinedFilter = metadata.filters.find { it.name == "declined" }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipOrganiserFilterRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipOrganiserFilterRoutesTest.kt
@@ -6,6 +6,7 @@ import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedRespons
 import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
 import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
@@ -107,7 +108,9 @@ class PartnershipOrganiserFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         // Should return only partnerships assigned to organiser1
         assertEquals(2, body.total)
@@ -174,7 +177,9 @@ class PartnershipOrganiserFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         // Should return only partnership with organiser, exclude null organiser
         assertEquals(1, body.total)
@@ -243,7 +248,9 @@ class PartnershipOrganiserFilterRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         // Should return only validated partnership with organiser
         assertEquals(1, body.total)

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipPaginationWithFiltersRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/PartnershipPaginationWithFiltersRoutesTest.kt
@@ -7,6 +7,7 @@ import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
 import fr.devlille.partners.connect.partnership.domain.InvoiceStatus
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.factories.insertMockedBilling
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
@@ -81,7 +82,9 @@ class PartnershipPaginationWithFiltersRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage1.status)
-        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage1.bodyAsText())
+        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage1.bodyAsText(),
+        )
         assertEquals(1, page1.page)
         assertEquals(2, page1.pageSize)
         assertEquals(5, page1.total)
@@ -94,7 +97,9 @@ class PartnershipPaginationWithFiltersRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage2.status)
-        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage2.bodyAsText())
+        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage2.bodyAsText(),
+        )
         assertEquals(2, page2.page)
         assertEquals(2, page2.pageSize)
         assertEquals(5, page2.total)
@@ -167,7 +172,9 @@ class PartnershipPaginationWithFiltersRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage1.status)
-        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage1.bodyAsText())
+        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage1.bodyAsText(),
+        )
         assertEquals(1, page1.page)
         assertEquals(2, page1.pageSize)
         assertEquals(4, page1.total)
@@ -180,7 +187,9 @@ class PartnershipPaginationWithFiltersRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage2.status)
-        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage2.bodyAsText())
+        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage2.bodyAsText(),
+        )
         assertEquals(2, page2.page)
         assertEquals(2, page2.pageSize)
         assertEquals(4, page2.total)
@@ -241,7 +250,9 @@ class PartnershipPaginationWithFiltersRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.page)
         assertEquals(2, body.pageSize)
         assertEquals(3, body.total)
@@ -254,7 +265,9 @@ class PartnershipPaginationWithFiltersRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage2.status)
-        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage2.bodyAsText())
+        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage2.bodyAsText(),
+        )
         assertEquals(2, page2.page)
         assertEquals(3, page2.total)
         assertEquals(1, page2.items.size)

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListDeclinedFilterRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListDeclinedFilterRouteGetTest.kt
@@ -6,6 +6,7 @@ import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedRespons
 import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
 import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
@@ -74,7 +75,9 @@ class PartnershipListDeclinedFilterRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.items.size)
     }
 
@@ -118,7 +121,9 @@ class PartnershipListDeclinedFilterRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.items.size)
     }
 
@@ -162,7 +167,9 @@ class PartnershipListDeclinedFilterRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.items.size)
     }
 
@@ -248,7 +255,9 @@ class PartnershipListDeclinedFilterRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(0, body.items.size)
     }
 }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListMetadataRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListMetadataRouteGetTest.kt
@@ -1,0 +1,183 @@
+package fr.devlille.partners.connect.partnership.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedResponse
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
+import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class PartnershipListMetadataRouteGetTest {
+    @Test
+    fun `GET returns metadata with pack counts`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val pack1Id = UUID.randomUUID()
+        val pack2Id = UUID.randomUUID()
+        val company1Id = UUID.randomUUID()
+        val company2Id = UUID.randomUUID()
+        val company3Id = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(company1Id)
+                insertMockedCompany(company2Id)
+                insertMockedCompany(company3Id)
+                insertMockedSponsoringPack(pack1Id, eventId, name = "Gold")
+                insertMockedSponsoringPack(pack2Id, eventId, name = "Silver")
+                // 2 partnerships on Gold pack
+                insertMockedPartnership(
+                    eventId = eventId,
+                    companyId = company1Id,
+                    selectedPackId = pack1Id,
+                )
+                insertMockedPartnership(
+                    eventId = eventId,
+                    companyId = company2Id,
+                    selectedPackId = pack1Id,
+                )
+                // 1 partnership on Silver pack
+                insertMockedPartnership(
+                    eventId = eventId,
+                    companyId = company3Id,
+                    selectedPackId = pack2Id,
+                )
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/partnerships") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val result = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
+        val metadata = result.metadata
+        assertNotNull(metadata)
+        assertEquals(3, result.items.size)
+
+        val goldCount = metadata.packCounts.find { it.packName == "Gold" }
+        assertNotNull(goldCount)
+        assertEquals(pack1Id.toString(), goldCount.packId)
+        assertEquals(2, goldCount.count)
+
+        val silverCount = metadata.packCounts.find { it.packName == "Silver" }
+        assertNotNull(silverCount)
+        assertEquals(pack2Id.toString(), silverCount.packId)
+        assertEquals(1, silverCount.count)
+    }
+
+    @Test
+    fun `GET excludes declined partnerships from pack counts`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val company1Id = UUID.randomUUID()
+        val company2Id = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(company1Id)
+                insertMockedCompany(company2Id)
+                insertMockedSponsoringPack(packId, eventId, name = "Gold")
+                // Active partnership
+                insertMockedPartnership(
+                    eventId = eventId,
+                    companyId = company1Id,
+                    selectedPackId = packId,
+                )
+                // Declined partnership
+                insertMockedPartnership(
+                    eventId = eventId,
+                    companyId = company2Id,
+                    selectedPackId = packId,
+                    declinedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC),
+                )
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/partnerships") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val result = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
+        val metadata = result.metadata
+        assertNotNull(metadata)
+
+        val goldCount = metadata.packCounts.find { it.packName == "Gold" }
+        assertNotNull(goldCount)
+        assertEquals(1, goldCount.count)
+    }
+
+    @Test
+    fun `GET returns pack with zero count when no partnerships`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedSponsoringPack(packId, eventId, name = "Platinum")
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/partnerships") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val result = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
+        val metadata = result.metadata
+        assertNotNull(metadata)
+        assertEquals(1, metadata.packCounts.size)
+
+        val platinumCount = metadata.packCounts.first()
+        assertEquals(packId.toString(), platinumCount.packId)
+        assertEquals("Platinum", platinumCount.packName)
+        assertEquals(0, platinumCount.count)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListPaginationRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListPaginationRouteGetTest.kt
@@ -6,6 +6,7 @@ import fr.devlille.partners.connect.internal.infrastructure.api.PaginatedRespons
 import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
 import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
@@ -55,7 +56,9 @@ class PartnershipListPaginationRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.page)
         assertEquals(20, body.pageSize)
         assertEquals(1, body.total)
@@ -95,7 +98,9 @@ class PartnershipListPaginationRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage1.status)
-        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage1.bodyAsText())
+        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage1.bodyAsText(),
+        )
         assertEquals(1, page1.page)
         assertEquals(2, page1.pageSize)
         assertEquals(5, page1.total)
@@ -106,7 +111,9 @@ class PartnershipListPaginationRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage2.status)
-        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage2.bodyAsText())
+        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage2.bodyAsText(),
+        )
         assertEquals(2, page2.page)
         assertEquals(2, page2.pageSize)
         assertEquals(5, page2.total)
@@ -117,7 +124,9 @@ class PartnershipListPaginationRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, responsePage3.status)
-        val page3 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage3.bodyAsText())
+        val page3 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage3.bodyAsText(),
+        )
         assertEquals(3, page3.page)
         assertEquals(2, page3.pageSize)
         assertEquals(5, page3.total)
@@ -154,7 +163,9 @@ class PartnershipListPaginationRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(10, body.page)
         assertEquals(5, body.pageSize)
         assertEquals(1, body.total)
@@ -195,8 +206,12 @@ class PartnershipListPaginationRouteGetTest {
             header(HttpHeaders.Authorization, "Bearer valid")
         }
 
-        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage1.bodyAsText())
-        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem>>(responsePage2.bodyAsText())
+        val page1 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage1.bodyAsText(),
+        )
+        val page2 = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            responsePage2.bodyAsText(),
+        )
 
         val page1Ids = page1.items.map { it.id }
         val page2Ids = page2.items.map { it.id }
@@ -224,7 +239,9 @@ class PartnershipListPaginationRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val body = json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val body = json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, body.page)
         assertEquals(20, body.pageSize)
     }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipListRouteGetTest.kt
@@ -7,6 +7,7 @@ import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
 import fr.devlille.partners.connect.partnership.domain.InvoiceStatus
 import fr.devlille.partners.connect.partnership.domain.PartnershipItem
+import fr.devlille.partners.connect.partnership.domain.PartnershipListMetadata
 import fr.devlille.partners.connect.partnership.factories.insertMockedBilling
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
@@ -63,7 +64,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertEquals(1, paginatedResponse.items.size)
     }
 
@@ -111,7 +114,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(2, partnerships.size)
 
@@ -171,7 +176,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         assertEquals("John Doe", partnerships[0].contact.displayName)
@@ -219,7 +226,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         assertEquals("John Doe", partnerships[0].contact.displayName)
@@ -266,7 +275,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         assertEquals("Jane Smith", partnerships[0].contact.displayName)
@@ -315,7 +326,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         val partnership = partnerships[0]
@@ -368,7 +381,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         assertEquals("John Doe", partnerships[0].contact.displayName)
@@ -415,7 +430,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         assertEquals("John Doe", partnerships[0].contact.displayName)
@@ -470,7 +487,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         val partnerships = paginatedResponse.items
         assertEquals(1, partnerships.size)
         assertEquals("John Doe", partnerships[0].contact.displayName)
@@ -502,7 +521,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
         assertTrue(paginatedResponse.items.isEmpty())
     }
 
@@ -580,7 +601,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         // Verify metadata exists
         val metadata = paginatedResponse.metadata
@@ -637,7 +660,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         val metadata = paginatedResponse.metadata
         assertTrue(metadata != null)
@@ -694,7 +719,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         val metadata = paginatedResponse.metadata
         val organiserFilter = metadata?.filters?.find { it.name == "organiser" }
@@ -737,7 +764,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         val metadata = paginatedResponse.metadata
         assertTrue(metadata != null)
@@ -771,7 +800,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         // Metadata should be present even when there are no partnerships
         assertTrue(paginatedResponse.metadata != null, "Metadata should be present in empty results")
@@ -811,7 +842,9 @@ class PartnershipListRouteGetTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem>>(response.bodyAsText())
+        val paginatedResponse = Json.decodeFromString<PaginatedResponse<PartnershipItem, PartnershipListMetadata>>(
+            response.bodyAsText(),
+        )
 
         val metadata = paginatedResponse.metadata
         val organiserFilter = metadata?.filters?.find { it.name == "organiser" }


### PR DESCRIPTION
## Summary

Make the `metadata` field in `PaginatedResponse` generic so each endpoint can define its own metadata type. For the partnership list endpoint, add pack counts (number of active partnerships per sponsoring pack).

## Changes

- Add second type parameter `M` to `PaginatedResponse<T, M>` with `metadata: M? = null`
- Create `PartnershipListMetadata` model with `PackCount` (packId, packName, count)
- Count active (non-declined) partnerships per sponsoring pack in `buildMetadata()`
- Use `Unit` as metadata type for all other endpoints (no behavioral change)
- Update OpenAPI schema with `pack_counts` in pagination metadata
- Add 3 contract tests for pack count metadata (counts, declined exclusion, zero count)

## Files changed

- **Core**: `PaginatedResponse.kt`, `SizedIterable.ext.kt`
- **New**: `PartnershipListMetadata.kt`
- **Partnership**: `PartnershipRepository.kt`, `PartnershipRepositoryExposed.kt`
- **Other repos**: All repository interfaces and implementations updated to `<T, Unit>`
- **Tests**: All test files updated with second type parameter, new `PartnershipListMetadataRouteGetTest.kt`
- **OpenAPI**: `pagination_metadata.schema.json`, `documentation.yaml`