### PR TITLE
Fix speaker source column migration for production deployment

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/agenda/infrastructure/db/SpeakersTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/agenda/infrastructure/db/SpeakersTable.kt
@@ -9,6 +9,8 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
 import org.jetbrains.exposed.v1.datetime.datetime
 
+private const val SOURCE_COLUMN_LENGTH = 50
+
 object SpeakersTable : UUIDTable("speakers") {
     val externalId = varchar("externalId", length = 255).uniqueIndex()
     val name = varchar("name", length = 255)
@@ -16,8 +18,8 @@ object SpeakersTable : UUIDTable("speakers") {
     val photoUrl = text("photo_url").nullable()
     val jobTitle = varchar("job_title", length = 255).nullable()
     val pronouns = varchar("pronouns", length = 50).nullable()
-    val sourceProvider = enumeration<IntegrationProvider>("source")
-        .clientDefault { IntegrationProvider.OPENPLANNER }
+    val sourceProvider = enumerationByName<IntegrationProvider>("source", SOURCE_COLUMN_LENGTH)
+        .default(IntegrationProvider.OPENPLANNER)
     val eventId = reference("event_id", EventsTable)
     val companyId = reference("company_id", CompaniesTable).nullable()
     val createdAt = datetime("created_at").clientDefault {


### PR DESCRIPTION
Use a database-level `default` instead of `clientDefault` for the speaker source column so that the DDL includes a `DEFAULT 'OPENPLANNER'` clause. Without this, `SchemaUtils.createMissingTablesAndColumns` generates `ALTER TABLE speakers ADD "source" VARCHAR(50) NOT NULL` which fails on PostgreSQL when existing rows have no value for the column.

Also simplifies the migration to just `SchemaUtils.createMissingTablesAndColumns(SpeakersTable)` since the DB-level default handles backfilling automatically.