### PR TITLE
feat(server): add ecosystem partner module (community/media/host)

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
@@ -10,6 +10,7 @@ import fr.devlille.partners.connect.companies.infrastructure.bindings.companyMod
 import fr.devlille.partners.connect.digest.infrastructure.api.digestRoutes
 import fr.devlille.partners.connect.digest.infrastructure.bindings.digestModule
 import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerCategoryRoutes
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerRoutes
 import fr.devlille.partners.connect.ecosystempartners.infrastructure.bindings.ecosystemPartnerModule
 import fr.devlille.partners.connect.events.infrastructure.api.eventBoothPlanRoutes
 import fr.devlille.partners.connect.events.infrastructure.api.eventExternalLinkRoutes
@@ -147,6 +148,7 @@ fun Application.module(config: ApplicationConfig = ApplicationConfig()) {
         sponsoringRoutes()
         partnershipRoutes()
         ecosystemPartnerCategoryRoutes()
+        ecosystemPartnerRoutes()
         integrationRoutes()
         providersRoutes()
         digestRoutes()

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
@@ -9,6 +9,8 @@ import fr.devlille.partners.connect.companies.infrastructure.api.companyRoutes
 import fr.devlille.partners.connect.companies.infrastructure.bindings.companyModule
 import fr.devlille.partners.connect.digest.infrastructure.api.digestRoutes
 import fr.devlille.partners.connect.digest.infrastructure.bindings.digestModule
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerCategoryRoutes
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.bindings.ecosystemPartnerModule
 import fr.devlille.partners.connect.events.infrastructure.api.eventBoothPlanRoutes
 import fr.devlille.partners.connect.events.infrastructure.api.eventExternalLinkRoutes
 import fr.devlille.partners.connect.events.infrastructure.api.eventRoutes
@@ -96,6 +98,7 @@ data class ApplicationConfig(
         sponsoringModule,
         companyModule,
         partnershipModule,
+        ecosystemPartnerModule,
         notificationModule,
         billingModule,
         ticketingModule,
@@ -143,6 +146,7 @@ fun Application.module(config: ApplicationConfig = ApplicationConfig()) {
         userRoutes()
         sponsoringRoutes()
         partnershipRoutes()
+        ecosystemPartnerCategoryRoutes()
         integrationRoutes()
         providersRoutes()
         digestRoutes()

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
@@ -10,6 +10,7 @@ import fr.devlille.partners.connect.companies.infrastructure.bindings.companyMod
 import fr.devlille.partners.connect.digest.infrastructure.api.digestRoutes
 import fr.devlille.partners.connect.digest.infrastructure.bindings.digestModule
 import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerCategoryRoutes
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerDecisionRoutes
 import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerRoutes
 import fr.devlille.partners.connect.ecosystempartners.infrastructure.bindings.ecosystemPartnerModule
 import fr.devlille.partners.connect.events.infrastructure.api.eventBoothPlanRoutes
@@ -149,6 +150,7 @@ fun Application.module(config: ApplicationConfig = ApplicationConfig()) {
         partnershipRoutes()
         ecosystemPartnerCategoryRoutes()
         ecosystemPartnerRoutes()
+        ecosystemPartnerDecisionRoutes()
         integrationRoutes()
         providersRoutes()
         digestRoutes()

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerCategoryRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerCategoryRepositoryExposed.kt
@@ -1,0 +1,83 @@
+package fr.devlille.partners.connect.ecosystempartners.application
+
+import fr.devlille.partners.connect.ecosystempartners.application.mappers.toDomain
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerCategoryRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoriesTable
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoryEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.findBySlug
+import fr.devlille.partners.connect.internal.infrastructure.api.ConflictException
+import io.ktor.server.plugins.NotFoundException
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+
+class EcosystemPartnerCategoryRepositoryExposed : EcosystemPartnerCategoryRepository {
+    override fun create(eventSlug: String, request: RegisterEcosystemPartnerCategory): UUID = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        if (EcosystemPartnerCategoryEntity.singleByEventAndName(event.id.value, request.name) != null) {
+            throw ConflictException("Category '${request.name}' already exists for this event")
+        }
+        val entity = EcosystemPartnerCategoryEntity.new {
+            this.event = event
+            this.name = request.name
+            this.displayOrder = request.displayOrder
+        }
+        entity.id.value
+    }
+
+    override fun listByEvent(eventSlug: String): List<EcosystemPartnerCategory> = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        EcosystemPartnerCategoryEntity
+            .find { EcosystemPartnerCategoriesTable.eventId eq event.id.value }
+            .orderBy(
+                EcosystemPartnerCategoriesTable.displayOrder to SortOrder.ASC_NULLS_LAST,
+                EcosystemPartnerCategoriesTable.name to SortOrder.ASC,
+            )
+            .map { it.toDomain() }
+    }
+
+    override fun update(
+        eventSlug: String,
+        categoryId: UUID,
+        request: UpdateEcosystemPartnerCategory,
+    ): EcosystemPartnerCategory = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val category = EcosystemPartnerCategoryEntity.findById(categoryId)
+            ?: throw NotFoundException("Category $categoryId not found")
+        if (category.event.id.value != event.id.value) {
+            throw NotFoundException("Category $categoryId does not belong to event $eventSlug")
+        }
+        request.name?.let { newName ->
+            val existing = EcosystemPartnerCategoryEntity.singleByEventAndName(event.id.value, newName)
+            if (existing != null && existing.id.value != categoryId) {
+                throw ConflictException("Category '$newName' already exists for this event")
+            }
+            category.name = newName
+        }
+        request.displayOrder?.let { category.displayOrder = it }
+        category.toDomain()
+    }
+
+    override fun delete(eventSlug: String, categoryId: UUID) = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val category = EcosystemPartnerCategoryEntity.findById(categoryId)
+            ?: throw NotFoundException("Category $categoryId not found")
+        if (category.event.id.value != event.id.value) {
+            throw NotFoundException("Category $categoryId does not belong to event $eventSlug")
+        }
+        if (EcosystemPartnerEntity.countByCategory(categoryId) > 0) {
+            throw ConflictException("Category $categoryId is in use by one or more ecosystem partners")
+        }
+        category.delete()
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerDecisionRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerDecisionRepositoryExposed.kt
@@ -1,0 +1,40 @@
+package fr.devlille.partners.connect.ecosystempartners.application
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerDecisionRepository
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.findBySlug
+import io.ktor.server.plugins.NotFoundException
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+
+class EcosystemPartnerDecisionRepositoryExposed : EcosystemPartnerDecisionRepository {
+    override fun validate(eventSlug: String, ecosystemPartnerId: UUID): UUID = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val entity = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            ?: throw NotFoundException("Ecosystem partner $ecosystemPartnerId not found")
+        if (entity.event.id.value != event.id.value) {
+            throw NotFoundException("Ecosystem partner $ecosystemPartnerId does not belong to event $eventSlug")
+        }
+        entity.validatedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC)
+        entity.declinedAt = null
+        entity.id.value
+    }
+
+    override fun decline(eventSlug: String, ecosystemPartnerId: UUID): UUID = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val entity = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            ?: throw NotFoundException("Ecosystem partner $ecosystemPartnerId not found")
+        if (entity.event.id.value != event.id.value) {
+            throw NotFoundException("Ecosystem partner $ecosystemPartnerId does not belong to event $eventSlug")
+        }
+        entity.declinedAt = Clock.System.now().toLocalDateTime(TimeZone.UTC)
+        entity.validatedAt = null
+        entity.id.value
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerRepositoryExposed.kt
@@ -1,0 +1,169 @@
+package fr.devlille.partners.connect.ecosystempartners.application
+
+import fr.devlille.partners.connect.companies.infrastructure.db.CompanyEntity
+import fr.devlille.partners.connect.ecosystempartners.application.mappers.toDomain
+import fr.devlille.partners.connect.ecosystempartners.application.mappers.toItem
+import fr.devlille.partners.connect.ecosystempartners.application.mappers.toPublic
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerFilters
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerItem
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.PublicEcosystemPartnerGroup
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoryEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEmailEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnersTable
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.findBySlug
+import fr.devlille.partners.connect.internal.infrastructure.api.ConflictException
+import io.ktor.server.plugins.NotFoundException
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+
+class EcosystemPartnerRepositoryExposed : EcosystemPartnerRepository {
+    override fun register(eventSlug: String, request: RegisterEcosystemPartner): UUID = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val company = CompanyEntity.findById(UUID.fromString(request.companyId))
+            ?: throw NotFoundException("Company ${request.companyId} not found")
+        val category = EcosystemPartnerCategoryEntity.findById(UUID.fromString(request.categoryId))
+            ?: throw NotFoundException("Category ${request.categoryId} not found")
+        if (category.event.id.value != event.id.value) {
+            throw NotFoundException("Category ${request.categoryId} does not belong to event $eventSlug")
+        }
+        val duplicate = EcosystemPartnerEntity.find {
+            (EcosystemPartnersTable.eventId eq event.id.value) and
+                (EcosystemPartnersTable.companyId eq company.id.value) and
+                (EcosystemPartnersTable.categoryId eq category.id.value)
+        }.singleOrNull()
+        if (duplicate != null) {
+            throw ConflictException("Company already registered for this category on this event")
+        }
+        val entity = EcosystemPartnerEntity.new {
+            this.event = event
+            this.company = company
+            this.category = category
+            this.displayOrder = request.displayOrder
+            this.language = request.language
+        }
+        request.emails.forEach { addr ->
+            EcosystemPartnerEmailEntity.new {
+                this.ecosystemPartner = entity
+                this.email = addr
+            }
+        }
+        entity.id.value
+    }
+
+    override fun getById(eventSlug: String, ecosystemPartnerId: UUID): EcosystemPartner = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val entity = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            ?: throw NotFoundException("Ecosystem partner $ecosystemPartnerId not found")
+        if (entity.event.id.value != event.id.value) {
+            throw NotFoundException("Ecosystem partner $ecosystemPartnerId does not belong to event $eventSlug")
+        }
+        val emails = EcosystemPartnerEmailEntity
+            .listByEcosystemPartner(ecosystemPartnerId)
+            .map { it.email }
+        entity.toDomain(emails)
+    }
+
+    override fun update(
+        eventSlug: String,
+        ecosystemPartnerId: UUID,
+        request: UpdateEcosystemPartner,
+    ): EcosystemPartner = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val entity = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            ?: throw NotFoundException("Ecosystem partner $ecosystemPartnerId not found")
+        if (entity.event.id.value != event.id.value) {
+            throw NotFoundException("Ecosystem partner $ecosystemPartnerId does not belong to event $eventSlug")
+        }
+        if (entity.validatedAt != null) {
+            throw ConflictException("Ecosystem partner is validated; decline first to edit")
+        }
+        request.categoryId?.let { newCatId ->
+            val newCategory = EcosystemPartnerCategoryEntity.findById(UUID.fromString(newCatId))
+                ?: throw NotFoundException("Category $newCatId not found")
+            if (newCategory.event.id.value != event.id.value) {
+                throw NotFoundException("Category $newCatId does not belong to event $eventSlug")
+            }
+            entity.category = newCategory
+        }
+        request.displayOrder?.let { entity.displayOrder = it }
+        request.language?.let { entity.language = it }
+        request.emails?.let { newEmails ->
+            EcosystemPartnerEmailEntity.deleteByEcosystemPartner(ecosystemPartnerId)
+            newEmails.forEach { addr ->
+                EcosystemPartnerEmailEntity.new {
+                    this.ecosystemPartner = entity
+                    this.email = addr
+                }
+            }
+        }
+        val emails = EcosystemPartnerEmailEntity
+            .listByEcosystemPartner(ecosystemPartnerId)
+            .map { it.email }
+        entity.toDomain(emails)
+    }
+
+    override fun delete(eventSlug: String, ecosystemPartnerId: UUID) = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val entity = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            ?: throw NotFoundException("Ecosystem partner $ecosystemPartnerId not found")
+        if (entity.event.id.value != event.id.value) {
+            throw NotFoundException("Ecosystem partner $ecosystemPartnerId does not belong to event $eventSlug")
+        }
+        entity.delete()
+    }
+
+    override fun listByEvent(eventSlug: String, filters: EcosystemPartnerFilters): List<EcosystemPartnerItem> =
+        transaction {
+            val event = EventEntity.findBySlug(eventSlug)
+                ?: throw NotFoundException("Event with slug $eventSlug not found")
+            EcosystemPartnerEntity
+                .filters(
+                    eventId = event.id.value,
+                    categoryId = filters.categoryId?.let(UUID::fromString),
+                    validated = filters.validated,
+                    declined = filters.declined,
+                )
+                .orderBy(EcosystemPartnersTable.createdAt to SortOrder.ASC)
+                .map { it.toItem() }
+        }
+
+    override fun listPublic(eventSlug: String): List<PublicEcosystemPartnerGroup> = transaction {
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event with slug $eventSlug not found")
+        val partners = EcosystemPartnerEntity.listPublic(event.id.value)
+        partners
+            .groupBy { it.category }
+            .toList()
+            .sortedWith(
+                compareBy(
+                    { it.first.displayOrder ?: Int.MAX_VALUE },
+                    { it.first.name },
+                ),
+            )
+            .map { (category, entities) ->
+                val sorted = entities.sortedWith(
+                    compareBy(
+                        { it.displayOrder ?: Int.MAX_VALUE },
+                        { it.company.name },
+                    ),
+                )
+                PublicEcosystemPartnerGroup(
+                    category = category.name,
+                    partners = sorted.map { it.toPublic() },
+                )
+            }
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/mappers/EcosystemPartnerCategoryEntity.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/mappers/EcosystemPartnerCategoryEntity.ext.kt
@@ -1,0 +1,11 @@
+package fr.devlille.partners.connect.ecosystempartners.application.mappers
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoryEntity
+
+fun EcosystemPartnerCategoryEntity.toDomain(): EcosystemPartnerCategory = EcosystemPartnerCategory(
+    id = id.value.toString(),
+    eventId = event.id.value.toString(),
+    name = name,
+    displayOrder = displayOrder,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/mappers/EcosystemPartnerEntity.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/mappers/EcosystemPartnerEntity.ext.kt
@@ -1,0 +1,37 @@
+package fr.devlille.partners.connect.ecosystempartners.application.mappers
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerItem
+import fr.devlille.partners.connect.ecosystempartners.domain.PublicEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+
+fun EcosystemPartnerEntity.toDomain(emails: List<String>): EcosystemPartner = EcosystemPartner(
+    id = id.value.toString(),
+    eventId = event.id.value.toString(),
+    companyId = company.id.value.toString(),
+    category = category.toDomain(),
+    displayOrder = displayOrder,
+    language = language,
+    emails = emails,
+    validatedAt = validatedAt?.toString(),
+    declinedAt = declinedAt?.toString(),
+    createdAt = createdAt.toString(),
+)
+
+fun EcosystemPartnerEntity.toItem(): EcosystemPartnerItem = EcosystemPartnerItem(
+    id = id.value.toString(),
+    companyName = company.name,
+    companyLogoUrl = company.logoUrl500 ?: company.logoUrl1000 ?: company.logoUrlOriginal,
+    category = category.toDomain(),
+    displayOrder = displayOrder,
+    validatedAt = validatedAt,
+    declinedAt = declinedAt,
+    createdAt = createdAt,
+)
+
+fun EcosystemPartnerEntity.toPublic(): PublicEcosystemPartner = PublicEcosystemPartner(
+    id = id.value.toString(),
+    companyName = company.name,
+    logoUrl = company.logoUrl500 ?: company.logoUrl1000 ?: company.logoUrlOriginal,
+    siteUrl = company.siteUrl,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartner.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartner.kt
@@ -1,0 +1,24 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EcosystemPartner(
+    val id: String,
+    @SerialName("event_id")
+    val eventId: String,
+    @SerialName("company_id")
+    val companyId: String,
+    val category: EcosystemPartnerCategory,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+    val language: String,
+    val emails: List<String> = emptyList(),
+    @SerialName("validated_at")
+    val validatedAt: String? = null,
+    @SerialName("declined_at")
+    val declinedAt: String? = null,
+    @SerialName("created_at")
+    val createdAt: String,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerCategory.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerCategory.kt
@@ -1,0 +1,14 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EcosystemPartnerCategory(
+    val id: String,
+    @SerialName("event_id")
+    val eventId: String,
+    val name: String,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerCategoryRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerCategoryRepository.kt
@@ -1,0 +1,13 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import java.util.UUID
+
+interface EcosystemPartnerCategoryRepository {
+    fun create(eventSlug: String, request: RegisterEcosystemPartnerCategory): UUID
+
+    fun listByEvent(eventSlug: String): List<EcosystemPartnerCategory>
+
+    fun update(eventSlug: String, categoryId: UUID, request: UpdateEcosystemPartnerCategory): EcosystemPartnerCategory
+
+    fun delete(eventSlug: String, categoryId: UUID)
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerDecisionRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerDecisionRepository.kt
@@ -1,0 +1,9 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import java.util.UUID
+
+interface EcosystemPartnerDecisionRepository {
+    fun validate(eventSlug: String, ecosystemPartnerId: UUID): UUID
+
+    fun decline(eventSlug: String, ecosystemPartnerId: UUID): UUID
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerFilters.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerFilters.kt
@@ -1,0 +1,10 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EcosystemPartnerFilters(
+    val categoryId: String? = null,
+    val validated: Boolean? = null,
+    val declined: Boolean = false,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerItem.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerItem.kt
@@ -1,0 +1,23 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EcosystemPartnerItem(
+    val id: String,
+    @SerialName("company_name")
+    val companyName: String,
+    @SerialName("company_logo_url")
+    val companyLogoUrl: String? = null,
+    val category: EcosystemPartnerCategory,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+    @SerialName("validated_at")
+    val validatedAt: LocalDateTime? = null,
+    @SerialName("declined_at")
+    val declinedAt: LocalDateTime? = null,
+    @SerialName("created_at")
+    val createdAt: LocalDateTime,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerRepository.kt
@@ -1,0 +1,17 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import java.util.UUID
+
+interface EcosystemPartnerRepository {
+    fun register(eventSlug: String, request: RegisterEcosystemPartner): UUID
+
+    fun getById(eventSlug: String, ecosystemPartnerId: UUID): EcosystemPartner
+
+    fun update(eventSlug: String, ecosystemPartnerId: UUID, request: UpdateEcosystemPartner): EcosystemPartner
+
+    fun delete(eventSlug: String, ecosystemPartnerId: UUID)
+
+    fun listByEvent(eventSlug: String, filters: EcosystemPartnerFilters): List<EcosystemPartnerItem>
+
+    fun listPublic(eventSlug: String): List<PublicEcosystemPartnerGroup>
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerUrls.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerUrls.kt
@@ -1,0 +1,7 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import fr.devlille.partners.connect.events.domain.EventWithOrganisation
+import fr.devlille.partners.connect.internal.infrastructure.system.SystemVarEnv
+
+fun publicEventUrl(event: EventWithOrganisation): String =
+    "${SystemVarEnv.frontendBaseUrl}/${event.event.slug}"

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/PublicEcosystemPartner.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/PublicEcosystemPartner.kt
@@ -1,0 +1,21 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PublicEcosystemPartnerGroup(
+    val category: String,
+    val partners: List<PublicEcosystemPartner>,
+)
+
+@Serializable
+data class PublicEcosystemPartner(
+    val id: String,
+    @SerialName("company_name")
+    val companyName: String,
+    @SerialName("logo_url")
+    val logoUrl: String? = null,
+    @SerialName("site_url")
+    val siteUrl: String? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/RegisterEcosystemPartner.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/RegisterEcosystemPartner.kt
@@ -1,0 +1,16 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterEcosystemPartner(
+    @SerialName("company_id")
+    val companyId: String,
+    @SerialName("category_id")
+    val categoryId: String,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+    val language: String = "en",
+    val emails: List<String> = emptyList(),
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/RegisterEcosystemPartnerCategory.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/RegisterEcosystemPartnerCategory.kt
@@ -1,0 +1,11 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterEcosystemPartnerCategory(
+    val name: String,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/UpdateEcosystemPartner.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/UpdateEcosystemPartner.kt
@@ -1,0 +1,14 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateEcosystemPartner(
+    @SerialName("category_id")
+    val categoryId: String? = null,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+    val language: String? = null,
+    val emails: List<String>? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/UpdateEcosystemPartnerCategory.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/UpdateEcosystemPartnerCategory.kt
@@ -1,0 +1,11 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateEcosystemPartnerCategory(
+    val name: String? = null,
+    @SerialName("display_order")
+    val displayOrder: Int? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRoutes.kt
@@ -1,0 +1,75 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerCategoryRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
+import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.inject
+
+fun Route.ecosystemPartnerCategoryRoutes() {
+    orgsEcosystemPartnerCategoryRoutes()
+    publicEcosystemPartnerCategoryRoutes()
+}
+
+private fun Route.orgsEcosystemPartnerCategoryRoutes() {
+    val repository by inject<EcosystemPartnerCategoryRepository>()
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partner-categories") {
+        install(AuthorizedOrganisationPlugin)
+
+        post {
+            val eventSlug = call.parameters.eventSlug
+            val request = call.receive<RegisterEcosystemPartnerCategory>(
+                schema = "register_ecosystem_partner_category.schema.json",
+            )
+            val id = repository.create(eventSlug, request)
+            call.respond(HttpStatusCode.Created, mapOf("id" to id.toString()))
+        }
+
+        get {
+            val eventSlug = call.parameters.eventSlug
+            call.respond(HttpStatusCode.OK, repository.listByEvent(eventSlug))
+        }
+    }
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partner-categories/{categoryId}") {
+        install(AuthorizedOrganisationPlugin)
+
+        put {
+            val eventSlug = call.parameters.eventSlug
+            val categoryId = call.parameters.ecosystemPartnerCategoryId
+            val request = call.receive<UpdateEcosystemPartnerCategory>(
+                schema = "update_ecosystem_partner_category.schema.json",
+            )
+            call.respond(HttpStatusCode.OK, repository.update(eventSlug, categoryId, request))
+        }
+
+        delete {
+            val eventSlug = call.parameters.eventSlug
+            val categoryId = call.parameters.ecosystemPartnerCategoryId
+            repository.delete(eventSlug, categoryId)
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}
+
+private fun Route.publicEcosystemPartnerCategoryRoutes() {
+    val repository by inject<EcosystemPartnerCategoryRepository>()
+
+    route("/events/{eventSlug}/ecosystem-partner-categories") {
+        get {
+            val eventSlug = call.parameters.eventSlug
+            call.respond(HttpStatusCode.OK, repository.listByEvent(eventSlug))
+        }
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
@@ -7,6 +7,7 @@ import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
 import fr.devlille.partners.connect.events.domain.EventRepository
 import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.WebhookEcosystemPartnerPlugin
 import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
 import fr.devlille.partners.connect.notifications.domain.NotificationRepository
 import fr.devlille.partners.connect.notifications.domain.NotificationVariables
@@ -26,6 +27,7 @@ fun Route.ecosystemPartnerDecisionRoutes() {
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/validate") {
         install(AuthorizedOrganisationPlugin)
+        install(WebhookEcosystemPartnerPlugin)
 
         post {
             val eventSlug = call.parameters.eventSlug
@@ -48,6 +50,7 @@ fun Route.ecosystemPartnerDecisionRoutes() {
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline") {
         install(AuthorizedOrganisationPlugin)
+        install(WebhookEcosystemPartnerPlugin)
 
         post {
             val eventSlug = call.parameters.eventSlug

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
@@ -1,0 +1,37 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerDecisionRepository
+import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
+import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.inject
+
+fun Route.ecosystemPartnerDecisionRoutes() {
+    val repository by inject<EcosystemPartnerDecisionRepository>()
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/validate") {
+        install(AuthorizedOrganisationPlugin)
+
+        post {
+            val eventSlug = call.parameters.eventSlug
+            val id = call.parameters.ecosystemPartnerId
+            val result = repository.validate(eventSlug, id)
+            call.respond(HttpStatusCode.OK, mapOf("id" to result.toString()))
+        }
+    }
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline") {
+        install(AuthorizedOrganisationPlugin)
+
+        post {
+            val eventSlug = call.parameters.eventSlug
+            val id = call.parameters.ecosystemPartnerId
+            val result = repository.decline(eventSlug, id)
+            call.respond(HttpStatusCode.OK, mapOf("id" to result.toString()))
+        }
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
@@ -1,8 +1,15 @@
 package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
 
+import fr.devlille.partners.connect.companies.domain.CompanyRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerDecisionRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
+import fr.devlille.partners.connect.events.domain.EventRepository
 import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
+import fr.devlille.partners.connect.notifications.domain.NotificationRepository
+import fr.devlille.partners.connect.notifications.domain.NotificationVariables
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -12,6 +19,10 @@ import org.koin.ktor.ext.inject
 
 fun Route.ecosystemPartnerDecisionRoutes() {
     val repository by inject<EcosystemPartnerDecisionRepository>()
+    val ecosystemPartnerRepository by inject<EcosystemPartnerRepository>()
+    val eventRepository by inject<EventRepository>()
+    val companyRepository by inject<CompanyRepository>()
+    val notificationRepository by inject<NotificationRepository>()
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/validate") {
         install(AuthorizedOrganisationPlugin)
@@ -20,6 +31,17 @@ fun Route.ecosystemPartnerDecisionRoutes() {
             val eventSlug = call.parameters.eventSlug
             val id = call.parameters.ecosystemPartnerId
             val result = repository.validate(eventSlug, id)
+            val partner = ecosystemPartnerRepository.getById(eventSlug, id)
+            val event = eventRepository.getBySlug(eventSlug)
+            val company = companyRepository.getById(partner.companyId.toUUID())
+            val variables = NotificationVariables.EcosystemPartnerValidated(
+                language = partner.language,
+                event = event,
+                company = company,
+                categoryName = partner.category.name,
+                publicEventUrl = publicEventUrl(event),
+            )
+            notificationRepository.sendMessage(variables)
             call.respond(HttpStatusCode.OK, mapOf("id" to result.toString()))
         }
     }
@@ -31,6 +53,16 @@ fun Route.ecosystemPartnerDecisionRoutes() {
             val eventSlug = call.parameters.eventSlug
             val id = call.parameters.ecosystemPartnerId
             val result = repository.decline(eventSlug, id)
+            val partner = ecosystemPartnerRepository.getById(eventSlug, id)
+            val event = eventRepository.getBySlug(eventSlug)
+            val company = companyRepository.getById(partner.companyId.toUUID())
+            val variables = NotificationVariables.EcosystemPartnerDeclined(
+                language = partner.language,
+                event = event,
+                company = company,
+                categoryName = partner.category.name,
+            )
+            notificationRepository.sendMessage(variables)
             call.respond(HttpStatusCode.OK, mapOf("id" to result.toString()))
         }
     }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
@@ -1,0 +1,98 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerFilters
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartner
+import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
+import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
+import fr.devlille.partners.connect.partnership.infrastructure.api.toBooleanStrict
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.inject
+
+fun Route.ecosystemPartnerRoutes() {
+    publicEcosystemPartnerRoutes()
+    publicEcosystemPartnerListingRoute()
+    orgsEcosystemPartnerRoutes()
+}
+
+private fun Route.publicEcosystemPartnerRoutes() {
+    val repository by inject<EcosystemPartnerRepository>()
+
+    route("/events/{eventSlug}/ecosystem-partners") {
+        post {
+            val eventSlug = call.parameters.eventSlug
+            val request = call.receive<RegisterEcosystemPartner>(
+                schema = "register_ecosystem_partner.schema.json",
+            )
+            val id = repository.register(eventSlug, request)
+            call.respond(HttpStatusCode.Created, mapOf("id" to id.toString()))
+        }
+    }
+
+    route("/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}") {
+        get {
+            val eventSlug = call.parameters.eventSlug
+            val id = call.parameters.ecosystemPartnerId
+            call.respond(HttpStatusCode.OK, repository.getById(eventSlug, id))
+        }
+
+        put {
+            val eventSlug = call.parameters.eventSlug
+            val id = call.parameters.ecosystemPartnerId
+            val request = call.receive<UpdateEcosystemPartner>(
+                schema = "update_ecosystem_partner.schema.json",
+            )
+            call.respond(HttpStatusCode.OK, repository.update(eventSlug, id, request))
+        }
+    }
+}
+
+private fun Route.publicEcosystemPartnerListingRoute() {
+    val repository by inject<EcosystemPartnerRepository>()
+
+    route("/events/{eventSlug}/ecosystem-partners") {
+        get {
+            val eventSlug = call.parameters.eventSlug
+            call.respond(HttpStatusCode.OK, repository.listPublic(eventSlug))
+        }
+    }
+}
+
+private fun Route.orgsEcosystemPartnerRoutes() {
+    val repository by inject<EcosystemPartnerRepository>()
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners") {
+        install(AuthorizedOrganisationPlugin)
+
+        get {
+            val eventSlug = call.parameters.eventSlug
+            val filters = EcosystemPartnerFilters(
+                categoryId = call.request.queryParameters["filter[category_id]"],
+                validated = call.request.queryParameters["filter[validated]"]?.toBoolean(),
+                declined = call.request.queryParameters["filter[declined]"]
+                    .toBooleanStrict("filter[declined]", default = false),
+            )
+            call.respond(HttpStatusCode.OK, repository.listByEvent(eventSlug, filters))
+        }
+    }
+
+    route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}") {
+        install(AuthorizedOrganisationPlugin)
+
+        delete {
+            val eventSlug = call.parameters.eventSlug
+            val id = call.parameters.ecosystemPartnerId
+            repository.delete(eventSlug, id)
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
@@ -1,12 +1,18 @@
 package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
 
+import fr.devlille.partners.connect.companies.domain.CompanyRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerFilters
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartner
 import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
+import fr.devlille.partners.connect.events.domain.EventRepository
 import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
 import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
+import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
+import fr.devlille.partners.connect.notifications.domain.NotificationRepository
+import fr.devlille.partners.connect.notifications.domain.NotificationVariables
 import fr.devlille.partners.connect.partnership.infrastructure.api.toBooleanStrict
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
@@ -26,6 +32,9 @@ fun Route.ecosystemPartnerRoutes() {
 
 private fun Route.publicEcosystemPartnerRoutes() {
     val repository by inject<EcosystemPartnerRepository>()
+    val eventRepository by inject<EventRepository>()
+    val companyRepository by inject<CompanyRepository>()
+    val notificationRepository by inject<NotificationRepository>()
 
     route("/events/{eventSlug}/ecosystem-partners") {
         post {
@@ -34,6 +43,17 @@ private fun Route.publicEcosystemPartnerRoutes() {
                 schema = "register_ecosystem_partner.schema.json",
             )
             val id = repository.register(eventSlug, request)
+            val partner = repository.getById(eventSlug, id)
+            val event = eventRepository.getBySlug(eventSlug)
+            val company = companyRepository.getById(request.companyId.toUUID())
+            val variables = NotificationVariables.EcosystemPartnerSubmitted(
+                language = request.language,
+                event = event,
+                company = company,
+                categoryName = partner.category.name,
+                publicEventUrl = publicEventUrl(event),
+            )
+            notificationRepository.sendMessage(variables)
             call.respond(HttpStatusCode.Created, mapOf("id" to id.toString()))
         }
     }
@@ -69,6 +89,9 @@ private fun Route.publicEcosystemPartnerListingRoute() {
 
 private fun Route.orgsEcosystemPartnerRoutes() {
     val repository by inject<EcosystemPartnerRepository>()
+    val eventRepository by inject<EventRepository>()
+    val companyRepository by inject<CompanyRepository>()
+    val notificationRepository by inject<NotificationRepository>()
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners") {
         install(AuthorizedOrganisationPlugin)
@@ -91,6 +114,16 @@ private fun Route.orgsEcosystemPartnerRoutes() {
         delete {
             val eventSlug = call.parameters.eventSlug
             val id = call.parameters.ecosystemPartnerId
+            val partner = repository.getById(eventSlug, id)
+            val event = eventRepository.getBySlug(eventSlug)
+            val company = companyRepository.getById(partner.companyId.toUUID())
+            val variables = NotificationVariables.EcosystemPartnerRemoved(
+                language = partner.language,
+                event = event,
+                company = company,
+                categoryName = partner.category.name,
+            )
+            notificationRepository.sendMessage(variables)
             repository.delete(eventSlug, id)
             call.respond(HttpStatusCode.NoContent)
         }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
@@ -9,11 +9,15 @@ import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
 import fr.devlille.partners.connect.events.domain.EventRepository
 import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.WebhookEcosystemPartnerPlugin
 import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
 import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
 import fr.devlille.partners.connect.notifications.domain.NotificationRepository
 import fr.devlille.partners.connect.notifications.domain.NotificationVariables
 import fr.devlille.partners.connect.partnership.infrastructure.api.toBooleanStrict
+import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
+import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -35,6 +39,7 @@ private fun Route.publicEcosystemPartnerRoutes() {
     val eventRepository by inject<EventRepository>()
     val companyRepository by inject<CompanyRepository>()
     val notificationRepository by inject<NotificationRepository>()
+    val webhookRepository by inject<WebhookRepository>()
 
     route("/events/{eventSlug}/ecosystem-partners") {
         post {
@@ -54,6 +59,12 @@ private fun Route.publicEcosystemPartnerRoutes() {
                 publicEventUrl = publicEventUrl(event),
             )
             notificationRepository.sendMessage(variables)
+            webhookRepository.sendWebhooks(
+                eventSlug = eventSlug,
+                resourceType = WebhookResourceType.ECOSYSTEM_PARTNER,
+                resourceId = id,
+                eventType = WebhookEventType.CREATED,
+            )
             call.respond(HttpStatusCode.Created, mapOf("id" to id.toString()))
         }
     }
@@ -64,6 +75,10 @@ private fun Route.publicEcosystemPartnerRoutes() {
             val id = call.parameters.ecosystemPartnerId
             call.respond(HttpStatusCode.OK, repository.getById(eventSlug, id))
         }
+    }
+
+    route("/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}") {
+        install(WebhookEcosystemPartnerPlugin)
 
         put {
             val eventSlug = call.parameters.eventSlug
@@ -92,6 +107,7 @@ private fun Route.orgsEcosystemPartnerRoutes() {
     val eventRepository by inject<EventRepository>()
     val companyRepository by inject<CompanyRepository>()
     val notificationRepository by inject<NotificationRepository>()
+    val webhookRepository by inject<WebhookRepository>()
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners") {
         install(AuthorizedOrganisationPlugin)
@@ -124,6 +140,12 @@ private fun Route.orgsEcosystemPartnerRoutes() {
                 categoryName = partner.category.name,
             )
             notificationRepository.sendMessage(variables)
+            webhookRepository.sendWebhooks(
+                eventSlug = eventSlug,
+                resourceType = WebhookResourceType.ECOSYSTEM_PARTNER,
+                resourceId = id,
+                eventType = WebhookEventType.DELETED,
+            )
             repository.delete(eventSlug, id)
             call.respond(HttpStatusCode.NoContent)
         }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/StringValues.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/StringValues.ext.kt
@@ -1,0 +1,12 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.internal.infrastructure.api.getValue
+import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
+import io.ktor.util.StringValues
+import java.util.UUID
+
+val StringValues.ecosystemPartnerId: UUID
+    get() = getValue("ecosystemPartnerId").toUUID()
+
+val StringValues.ecosystemPartnerCategoryId: UUID
+    get() = getValue("categoryId").toUUID()

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/bindings/EcosystemPartnerModule.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/bindings/EcosystemPartnerModule.kt
@@ -1,0 +1,15 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.bindings
+
+import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerCategoryRepositoryExposed
+import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerDecisionRepositoryExposed
+import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerRepositoryExposed
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerCategoryRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerDecisionRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
+import org.koin.dsl.module
+
+val ecosystemPartnerModule = module {
+    single<EcosystemPartnerCategoryRepository> { EcosystemPartnerCategoryRepositoryExposed() }
+    single<EcosystemPartnerRepository> { EcosystemPartnerRepositoryExposed() }
+    single<EcosystemPartnerDecisionRepository> { EcosystemPartnerDecisionRepositoryExposed() }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerCategoriesTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerCategoriesTable.kt
@@ -1,0 +1,22 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.db
+
+import fr.devlille.partners.connect.events.infrastructure.db.EventsTable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
+import org.jetbrains.exposed.v1.datetime.datetime
+
+object EcosystemPartnerCategoriesTable : UUIDTable("event_ecosystem_partner_categories") {
+    val eventId = reference("event_id", EventsTable)
+    val name = text("name")
+    val displayOrder = integer("display_order").nullable()
+    val createdAt = datetime("created_at").clientDefault {
+        Clock.System.now().toLocalDateTime(TimeZone.UTC)
+    }
+
+    init {
+        uniqueIndex("uk_ecosystem_partner_category_event_name", eventId, name)
+        index(isUnique = false, eventId)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerCategoryEntity.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerCategoryEntity.kt
@@ -1,0 +1,26 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.db
+
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.UUIDEntity
+import org.jetbrains.exposed.v1.dao.UUIDEntityClass
+import java.util.UUID
+
+class EcosystemPartnerCategoryEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<EcosystemPartnerCategoryEntity>(EcosystemPartnerCategoriesTable) {
+        fun listByEvent(eventId: UUID): List<EcosystemPartnerCategoryEntity> =
+            find { EcosystemPartnerCategoriesTable.eventId eq eventId }.toList()
+
+        fun singleByEventAndName(eventId: UUID, name: String): EcosystemPartnerCategoryEntity? = find {
+            (EcosystemPartnerCategoriesTable.eventId eq eventId) and
+                (EcosystemPartnerCategoriesTable.name eq name)
+        }.singleOrNull()
+    }
+
+    var event by EventEntity referencedOn EcosystemPartnerCategoriesTable.eventId
+    var name by EcosystemPartnerCategoriesTable.name
+    var displayOrder by EcosystemPartnerCategoriesTable.displayOrder
+    var createdAt by EcosystemPartnerCategoriesTable.createdAt
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerEmailEntity.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerEmailEntity.kt
@@ -1,0 +1,22 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.db
+
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.UUIDEntity
+import org.jetbrains.exposed.v1.dao.UUIDEntityClass
+import java.util.UUID
+
+class EcosystemPartnerEmailEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<EcosystemPartnerEmailEntity>(EcosystemPartnerEmailsTable) {
+        fun listByEcosystemPartner(ecosystemPartnerId: UUID): List<EcosystemPartnerEmailEntity> =
+            find { EcosystemPartnerEmailsTable.ecosystemPartnerId eq ecosystemPartnerId }.toList()
+
+        fun deleteByEcosystemPartner(ecosystemPartnerId: UUID) {
+            find { EcosystemPartnerEmailsTable.ecosystemPartnerId eq ecosystemPartnerId }
+                .forEach { it.delete() }
+        }
+    }
+
+    var ecosystemPartner by EcosystemPartnerEntity referencedOn EcosystemPartnerEmailsTable.ecosystemPartnerId
+    var email by EcosystemPartnerEmailsTable.email
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerEmailsTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerEmailsTable.kt
@@ -1,0 +1,17 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.db
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
+
+object EcosystemPartnerEmailsTable : UUIDTable("ecosystem_partner_emails") {
+    val ecosystemPartnerId = reference(
+        name = "ecosystem_partner_id",
+        foreign = EcosystemPartnersTable,
+        onDelete = ReferenceOption.CASCADE,
+    )
+    val email = text("email")
+
+    init {
+        index(isUnique = false, ecosystemPartnerId)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerEntity.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnerEntity.kt
@@ -1,0 +1,60 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.db
+
+import fr.devlille.partners.connect.companies.infrastructure.db.CompanyEntity
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.isNotNull
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.isNull
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.UUIDEntity
+import org.jetbrains.exposed.v1.dao.UUIDEntityClass
+import org.jetbrains.exposed.v1.jdbc.SizedIterable
+import java.util.UUID
+
+class EcosystemPartnerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<EcosystemPartnerEntity>(EcosystemPartnersTable) {
+        fun filters(
+            eventId: UUID,
+            categoryId: UUID?,
+            validated: Boolean?,
+            declined: Boolean = false,
+        ): SizedIterable<EcosystemPartnerEntity> {
+            var op = EcosystemPartnersTable.eventId eq eventId
+            if (categoryId != null) {
+                op = op and (EcosystemPartnersTable.categoryId eq categoryId)
+            }
+            if (validated != null) {
+                op = if (validated) {
+                    op and EcosystemPartnersTable.validatedAt.isNotNull()
+                } else {
+                    op and EcosystemPartnersTable.validatedAt.isNull()
+                }
+            }
+            op = if (declined) {
+                op and EcosystemPartnersTable.declinedAt.isNotNull()
+            } else {
+                op and EcosystemPartnersTable.declinedAt.isNull()
+            }
+            return find { op }
+        }
+
+        fun listPublic(eventId: UUID): List<EcosystemPartnerEntity> = find {
+            (EcosystemPartnersTable.eventId eq eventId) and
+                EcosystemPartnersTable.validatedAt.isNotNull() and
+                EcosystemPartnersTable.declinedAt.isNull()
+        }.toList()
+
+        fun countByCategory(categoryId: UUID): Long =
+            find { EcosystemPartnersTable.categoryId eq categoryId }.count()
+    }
+
+    var event by EventEntity referencedOn EcosystemPartnersTable.eventId
+    var company by CompanyEntity referencedOn EcosystemPartnersTable.companyId
+    var category by EcosystemPartnerCategoryEntity referencedOn EcosystemPartnersTable.categoryId
+    var displayOrder by EcosystemPartnersTable.displayOrder
+    var language by EcosystemPartnersTable.language
+    var validatedAt by EcosystemPartnersTable.validatedAt
+    var declinedAt by EcosystemPartnersTable.declinedAt
+    var createdAt by EcosystemPartnersTable.createdAt
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnersTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/db/EcosystemPartnersTable.kt
@@ -1,0 +1,32 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.db
+
+import fr.devlille.partners.connect.companies.infrastructure.db.CompaniesTable
+import fr.devlille.partners.connect.events.infrastructure.db.EventsTable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
+import org.jetbrains.exposed.v1.datetime.datetime
+
+object EcosystemPartnersTable : UUIDTable("ecosystem_partners") {
+    val eventId = reference("event_id", EventsTable)
+    val companyId = reference("company_id", CompaniesTable)
+    val categoryId = reference("category_id", EcosystemPartnerCategoriesTable)
+    val displayOrder = integer("display_order").nullable()
+    val language = text("language").default("en")
+    val validatedAt = datetime("validated_at").nullable()
+    val declinedAt = datetime("declined_at").nullable()
+    val createdAt = datetime("created_at").clientDefault {
+        Clock.System.now().toLocalDateTime(TimeZone.UTC)
+    }
+
+    init {
+        uniqueIndex(
+            "uk_ecosystem_partner_event_company_category",
+            eventId,
+            companyId,
+            categoryId,
+        )
+        index(isUnique = false, eventId, validatedAt)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/WebhookEcosystemPartnerPlugin.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/WebhookEcosystemPartnerPlugin.kt
@@ -1,0 +1,24 @@
+package fr.devlille.partners.connect.internal.infrastructure.ktor
+
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerId
+import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
+import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
+import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
+import io.ktor.server.application.createRouteScopedPlugin
+import org.koin.ktor.ext.inject
+
+val WebhookEcosystemPartnerPlugin = createRouteScopedPlugin(name = "WebhookEcosystemPartnerPlugin") {
+    val webhookRepository by application.inject<WebhookRepository>()
+
+    onCallRespond { call ->
+        val eventSlug = call.parameters.eventSlug
+        val ecosystemPartnerId = call.parameters.ecosystemPartnerId
+        webhookRepository.sendWebhooks(
+            eventSlug = eventSlug,
+            resourceType = WebhookResourceType.ECOSYSTEM_PARTNER,
+            resourceId = ecosystemPartnerId,
+            eventType = WebhookEventType.UPDATED,
+        )
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/WebhookPartnershipPlugin.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/WebhookPartnershipPlugin.kt
@@ -4,6 +4,7 @@ import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.partnership.infrastructure.api.partnershipId
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
 import io.ktor.server.application.createRouteScopedPlugin
 import org.koin.ktor.ext.inject
 
@@ -13,6 +14,11 @@ val WebhookPartnershipPlugin = createRouteScopedPlugin(name = "WebhookPartnershi
     onCallRespond { call ->
         val eventSlug = call.parameters.eventSlug
         val partnershipId = call.parameters.partnershipId
-        webhookRepository.sendWebhooks(eventSlug, partnershipId, WebhookEventType.UPDATED)
+        webhookRepository.sendWebhooks(
+            eventSlug = eventSlug,
+            resourceType = WebhookResourceType.PARTNERSHIP,
+            resourceId = partnershipId,
+            eventType = WebhookEventType.UPDATED,
+        )
     }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
@@ -20,6 +20,7 @@ import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateCommunicationPlansTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateCompanyJobOffersTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateEcosystemPartnerCategoriesTableMigration
+import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateEcosystemPartnerEmailsTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateEcosystemPartnersTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateJobOfferPromotionsTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreatePartnershipSupportVideosTableMigration
@@ -67,6 +68,7 @@ object MigrationRegistry {
         AddFlyerTemplateColumnsToSponsoringPacksMigration,
         CreateEcosystemPartnerCategoriesTableMigration,
         CreateEcosystemPartnersTableMigration,
+        CreateEcosystemPartnerEmailsTableMigration,
     )
 
     /**

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
@@ -19,6 +19,7 @@ import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateBoothActivitiesTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateCommunicationPlansTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateCompanyJobOffersTableMigration
+import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateEcosystemPartnerCategoriesTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateJobOfferPromotionsTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreatePartnershipSupportVideosTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateQandaTablesMigration
@@ -63,6 +64,7 @@ object MigrationRegistry {
         AddSpeakerSourceColumnMigration,
         CreatePartnershipSupportVideosTableMigration,
         AddFlyerTemplateColumnsToSponsoringPacksMigration,
+        CreateEcosystemPartnerCategoriesTableMigration,
     )
 
     /**

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
@@ -20,6 +20,7 @@ import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateCommunicationPlansTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateCompanyJobOffersTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateEcosystemPartnerCategoriesTableMigration
+import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateEcosystemPartnersTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateJobOfferPromotionsTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreatePartnershipSupportVideosTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.CreateQandaTablesMigration
@@ -65,6 +66,7 @@ object MigrationRegistry {
         CreatePartnershipSupportVideosTableMigration,
         AddFlyerTemplateColumnsToSponsoringPacksMigration,
         CreateEcosystemPartnerCategoriesTableMigration,
+        CreateEcosystemPartnersTableMigration,
     )
 
     /**

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/CreateEcosystemPartnerCategoriesTableMigration.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/CreateEcosystemPartnerCategoriesTableMigration.kt
@@ -1,0 +1,14 @@
+package fr.devlille.partners.connect.internal.infrastructure.migrations.versions
+
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoriesTable
+import fr.devlille.partners.connect.internal.infrastructure.migrations.Migration
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+
+object CreateEcosystemPartnerCategoriesTableMigration : Migration {
+    override val id = "20260516_create_ecosystem_partner_categories_table"
+    override val description = "Create per-event ecosystem partner categories table"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(EcosystemPartnerCategoriesTable)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/CreateEcosystemPartnerEmailsTableMigration.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/CreateEcosystemPartnerEmailsTableMigration.kt
@@ -1,0 +1,14 @@
+package fr.devlille.partners.connect.internal.infrastructure.migrations.versions
+
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEmailsTable
+import fr.devlille.partners.connect.internal.infrastructure.migrations.Migration
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+
+object CreateEcosystemPartnerEmailsTableMigration : Migration {
+    override val id = "20260516_create_ecosystem_partner_emails_table"
+    override val description = "Create ecosystem_partner_emails table for notification contacts"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(EcosystemPartnerEmailsTable)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/CreateEcosystemPartnersTableMigration.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/CreateEcosystemPartnersTableMigration.kt
@@ -1,0 +1,14 @@
+package fr.devlille.partners.connect.internal.infrastructure.migrations.versions
+
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnersTable
+import fr.devlille.partners.connect.internal.infrastructure.migrations.Migration
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+
+object CreateEcosystemPartnersTableMigration : Migration {
+    override val id = "20260516_create_ecosystem_partners_table"
+    override val description = "Create ecosystem_partners table (curated non-contractual partners per event)"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(EcosystemPartnersTable)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
@@ -360,4 +360,68 @@ sealed interface NotificationVariables {
                 .replace("{{flyer_section}}", formatSection(flyerItems, "n/a"))
         }
     }
+
+    data class EcosystemPartnerSubmitted(
+        override val language: String,
+        override val event: EventWithOrganisation,
+        override val company: Company,
+        val categoryName: String,
+        val publicEventUrl: String,
+    ) : NotificationVariables {
+        override val usageName: String = "ecosystem_partner_submitted"
+
+        override fun populate(content: String): String = content
+            .replace("{{event_name}}", event.event.name)
+            .replace("{{event_contact}}", event.event.contact.email)
+            .replace("{{company_name}}", company.name)
+            .replace("{{category_name}}", categoryName)
+            .replace("{{public_event_url}}", publicEventUrl)
+    }
+
+    data class EcosystemPartnerValidated(
+        override val language: String,
+        override val event: EventWithOrganisation,
+        override val company: Company,
+        val categoryName: String,
+        val publicEventUrl: String,
+    ) : NotificationVariables {
+        override val usageName: String = "ecosystem_partner_validated"
+
+        override fun populate(content: String): String = content
+            .replace("{{event_name}}", event.event.name)
+            .replace("{{event_contact}}", event.event.contact.email)
+            .replace("{{company_name}}", company.name)
+            .replace("{{category_name}}", categoryName)
+            .replace("{{public_event_url}}", publicEventUrl)
+    }
+
+    data class EcosystemPartnerDeclined(
+        override val language: String,
+        override val event: EventWithOrganisation,
+        override val company: Company,
+        val categoryName: String,
+    ) : NotificationVariables {
+        override val usageName: String = "ecosystem_partner_declined"
+
+        override fun populate(content: String): String = content
+            .replace("{{event_name}}", event.event.name)
+            .replace("{{event_contact}}", event.event.contact.email)
+            .replace("{{company_name}}", company.name)
+            .replace("{{category_name}}", categoryName)
+    }
+
+    data class EcosystemPartnerRemoved(
+        override val language: String,
+        override val event: EventWithOrganisation,
+        override val company: Company,
+        val categoryName: String,
+    ) : NotificationVariables {
+        override val usageName: String = "ecosystem_partner_removed"
+
+        override fun populate(content: String): String = content
+            .replace("{{event_name}}", event.event.name)
+            .replace("{{event_contact}}", event.event.contact.email)
+            .replace("{{company_name}}", company.name)
+            .replace("{{category_name}}", categoryName)
+    }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipRoutes.kt
@@ -18,6 +18,7 @@ import fr.devlille.partners.connect.partnership.domain.UpdatePartnershipContactI
 import fr.devlille.partners.connect.partnership.domain.UpdatePartnershipPricing
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.NotFoundException
 import io.ktor.server.response.respond
@@ -87,7 +88,12 @@ private fun Route.publicPartnershipRoutes() {
             // Send notification to partnership contact without log history
             notificationRepository.sendMessage(variables)
             // Send webhook notification for partnership creation
-            webhookRepository.sendWebhooks(eventSlug, id, WebhookEventType.CREATED)
+            webhookRepository.sendWebhooks(
+                eventSlug = eventSlug,
+                resourceType = WebhookResourceType.PARTNERSHIP,
+                resourceId = id,
+                eventType = WebhookEventType.CREATED,
+            )
             call.respond(HttpStatusCode.Created, mapOf("id" to id.toString()))
         }
     }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/WebhookRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/WebhookRepositoryExposed.kt
@@ -8,6 +8,7 @@ import fr.devlille.partners.connect.integrations.infrastructure.db.IntegrationsT
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookGateway
 import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
 import io.ktor.server.plugins.NotFoundException
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -18,7 +19,8 @@ class WebhookRepositoryExposed(
 ) : WebhookRepository {
     override suspend fun sendWebhooks(
         eventSlug: String,
-        partnershipId: UUID,
+        resourceType: WebhookResourceType,
+        resourceId: UUID,
         eventType: WebhookEventType,
     ) {
         val eventId = transaction {
@@ -33,7 +35,7 @@ class WebhookRepositoryExposed(
         for (integration in integrations) {
             val gateway = webhookGateways.find { it.provider == integration.provider }
                 ?: throw NotFoundException("No gateway for provider ${integration.provider}")
-            gateway.sendWebhook(integration.id.value, eventId, partnershipId, eventType)
+            gateway.sendWebhook(integration.id.value, eventId, resourceType, resourceId, eventType)
         }
     }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookGateway.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookGateway.kt
@@ -9,6 +9,8 @@ enum class WebhookEventType {
     DELETED,
 }
 
+enum class WebhookResourceType { PARTNERSHIP, ECOSYSTEM_PARTNER }
+
 interface WebhookGateway {
     val provider: IntegrationProvider
 
@@ -18,7 +20,8 @@ interface WebhookGateway {
     suspend fun sendWebhook(
         integrationId: UUID,
         eventId: UUID,
-        partnershipId: UUID,
+        resourceType: WebhookResourceType,
+        resourceId: UUID,
         eventType: WebhookEventType,
     ): Boolean
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookPayload.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookPayload.kt
@@ -7,18 +7,46 @@ import fr.devlille.partners.connect.events.domain.EventSummary
 import fr.devlille.partners.connect.partnership.domain.BoothActivity
 import fr.devlille.partners.connect.partnership.domain.PartnershipDetail
 import fr.devlille.partners.connect.partnership.domain.QandaQuestion
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class WebhookPayload(
-    val eventType: WebhookEventType,
-    val partnership: PartnershipDetail,
-    val company: Company,
-    val event: EventSummary,
-    val jobs: List<JobOffer>,
-    val activities: List<BoothActivity>,
-    val questions: List<QandaQuestion>,
-    val speakers: List<Speaker>,
-    val supportVideoUrl: String? = null,
-    val timestamp: String,
-)
+sealed class WebhookPayload {
+    abstract val eventType: WebhookEventType
+    abstract val resourceType: WebhookResourceType
+    abstract val resourceId: String
+    abstract val company: Company
+    abstract val event: EventSummary
+    abstract val timestamp: String
+
+    @Serializable
+    @SerialName("partnership")
+    data class Partnership(
+        override val eventType: WebhookEventType,
+        override val resourceId: String,
+        override val company: Company,
+        override val event: EventSummary,
+        override val timestamp: String,
+        val partnership: PartnershipDetail,
+        val jobs: List<JobOffer>,
+        val activities: List<BoothActivity>,
+        val questions: List<QandaQuestion>,
+        val speakers: List<Speaker>,
+        val supportVideoUrl: String? = null,
+    ) : WebhookPayload() {
+        override val resourceType: WebhookResourceType = WebhookResourceType.PARTNERSHIP
+    }
+
+    @Serializable
+    @SerialName("ecosystem_partner")
+    data class EcosystemPartner(
+        override val eventType: WebhookEventType,
+        override val resourceId: String,
+        override val company: Company,
+        override val event: EventSummary,
+        override val timestamp: String,
+        val category: String,
+    ) : WebhookPayload() {
+        override val resourceType: WebhookResourceType = WebhookResourceType.ECOSYSTEM_PARTNER
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookRepository.kt
@@ -4,11 +4,12 @@ import java.util.UUID
 
 interface WebhookRepository {
     /**
-     * Send webhook notifications for a partnership event to all configured webhook gateways
+     * Send webhook notifications for a resource event to all configured webhook gateways
      */
     suspend fun sendWebhooks(
         eventSlug: String,
-        partnershipId: UUID,
+        resourceType: WebhookResourceType,
+        resourceId: UUID,
         eventType: WebhookEventType,
     )
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/infrastructure/gateways/HttpWebhookGateway.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/infrastructure/gateways/HttpWebhookGateway.kt
@@ -4,6 +4,7 @@ import fr.devlille.partners.connect.agenda.domain.Speaker
 import fr.devlille.partners.connect.companies.application.mappers.toDomain
 import fr.devlille.partners.connect.companies.infrastructure.db.CompanyJobOfferPromotionEntity
 import fr.devlille.partners.connect.companies.infrastructure.db.CompanySocialEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
 import fr.devlille.partners.connect.events.domain.EventSummary
 import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
 import fr.devlille.partners.connect.integrations.domain.IntegrationProvider
@@ -26,6 +27,7 @@ import fr.devlille.partners.connect.partnership.infrastructure.db.validatedPack
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookGateway
 import fr.devlille.partners.connect.webhooks.domain.WebhookPayload
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
 import io.ktor.client.HttpClient
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
@@ -45,11 +47,11 @@ class HttpWebhookGateway(
 ) : WebhookGateway {
     override val provider = IntegrationProvider.WEBHOOK
 
-    @Suppress("LongMethod")
     override suspend fun sendWebhook(
         integrationId: UUID,
         eventId: UUID,
-        partnershipId: UUID,
+        resourceType: WebhookResourceType,
+        resourceId: UUID,
         eventType: WebhookEventType,
     ): Boolean {
         // Get integration configuration and check permissions in transaction
@@ -59,7 +61,8 @@ class HttpWebhookGateway(
             // Check if we can send webhook based on config type
             val canSend = when (webhookConfig.type) {
                 WebhookType.ALL -> true
-                WebhookType.PARTNERSHIP -> webhookConfig.partnershipId == partnershipId
+                WebhookType.PARTNERSHIP ->
+                    resourceType == WebhookResourceType.PARTNERSHIP && webhookConfig.partnershipId == resourceId
             }
 
             if (!canSend) null else webhookConfig
@@ -68,69 +71,9 @@ class HttpWebhookGateway(
         // If we can't send webhook, return false
         if (config == null) return false
 
-        // Get partnership entity and throw NotFoundException if it doesn't exist
-        val payload = transaction {
-            val eventEntity = EventEntity.findById(eventId) ?: throw NotFoundException("Event not found")
-            val billing = BillingEntity.singleByEventAndPartnership(eventEntity.id.value, partnershipId)
-            val partnership = PartnershipEntity.findById(partnershipId)
-                ?: throw NotFoundException("Partnership not found")
-            val jobs = CompanyJobOfferPromotionEntity
-                .listByPartnershipAndStatus(partnershipId, status = PromotionStatus.APPROVED)
-                .map { it.jobOffer.toDomain() }
-            val activities = BoothActivityEntity
-                .find { BoothActivitiesTable.partnershipId eq partnershipId }
-                .map { it.toDomain() }
-            val questions = QandaQuestionEntity
-                .find { QandaQuestionsTable.partnershipId eq partnershipId }
-                .map { it.toDomain() }
-            val speakers = SpeakerPartnershipEntity
-                .find { SpeakerPartnershipTable.partnershipId eq partnershipId }
-                .map { association ->
-                    val s = association.speaker
-                    Speaker(
-                        id = s.id.value.toString(),
-                        name = s.name,
-                        biography = s.biography,
-                        jobTitle = s.jobTitle,
-                        photoUrl = s.photoUrl,
-                        pronouns = s.pronouns,
-                        company = s.company?.name,
-                        externalId = s.externalId,
-                        source = s.sourceProvider.name.lowercase(),
-                    )
-                }
-                .sortedBy { it.name }
-            val supportVideoUrl = PartnershipSupportVideoEntity.singleByPartnership(partnershipId)
-                ?.takeIf { it.status == PromotionStatus.APPROVED }
-                ?.url
-            WebhookPayload(
-                eventType = eventType,
-                partnership = partnership.toDetailedDomain(
-                    billing = billing,
-                    selectedPack = partnership.selectedPack
-                        ?.toDomain(language = partnership.language, partnershipId = partnershipId),
-                    suggestionPack = partnership.suggestionPack
-                        ?.toDomain(language = partnership.language, partnershipId = partnershipId),
-                    validatedPack = partnership.validatedPack()
-                        ?.toDomain(language = partnership.language, partnershipId = partnershipId),
-                ),
-                company = partnership.company
-                    .toDomain(partnership.company.socials.map(CompanySocialEntity::toDomain)),
-                event = EventSummary(
-                    slug = eventEntity.slug,
-                    name = eventEntity.name,
-                    startTime = eventEntity.startTime,
-                    endTime = eventEntity.endTime,
-                    submissionStartTime = eventEntity.submissionStartTime,
-                    submissionEndTime = eventEntity.submissionEndTime,
-                ),
-                jobs = jobs,
-                activities = activities,
-                questions = questions,
-                speakers = speakers,
-                supportVideoUrl = supportVideoUrl,
-                timestamp = Clock.System.now().toString(),
-            )
+        val payload: WebhookPayload = when (resourceType) {
+            WebhookResourceType.PARTNERSHIP -> buildPartnershipPayload(eventId, resourceId, eventType)
+            WebhookResourceType.ECOSYSTEM_PARTNER -> buildEcosystemPartnerPayload(eventId, resourceId, eventType)
         }
 
         // Send HTTP call
@@ -146,5 +89,100 @@ class HttpWebhookGateway(
         }
 
         return response.status.isSuccess()
+    }
+
+    @Suppress("LongMethod")
+    private fun buildPartnershipPayload(
+        eventId: UUID,
+        resourceId: UUID,
+        eventType: WebhookEventType,
+    ): WebhookPayload.Partnership = transaction {
+        val eventEntity = EventEntity.findById(eventId) ?: throw NotFoundException("Event not found")
+        val billing = BillingEntity.singleByEventAndPartnership(eventEntity.id.value, resourceId)
+        val partnership = PartnershipEntity.findById(resourceId)
+            ?: throw NotFoundException("Partnership not found")
+        val jobs = CompanyJobOfferPromotionEntity
+            .listByPartnershipAndStatus(resourceId, status = PromotionStatus.APPROVED)
+            .map { it.jobOffer.toDomain() }
+        val activities = BoothActivityEntity
+            .find { BoothActivitiesTable.partnershipId eq resourceId }
+            .map { it.toDomain() }
+        val questions = QandaQuestionEntity
+            .find { QandaQuestionsTable.partnershipId eq resourceId }
+            .map { it.toDomain() }
+        val speakers = SpeakerPartnershipEntity
+            .find { SpeakerPartnershipTable.partnershipId eq resourceId }
+            .map { association ->
+                val s = association.speaker
+                Speaker(
+                    id = s.id.value.toString(),
+                    name = s.name,
+                    biography = s.biography,
+                    jobTitle = s.jobTitle,
+                    photoUrl = s.photoUrl,
+                    pronouns = s.pronouns,
+                    company = s.company?.name,
+                    externalId = s.externalId,
+                    source = s.sourceProvider.name.lowercase(),
+                )
+            }
+            .sortedBy { it.name }
+        val supportVideoUrl = PartnershipSupportVideoEntity.singleByPartnership(resourceId)
+            ?.takeIf { it.status == PromotionStatus.APPROVED }
+            ?.url
+        WebhookPayload.Partnership(
+            eventType = eventType,
+            resourceId = resourceId.toString(),
+            partnership = partnership.toDetailedDomain(
+                billing = billing,
+                selectedPack = partnership.selectedPack
+                    ?.toDomain(language = partnership.language, partnershipId = resourceId),
+                suggestionPack = partnership.suggestionPack
+                    ?.toDomain(language = partnership.language, partnershipId = resourceId),
+                validatedPack = partnership.validatedPack()
+                    ?.toDomain(language = partnership.language, partnershipId = resourceId),
+            ),
+            company = partnership.company
+                .toDomain(partnership.company.socials.map(CompanySocialEntity::toDomain)),
+            event = EventSummary(
+                slug = eventEntity.slug,
+                name = eventEntity.name,
+                startTime = eventEntity.startTime,
+                endTime = eventEntity.endTime,
+                submissionStartTime = eventEntity.submissionStartTime,
+                submissionEndTime = eventEntity.submissionEndTime,
+            ),
+            jobs = jobs,
+            activities = activities,
+            questions = questions,
+            speakers = speakers,
+            supportVideoUrl = supportVideoUrl,
+            timestamp = Clock.System.now().toString(),
+        )
+    }
+
+    private fun buildEcosystemPartnerPayload(
+        eventId: UUID,
+        resourceId: UUID,
+        eventType: WebhookEventType,
+    ): WebhookPayload.EcosystemPartner = transaction {
+        val eventEntity = EventEntity.findById(eventId) ?: throw NotFoundException("Event not found")
+        val partner = EcosystemPartnerEntity.findById(resourceId)
+            ?: throw NotFoundException("Ecosystem partner not found")
+        WebhookPayload.EcosystemPartner(
+            eventType = eventType,
+            resourceId = resourceId.toString(),
+            company = partner.company.toDomain(partner.company.socials.map(CompanySocialEntity::toDomain)),
+            event = EventSummary(
+                slug = eventEntity.slug,
+                name = eventEntity.name,
+                startTime = eventEntity.startTime,
+                endTime = eventEntity.endTime,
+                submissionStartTime = eventEntity.submissionStartTime,
+                submissionEndTime = eventEntity.submissionEndTime,
+            ),
+            timestamp = Clock.System.now().toString(),
+            category = partner.category.name,
+        )
     }
 }

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/content.en.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/content.en.html
@@ -1,0 +1,9 @@
+Hello,
+<br><br>
+We regret to inform you that your submission for <strong>{{company_name}}</strong> as a {{category_name}} partner for <strong>{{event_name}}</strong> has been declined.
+<br><br>
+For any questions, please contact us at {{event_contact}}.
+<br><br>
+Best regards,
+<br>
+The {{event_name}} Team

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/content.fr.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/content.fr.html
@@ -1,0 +1,9 @@
+Bonjour,
+<br><br>
+Nous regrettons de vous informer que votre inscription pour <strong>{{company_name}}</strong> en tant que partenaire {{category_name}} pour <strong>{{event_name}}</strong> a été refusée.
+<br><br>
+Pour toute question, contactez-nous à {{event_contact}}.
+<br><br>
+Cordialement,
+<br>
+L'équipe {{event_name}}

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/header.en.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/header.en.txt
@@ -1,0 +1,1 @@
+Your ecosystem partner submission was declined

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/header.fr.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_declined/header.fr.txt
@@ -1,0 +1,1 @@
+Votre inscription partenaire écosystème a été refusée

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/content.en.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/content.en.html
@@ -1,0 +1,9 @@
+Hello,
+<br><br>
+The listing for <strong>{{company_name}}</strong> as a {{category_name}} partner for <strong>{{event_name}}</strong> has been removed by the event organisers.
+<br><br>
+If you have questions, please contact us at {{event_contact}}.
+<br><br>
+Best regards,
+<br>
+The {{event_name}} Team

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/content.fr.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/content.fr.html
@@ -1,0 +1,9 @@
+Bonjour,
+<br><br>
+L'inscription de <strong>{{company_name}}</strong> en tant que partenaire {{category_name}} pour <strong>{{event_name}}</strong> a été supprimée par les organisateurs.
+<br><br>
+Pour toute question, contactez-nous à {{event_contact}}.
+<br><br>
+Cordialement,
+<br>
+L'équipe {{event_name}}

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/header.en.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/header.en.txt
@@ -1,0 +1,1 @@
+Your ecosystem partner listing has been removed

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/header.fr.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_removed/header.fr.txt
@@ -1,0 +1,1 @@
+Votre inscription partenaire écosystème a été supprimée

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/content.en.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/content.en.html
@@ -1,0 +1,13 @@
+Hello,
+<br><br>
+Thanks for submitting <strong>{{company_name}}</strong> as a {{category_name}} partner for <strong>{{event_name}}</strong>.
+<br><br>
+Your submission is now pending review by the event organisers. You will receive an email once it is validated or declined.
+<br><br>
+Event page: <a href="{{public_event_url}}">{{event_name}}</a>
+<br><br>
+For any questions, please contact us at {{event_contact}}.
+<br><br>
+Best regards,
+<br>
+The {{event_name}} Team

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/content.fr.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/content.fr.html
@@ -1,0 +1,13 @@
+Bonjour,
+<br><br>
+Merci d'avoir inscrit <strong>{{company_name}}</strong> en tant que partenaire {{category_name}} pour <strong>{{event_name}}</strong>.
+<br><br>
+Votre inscription est en attente de validation par les organisateurs. Vous recevrez un email une fois qu'elle aura été validée ou refusée.
+<br><br>
+Page de l'événement : <a href="{{public_event_url}}">{{event_name}}</a>
+<br><br>
+Pour toute question, contactez-nous à {{event_contact}}.
+<br><br>
+Cordialement,
+<br>
+L'équipe {{event_name}}

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/header.en.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/header.en.txt
@@ -1,0 +1,1 @@
+Ecosystem partner submission received

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/header.fr.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_submitted/header.fr.txt
@@ -1,0 +1,1 @@
+Inscription partenaire écosystème reçue

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/content.en.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/content.en.html
@@ -1,0 +1,11 @@
+Hello,
+<br><br>
+Great news! Your submission for <strong>{{company_name}}</strong> as a {{category_name}} partner for <strong>{{event_name}}</strong> has been validated.
+<br><br>
+Your logo and link will now appear on the public event page: <a href="{{public_event_url}}">{{event_name}}</a>
+<br><br>
+For any questions, please contact us at {{event_contact}}.
+<br><br>
+Best regards,
+<br>
+The {{event_name}} Team

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/content.fr.html
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/content.fr.html
@@ -1,0 +1,11 @@
+Bonjour,
+<br><br>
+Bonne nouvelle ! Votre inscription pour <strong>{{company_name}}</strong> en tant que partenaire {{category_name}} pour <strong>{{event_name}}</strong> a été validée.
+<br><br>
+Votre logo et votre lien apparaîtront désormais sur la page publique de l'événement : <a href="{{public_event_url}}">{{event_name}}</a>
+<br><br>
+Pour toute question, contactez-nous à {{event_contact}}.
+<br><br>
+Cordialement,
+<br>
+L'équipe {{event_name}}

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/header.en.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/header.en.txt
@@ -1,0 +1,1 @@
+Your ecosystem partner submission has been validated

--- a/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/header.fr.txt
+++ b/server/application/src/main/resources/notifications/email/ecosystem_partner_validated/header.fr.txt
@@ -1,0 +1,1 @@
+Votre inscription partenaire écosystème a été validée

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_declined/en.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_declined/en.md
@@ -1,0 +1,1 @@
+Ecosystem partner submission *{{company_name}}* ({{category_name}}) declined for {{event_name}}.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_declined/fr.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_declined/fr.md
@@ -1,0 +1,1 @@
+Inscription partenaire écosystème *{{company_name}}* ({{category_name}}) refusée pour {{event_name}}.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_removed/en.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_removed/en.md
@@ -1,0 +1,1 @@
+Ecosystem partner *{{company_name}}* ({{category_name}}) listing removed from {{event_name}}.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_removed/fr.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_removed/fr.md
@@ -1,0 +1,1 @@
+Inscription partenaire écosystème *{{company_name}}* ({{category_name}}) supprimée de {{event_name}}.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_submitted/en.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_submitted/en.md
@@ -1,0 +1,1 @@
+New ecosystem partner submission: *{{company_name}}* ({{category_name}}) for {{event_name}}. Awaiting validation.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_submitted/fr.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_submitted/fr.md
@@ -1,0 +1,1 @@
+Nouvelle inscription partenaire écosystème : *{{company_name}}* ({{category_name}}) pour {{event_name}}. En attente de validation.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_validated/en.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_validated/en.md
@@ -1,0 +1,1 @@
+Ecosystem partner *{{company_name}}* ({{category_name}}) validated for {{event_name}}.

--- a/server/application/src/main/resources/notifications/slack/ecosystem_partner_validated/fr.md
+++ b/server/application/src/main/resources/notifications/slack/ecosystem_partner_validated/fr.md
@@ -1,0 +1,1 @@
+Partenaire écosystème *{{company_name}}* ({{category_name}}) validé pour {{event_name}}.

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -6621,13 +6621,6 @@ components:
         mapping:
           partnership: '#/components/schemas/WebhookPartnershipPayload'
           ecosystem_partner: '#/components/schemas/WebhookEcosystemPartnerPayload'
-    WebhookEventType:
-      type: string
-      description: Type of event that triggered the webhook.
-      enum:
-        - CREATED
-        - UPDATED
-        - DELETED
     WebhookPartnershipPayload:
       type: object
       description: Webhook payload emitted when a partnership resource is created, updated or deleted.
@@ -6647,7 +6640,12 @@ components:
             - partnership
           description: Discriminator value identifying this variant.
         event_type:
-          $ref: '#/components/schemas/WebhookEventType'
+          type: string
+          enum:
+            - CREATED
+            - UPDATED
+            - DELETED
+          description: Type of event that triggered the webhook.
         resource_type:
           type: string
           enum:
@@ -6711,7 +6709,12 @@ components:
             - ecosystem_partner
           description: Discriminator value identifying this variant.
         event_type:
-          $ref: '#/components/schemas/WebhookEventType'
+          type: string
+          enum:
+            - CREATED
+            - UPDATED
+            - DELETED
+          description: Type of event that triggered the webhook.
         resource_type:
           type: string
           enum:

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -5823,6 +5823,582 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/organisation_item.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partner-categories:
+    post:
+      tags:
+        - ecosystem-partner-categories
+      summary: Create ecosystem partner category
+      operationId: postOrgsEventsEcosystemPartnerCategory
+      description: Create a new ecosystem partner category for an event. Categories group public partners (community sponsors, media partners, etc.) for display on the public event page.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          description: Organisation slug identifier.
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          description: Event slug identifier.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/register_ecosystem_partner_category.schema'
+      responses:
+        '201':
+          description: Created - Category created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identifier.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - A category with the same name already exists for this event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+    get:
+      tags:
+        - ecosystem-partner-categories
+      summary: List ecosystem partner categories
+      operationId: getOrgsEventsEcosystemPartnerCategories
+      description: List all ecosystem partner categories defined for the event, ordered by display order then name.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          description: Organisation slug identifier.
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          description: Event slug identifier.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK - List of categories.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ecosystem_partner_category.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partner-categories/{categoryId}:
+    put:
+      tags:
+        - ecosystem-partner-categories
+      summary: Update ecosystem partner category
+      operationId: putOrgsEventsEcosystemPartnerCategory
+      description: Update name and/or display order of an existing ecosystem partner category. All fields are optional for partial updates.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: categoryId
+          in: path
+          required: true
+          description: Ecosystem partner category UUID.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/update_ecosystem_partner_category.schema'
+      responses:
+        '200':
+          description: OK - Updated category.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ecosystem_partner_category.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Category or event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - Another category with the same name already exists for this event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+    delete:
+      tags:
+        - ecosystem-partner-categories
+      summary: Delete ecosystem partner category
+      operationId: deleteOrgsEventsEcosystemPartnerCategory
+      description: Delete an ecosystem partner category. The operation fails if the category is referenced by any ecosystem partner.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: categoryId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: No Content - Category deleted successfully.
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Category or event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - Category is still referenced by one or more ecosystem partners.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /events/{eventSlug}/ecosystem-partner-categories:
+    get:
+      tags:
+        - ecosystem-partner-categories
+      summary: Public list of ecosystem partner categories
+      operationId: getEventsEcosystemPartnerCategories
+      description: Public endpoint listing ecosystem partner categories for an event. Used by the public submission form to populate the category dropdown.
+      security:
+        - {}
+      parameters:
+        - name: eventSlug
+          in: path
+          required: true
+          description: Event slug identifier.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK - List of categories.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ecosystem_partner_category.schema'
+        '404':
+          description: Not Found - Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /events/{eventSlug}/ecosystem-partners:
+    post:
+      tags:
+        - ecosystem-partners
+      summary: Submit ecosystem partner
+      operationId: postEventsEcosystemPartners
+      description: Public endpoint allowing a company to submit itself as an ecosystem partner for an event. The submission lands in a pending state until an organiser validates or declines it.
+      security:
+        - {}
+      parameters:
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/register_ecosystem_partner.schema'
+      responses:
+        '201':
+          description: Created - Submission accepted, awaiting organiser review.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identifier.schema'
+        '404':
+          description: Not Found - Event, company or category does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - This company is already submitted as an ecosystem partner for the event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+    get:
+      tags:
+        - ecosystem-partners
+      summary: Public listing of validated ecosystem partners
+      operationId: getEventsEcosystemPartners
+      description: Public endpoint returning validated ecosystem partners grouped by category. Used to render the public event page.
+      security:
+        - {}
+      parameters:
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK - Validated ecosystem partners grouped by category.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/public_ecosystem_partner_group.schema'
+        '404':
+          description: Not Found - Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}:
+    get:
+      tags:
+        - ecosystem-partners
+      summary: Get ecosystem partner
+      operationId: getEventsEcosystemPartner
+      description: Public endpoint returning a single ecosystem partner submission by id. Used by the partner self-service edit form.
+      security:
+        - {}
+      parameters:
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ecosystemPartnerId
+          in: path
+          required: true
+          description: Ecosystem partner UUID.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK - Ecosystem partner details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ecosystem_partner.schema'
+        '404':
+          description: Not Found - Ecosystem partner or event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+    put:
+      tags:
+        - ecosystem-partners
+      summary: Update ecosystem partner submission
+      operationId: putEventsEcosystemPartner
+      description: Public endpoint allowing the submitter to update an ecosystem partner. All fields are optional; only provided fields are updated. Triggers an updated webhook to subscribers.
+      security:
+        - {}
+      parameters:
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ecosystemPartnerId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/update_ecosystem_partner.schema'
+      responses:
+        '200':
+          description: OK - Updated ecosystem partner.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ecosystem_partner.schema'
+        '404':
+          description: Not Found - Ecosystem partner, event or category does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners:
+    get:
+      tags:
+        - ecosystem-partners
+      summary: List ecosystem partners (organiser)
+      operationId: getOrgsEventsEcosystemPartners
+      description: List ecosystem partner submissions for an event, with optional filters by category and validation/decline state. Intended for the organiser dashboard.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: filter[category_id]
+          in: query
+          required: false
+          description: Filter by ecosystem partner category UUID.
+          schema:
+            type: string
+            format: uuid
+        - name: filter[validated]
+          in: query
+          required: false
+          description: Filter by validation status. When true, only validated partners are returned.
+          schema:
+            type: boolean
+        - name: filter[declined]
+          in: query
+          required: false
+          description: Filter by declined status. When absent or false (default), declined ecosystem partners are excluded from results. When true, declined partners are included.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK - List of ecosystem partners matching the filters.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ecosystem_partner_item.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}:
+    delete:
+      tags:
+        - ecosystem-partners
+      summary: Delete ecosystem partner
+      operationId: deleteOrgsEventsEcosystemPartner
+      description: Delete an ecosystem partner submission. Sends a removal notification to the partner and triggers a deleted webhook to subscribers.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ecosystemPartnerId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: No Content - Ecosystem partner deleted successfully.
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Ecosystem partner or event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/validate:
+    post:
+      tags:
+        - ecosystem-partners
+      summary: Validate ecosystem partner
+      operationId: postOrgsEventsEcosystemPartnerValidate
+      description: Validate a pending ecosystem partner submission. The partner becomes visible on the public listing, the submitter receives a validation notification, and an updated webhook is sent.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ecosystemPartnerId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK - Ecosystem partner validated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identifier.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Ecosystem partner or event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - Ecosystem partner has already been validated or declined.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline:
+    post:
+      tags:
+        - ecosystem-partners
+      summary: Decline ecosystem partner
+      operationId: postOrgsEventsEcosystemPartnerDecline
+      description: Decline a pending ecosystem partner submission. The partner is hidden from the public listing, the submitter receives a decline notification, and an updated webhook is sent.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventSlug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ecosystemPartnerId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK - Ecosystem partner declined.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identifier.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Ecosystem partner or event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - Ecosystem partner has already been validated or declined.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
 components:
   securitySchemes:
     bearerAuth:
@@ -5875,6 +6451,24 @@ components:
       $ref: '#/components/schemas/organisation.schema'
     EventWithOrganisation:
       $ref: '#/components/schemas/event_with_organisation.schema'
+    EcosystemPartner:
+      $ref: '#/components/schemas/ecosystem_partner.schema'
+    EcosystemPartnerCategory:
+      $ref: '#/components/schemas/ecosystem_partner_category.schema'
+    EcosystemPartnerItem:
+      $ref: '#/components/schemas/ecosystem_partner_item.schema'
+    PublicEcosystemPartner:
+      $ref: '#/components/schemas/public_ecosystem_partner.schema'
+    PublicEcosystemPartnerGroup:
+      $ref: '#/components/schemas/public_ecosystem_partner_group.schema'
+    RegisterEcosystemPartner:
+      $ref: '#/components/schemas/register_ecosystem_partner.schema'
+    RegisterEcosystemPartnerCategory:
+      $ref: '#/components/schemas/register_ecosystem_partner_category.schema'
+    UpdateEcosystemPartner:
+      $ref: '#/components/schemas/update_ecosystem_partner.schema'
+    UpdateEcosystemPartnerCategory:
+      $ref: '#/components/schemas/update_ecosystem_partner_category.schema'
     RegisterPartnership:
       $ref: '#/components/schemas/register_partnership.schema'
     UpdatePartnershipContactInfo:
@@ -6029,6 +6623,126 @@ components:
       $ref: '#/components/schemas/partnership_qanda_summary.schema'
     PartnershipQandaSummaryList:
       $ref: '#/components/schemas/partnership_qanda_summary_list.schema'
+    WebhookPayload:
+      description: Polymorphic webhook payload sent to subscribers. The `type` discriminator selects between a partnership notification and an ecosystem partner notification.
+      oneOf:
+        - $ref: '#/components/schemas/WebhookPartnershipPayload'
+        - $ref: '#/components/schemas/WebhookEcosystemPartnerPayload'
+      discriminator:
+        propertyName: type
+        mapping:
+          partnership: '#/components/schemas/WebhookPartnershipPayload'
+          ecosystem_partner: '#/components/schemas/WebhookEcosystemPartnerPayload'
+    WebhookEventType:
+      type: string
+      description: Type of event that triggered the webhook.
+      enum:
+        - CREATED
+        - UPDATED
+        - DELETED
+    WebhookPartnershipPayload:
+      type: object
+      description: Webhook payload emitted when a partnership resource is created, updated or deleted.
+      required:
+        - type
+        - event_type
+        - resource_type
+        - resource_id
+        - company
+        - event
+        - timestamp
+        - partnership
+      properties:
+        type:
+          type: string
+          enum:
+            - partnership
+          description: Discriminator value identifying this variant.
+        event_type:
+          $ref: '#/components/schemas/WebhookEventType'
+        resource_type:
+          type: string
+          enum:
+            - PARTNERSHIP
+        resource_id:
+          type: string
+          format: uuid
+          description: Identifier of the partnership resource.
+        company:
+          $ref: '#/components/schemas/company.schema'
+        event:
+          $ref: '#/components/schemas/event_summary.schema'
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO-8601 timestamp at which the webhook was emitted.
+        partnership:
+          $ref: '#/components/schemas/partnership_detail.schema'
+        jobs:
+          type: array
+          description: Job offers attached to the partnership.
+          items:
+            $ref: '#/components/schemas/job_offer_response.schema'
+        activities:
+          type: array
+          description: Booth activities attached to the partnership.
+          items:
+            $ref: '#/components/schemas/booth_activity_response.schema'
+        questions:
+          type: array
+          description: Partnership Q&A questions and answers.
+          items:
+            $ref: '#/components/schemas/qanda_question.schema'
+        speakers:
+          type: array
+          description: Speakers attached to the partnership.
+          items:
+            $ref: '#/components/schemas/speaker.schema'
+        support_video_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+          description: URL of the validated support video, if any.
+    WebhookEcosystemPartnerPayload:
+      type: object
+      description: Webhook payload emitted when an ecosystem partner resource is created, updated or deleted.
+      required:
+        - type
+        - event_type
+        - resource_type
+        - resource_id
+        - company
+        - event
+        - timestamp
+        - category
+      properties:
+        type:
+          type: string
+          enum:
+            - ecosystem_partner
+          description: Discriminator value identifying this variant.
+        event_type:
+          $ref: '#/components/schemas/WebhookEventType'
+        resource_type:
+          type: string
+          enum:
+            - ECOSYSTEM_PARTNER
+        resource_id:
+          type: string
+          format: uuid
+          description: Identifier of the ecosystem partner resource.
+        company:
+          $ref: '#/components/schemas/company.schema'
+        event:
+          $ref: '#/components/schemas/event_summary.schema'
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO-8601 timestamp at which the webhook was emitted.
+        category:
+          type: string
+          description: Display name of the ecosystem partner category.
     user_session.schema:
       $id: user_session.schema.json
       type: object
@@ -9840,6 +10554,249 @@ components:
         - revoked_count
         - not_found_emails
       additionalProperties: false
+    ecosystem_partner_category.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: EcosystemPartnerCategory
+      type: object
+      required:
+        - id
+        - event_id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+    register_ecosystem_partner_category.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: RegisterEcosystemPartnerCategory
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+    update_ecosystem_partner_category.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: UpdateEcosystemPartnerCategory
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type:
+            - string
+            - 'null'
+          minLength: 1
+          maxLength: 100
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+    public_ecosystem_partner.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: PublicEcosystemPartner
+      type: object
+      required:
+        - id
+        - company_name
+      properties:
+        id:
+          type: string
+          format: uuid
+        company_name:
+          type: string
+        logo_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+        site_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+    public_ecosystem_partner_group.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: PublicEcosystemPartnerGroup
+      type: object
+      required:
+        - category
+        - partners
+      properties:
+        category:
+          type: string
+        partners:
+          type: array
+          items:
+            $ref: '#/components/schemas/public_ecosystem_partner.schema'
+    register_ecosystem_partner.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: RegisterEcosystemPartner
+      type: object
+      required:
+        - company_id
+        - category_id
+      additionalProperties: false
+      properties:
+        company_id:
+          type: string
+          format: uuid
+        category_id:
+          type: string
+          format: uuid
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+        language:
+          type: string
+          minLength: 2
+          maxLength: 5
+        emails:
+          type: array
+          items:
+            type: string
+            format: email
+    ecosystem_partner.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: EcosystemPartner
+      type: object
+      required:
+        - id
+        - event_id
+        - company_id
+        - category
+        - language
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_id:
+          type: string
+          format: uuid
+        company_id:
+          type: string
+          format: uuid
+        category:
+          $ref: '#/components/schemas/ecosystem_partner_category.schema'
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+        language:
+          type: string
+          minLength: 2
+          maxLength: 5
+        emails:
+          type: array
+          items:
+            type: string
+            format: email
+        validated_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        declined_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+    update_ecosystem_partner.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: UpdateEcosystemPartner
+      type: object
+      additionalProperties: false
+      properties:
+        category_id:
+          type:
+            - string
+            - 'null'
+          format: uuid
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+        language:
+          type:
+            - string
+            - 'null'
+          minLength: 2
+          maxLength: 5
+        emails:
+          type:
+            - array
+            - 'null'
+          items:
+            type: string
+            format: email
+    ecosystem_partner_item.schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: EcosystemPartnerItem
+      type: object
+      required:
+        - id
+        - company_name
+        - category
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        company_name:
+          type: string
+        company_logo_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+        category:
+          $ref: '#/components/schemas/ecosystem_partner_category.schema'
+        display_order:
+          type:
+            - integer
+            - 'null'
+          minimum: 0
+        validated_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        declined_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
     event.schema:
       $id: event.schema.json
       type: object

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -6342,12 +6342,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error_response.schema'
-        '409':
-          description: Conflict - Ecosystem partner has already been validated or declined.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error_response.schema'
   /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline:
     post:
       tags:
@@ -6389,12 +6383,6 @@ paths:
                 $ref: '#/components/schemas/error_response.schema'
         '404':
           description: Not Found - Ecosystem partner or event does not exist.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error_response.schema'
-        '409':
-          description: Conflict - Ecosystem partner has already been validated or declined.
           content:
             application/json:
               schema:

--- a/server/application/src/main/resources/openapi/openapi.yaml
+++ b/server/application/src/main/resources/openapi/openapi.yaml
@@ -6334,12 +6334,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "409":
-          description: "Conflict - Ecosystem partner has already been validated or declined."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline:
     post:
       tags:
@@ -6383,12 +6377,6 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: "Not Found - Ecosystem partner or event does not exist."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "409":
-          description: "Conflict - Ecosystem partner has already been validated or declined."
           content:
             application/json:
               schema:

--- a/server/application/src/main/resources/openapi/openapi.yaml
+++ b/server/application/src/main/resources/openapi/openapi.yaml
@@ -5803,6 +5803,596 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/OrganisationItem"
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partner-categories:
+    post:
+      tags:
+        - "ecosystem-partner-categories"
+      summary: "Create ecosystem partner category"
+      operationId: "postOrgsEventsEcosystemPartnerCategory"
+      description: >-
+        Create a new ecosystem partner category for an event. Categories group public
+        partners (community sponsors, media partners, etc.) for display on the public event page.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          description: "Organisation slug identifier."
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          description: "Event slug identifier."
+          schema:
+            type: "string"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterEcosystemPartnerCategory"
+      responses:
+        "201":
+          description: "Created - Category created successfully."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Identifier"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - A category with the same name already exists for this event."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      tags:
+        - "ecosystem-partner-categories"
+      summary: "List ecosystem partner categories"
+      operationId: "getOrgsEventsEcosystemPartnerCategories"
+      description: "List all ecosystem partner categories defined for the event, ordered by display order then name."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          description: "Organisation slug identifier."
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          description: "Event slug identifier."
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "OK - List of categories."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/EcosystemPartnerCategory"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partner-categories/{categoryId}:
+    put:
+      tags:
+        - "ecosystem-partner-categories"
+      summary: "Update ecosystem partner category"
+      operationId: "putOrgsEventsEcosystemPartnerCategory"
+      description: "Update name and/or display order of an existing ecosystem partner category. All fields are optional for partial updates."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "categoryId"
+          in: "path"
+          required: true
+          description: "Ecosystem partner category UUID."
+          schema:
+            type: "string"
+            format: "uuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEcosystemPartnerCategory"
+      responses:
+        "200":
+          description: "OK - Updated category."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EcosystemPartnerCategory"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Category or event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - Another category with the same name already exists for this event."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags:
+        - "ecosystem-partner-categories"
+      summary: "Delete ecosystem partner category"
+      operationId: "deleteOrgsEventsEcosystemPartnerCategory"
+      description: "Delete an ecosystem partner category. The operation fails if the category is referenced by any ecosystem partner."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "categoryId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+      responses:
+        "204":
+          description: "No Content - Category deleted successfully."
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Category or event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - Category is still referenced by one or more ecosystem partners."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /events/{eventSlug}/ecosystem-partner-categories:
+    get:
+      tags:
+        - "ecosystem-partner-categories"
+      summary: "Public list of ecosystem partner categories"
+      operationId: "getEventsEcosystemPartnerCategories"
+      description: "Public endpoint listing ecosystem partner categories for an event. Used by the public submission form to populate the category dropdown."
+      security:
+        - {}
+      parameters:
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          description: "Event slug identifier."
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "OK - List of categories."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/EcosystemPartnerCategory"
+        "404":
+          description: "Not Found - Event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /events/{eventSlug}/ecosystem-partners:
+    post:
+      tags:
+        - "ecosystem-partners"
+      summary: "Submit ecosystem partner"
+      operationId: "postEventsEcosystemPartners"
+      description: >-
+        Public endpoint allowing a company to submit itself as an ecosystem partner for an event.
+        The submission lands in a pending state until an organiser validates or declines it.
+      security:
+        - {}
+      parameters:
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterEcosystemPartner"
+      responses:
+        "201":
+          description: "Created - Submission accepted, awaiting organiser review."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Identifier"
+        "404":
+          description: "Not Found - Event, company or category does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - This company is already submitted as an ecosystem partner for the event."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      tags:
+        - "ecosystem-partners"
+      summary: "Public listing of validated ecosystem partners"
+      operationId: "getEventsEcosystemPartners"
+      description: "Public endpoint returning validated ecosystem partners grouped by category. Used to render the public event page."
+      security:
+        - {}
+      parameters:
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "OK - Validated ecosystem partners grouped by category."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/PublicEcosystemPartnerGroup"
+        "404":
+          description: "Not Found - Event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}:
+    get:
+      tags:
+        - "ecosystem-partners"
+      summary: "Get ecosystem partner"
+      operationId: "getEventsEcosystemPartner"
+      description: "Public endpoint returning a single ecosystem partner submission by id. Used by the partner self-service edit form."
+      security:
+        - {}
+      parameters:
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "ecosystemPartnerId"
+          in: "path"
+          required: true
+          description: "Ecosystem partner UUID."
+          schema:
+            type: "string"
+            format: "uuid"
+      responses:
+        "200":
+          description: "OK - Ecosystem partner details."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EcosystemPartner"
+        "404":
+          description: "Not Found - Ecosystem partner or event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - "ecosystem-partners"
+      summary: "Update ecosystem partner submission"
+      operationId: "putEventsEcosystemPartner"
+      description: >-
+        Public endpoint allowing the submitter to update an ecosystem partner. All fields are
+        optional; only provided fields are updated. Triggers an updated webhook to subscribers.
+      security:
+        - {}
+      parameters:
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "ecosystemPartnerId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEcosystemPartner"
+      responses:
+        "200":
+          description: "OK - Updated ecosystem partner."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EcosystemPartner"
+        "404":
+          description: "Not Found - Ecosystem partner, event or category does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners:
+    get:
+      tags:
+        - "ecosystem-partners"
+      summary: "List ecosystem partners (organiser)"
+      operationId: "getOrgsEventsEcosystemPartners"
+      description: >-
+        List ecosystem partner submissions for an event, with optional filters by category and
+        validation/decline state. Intended for the organiser dashboard.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "filter[category_id]"
+          in: "query"
+          required: false
+          description: "Filter by ecosystem partner category UUID."
+          schema:
+            type: "string"
+            format: "uuid"
+        - name: "filter[validated]"
+          in: "query"
+          required: false
+          description: "Filter by validation status. When true, only validated partners are returned."
+          schema:
+            type: "boolean"
+        - name: "filter[declined]"
+          in: "query"
+          required: false
+          description: >-
+            Filter by declined status. When absent or false (default), declined ecosystem partners
+            are excluded from results. When true, declined partners are included.
+          schema:
+            type: "boolean"
+      responses:
+        "200":
+          description: "OK - List of ecosystem partners matching the filters."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/EcosystemPartnerItem"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}:
+    delete:
+      tags:
+        - "ecosystem-partners"
+      summary: "Delete ecosystem partner"
+      operationId: "deleteOrgsEventsEcosystemPartner"
+      description: "Delete an ecosystem partner submission. Sends a removal notification to the partner and triggers a deleted webhook to subscribers."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "ecosystemPartnerId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+      responses:
+        "204":
+          description: "No Content - Ecosystem partner deleted successfully."
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Ecosystem partner or event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/validate:
+    post:
+      tags:
+        - "ecosystem-partners"
+      summary: "Validate ecosystem partner"
+      operationId: "postOrgsEventsEcosystemPartnerValidate"
+      description: >-
+        Validate a pending ecosystem partner submission. The partner becomes visible on the public
+        listing, the submitter receives a validation notification, and an updated webhook is sent.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "ecosystemPartnerId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+      responses:
+        "200":
+          description: "OK - Ecosystem partner validated."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Identifier"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Ecosystem partner or event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - Ecosystem partner has already been validated or declined."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline:
+    post:
+      tags:
+        - "ecosystem-partners"
+      summary: "Decline ecosystem partner"
+      operationId: "postOrgsEventsEcosystemPartnerDecline"
+      description: >-
+        Decline a pending ecosystem partner submission. The partner is hidden from the public
+        listing, the submitter receives a decline notification, and an updated webhook is sent.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "eventSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "ecosystemPartnerId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+      responses:
+        "200":
+          description: "OK - Ecosystem partner declined."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Identifier"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Ecosystem partner or event does not exist."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - Ecosystem partner has already been validated or declined."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   securitySchemes:
     bearerAuth:
@@ -5855,6 +6445,24 @@ components:
       $ref: "../schemas/organisation.schema.json"
     EventWithOrganisation:
       $ref: "../schemas/event_with_organisation.schema.json"
+    EcosystemPartner:
+      $ref: "../schemas/ecosystem_partner.schema.json"
+    EcosystemPartnerCategory:
+      $ref: "../schemas/ecosystem_partner_category.schema.json"
+    EcosystemPartnerItem:
+      $ref: "../schemas/ecosystem_partner_item.schema.json"
+    PublicEcosystemPartner:
+      $ref: "../schemas/public_ecosystem_partner.schema.json"
+    PublicEcosystemPartnerGroup:
+      $ref: "../schemas/public_ecosystem_partner_group.schema.json"
+    RegisterEcosystemPartner:
+      $ref: "../schemas/register_ecosystem_partner.schema.json"
+    RegisterEcosystemPartnerCategory:
+      $ref: "../schemas/register_ecosystem_partner_category.schema.json"
+    UpdateEcosystemPartner:
+      $ref: "../schemas/update_ecosystem_partner.schema.json"
+    UpdateEcosystemPartnerCategory:
+      $ref: "../schemas/update_ecosystem_partner_category.schema.json"
     RegisterPartnership:
       $ref: "../schemas/register_partnership.schema.json"
     UpdatePartnershipContactInfo:
@@ -6009,3 +6617,118 @@ components:
       $ref: "../schemas/partnership_qanda_summary.schema.json"
     PartnershipQandaSummaryList:
       $ref: "../schemas/partnership_qanda_summary_list.schema.json"
+    WebhookPayload:
+      description: >-
+        Polymorphic webhook payload sent to subscribers. The `type` discriminator
+        selects between a partnership notification and an ecosystem partner notification.
+      oneOf:
+        - $ref: "#/components/schemas/WebhookPartnershipPayload"
+        - $ref: "#/components/schemas/WebhookEcosystemPartnerPayload"
+      discriminator:
+        propertyName: type
+        mapping:
+          partnership: "#/components/schemas/WebhookPartnershipPayload"
+          ecosystem_partner: "#/components/schemas/WebhookEcosystemPartnerPayload"
+    WebhookEventType:
+      type: string
+      description: "Type of event that triggered the webhook."
+      enum: ["CREATED", "UPDATED", "DELETED"]
+    WebhookPartnershipPayload:
+      type: object
+      description: >-
+        Webhook payload emitted when a partnership resource is created, updated or deleted.
+      required:
+        - type
+        - event_type
+        - resource_type
+        - resource_id
+        - company
+        - event
+        - timestamp
+        - partnership
+      properties:
+        type:
+          type: string
+          enum: ["partnership"]
+          description: "Discriminator value identifying this variant."
+        event_type:
+          $ref: "#/components/schemas/WebhookEventType"
+        resource_type:
+          type: string
+          enum: ["PARTNERSHIP"]
+        resource_id:
+          type: string
+          format: uuid
+          description: "Identifier of the partnership resource."
+        company:
+          $ref: "#/components/schemas/Company"
+        event:
+          $ref: "#/components/schemas/EventSummary"
+        timestamp:
+          type: string
+          format: date-time
+          description: "ISO-8601 timestamp at which the webhook was emitted."
+        partnership:
+          $ref: "#/components/schemas/PartnershipDetail"
+        jobs:
+          type: array
+          description: "Job offers attached to the partnership."
+          items:
+            $ref: "#/components/schemas/JobOfferResponse"
+        activities:
+          type: array
+          description: "Booth activities attached to the partnership."
+          items:
+            $ref: "#/components/schemas/BoothActivityResponse"
+        questions:
+          type: array
+          description: "Partnership Q&A questions and answers."
+          items:
+            $ref: "#/components/schemas/QandaQuestion"
+        speakers:
+          type: array
+          description: "Speakers attached to the partnership."
+          items:
+            $ref: "#/components/schemas/Speaker"
+        support_video_url:
+          type: ["string", "null"]
+          format: uri
+          description: "URL of the validated support video, if any."
+    WebhookEcosystemPartnerPayload:
+      type: object
+      description: >-
+        Webhook payload emitted when an ecosystem partner resource is created, updated or deleted.
+      required:
+        - type
+        - event_type
+        - resource_type
+        - resource_id
+        - company
+        - event
+        - timestamp
+        - category
+      properties:
+        type:
+          type: string
+          enum: ["ecosystem_partner"]
+          description: "Discriminator value identifying this variant."
+        event_type:
+          $ref: "#/components/schemas/WebhookEventType"
+        resource_type:
+          type: string
+          enum: ["ECOSYSTEM_PARTNER"]
+        resource_id:
+          type: string
+          format: uuid
+          description: "Identifier of the ecosystem partner resource."
+        company:
+          $ref: "#/components/schemas/Company"
+        event:
+          $ref: "#/components/schemas/EventSummary"
+        timestamp:
+          type: string
+          format: date-time
+          description: "ISO-8601 timestamp at which the webhook was emitted."
+        category:
+          type: string
+          description: "Display name of the ecosystem partner category."

--- a/server/application/src/main/resources/openapi/openapi.yaml
+++ b/server/application/src/main/resources/openapi/openapi.yaml
@@ -6617,10 +6617,6 @@ components:
         mapping:
           partnership: "#/components/schemas/WebhookPartnershipPayload"
           ecosystem_partner: "#/components/schemas/WebhookEcosystemPartnerPayload"
-    WebhookEventType:
-      type: string
-      description: "Type of event that triggered the webhook."
-      enum: ["CREATED", "UPDATED", "DELETED"]
     WebhookPartnershipPayload:
       type: object
       description: >-
@@ -6640,7 +6636,9 @@ components:
           enum: ["partnership"]
           description: "Discriminator value identifying this variant."
         event_type:
-          $ref: "#/components/schemas/WebhookEventType"
+          type: string
+          enum: ["CREATED", "UPDATED", "DELETED"]
+          description: "Type of event that triggered the webhook."
         resource_type:
           type: string
           enum: ["PARTNERSHIP"]
@@ -6701,7 +6699,9 @@ components:
           enum: ["ecosystem_partner"]
           description: "Discriminator value identifying this variant."
         event_type:
-          $ref: "#/components/schemas/WebhookEventType"
+          type: string
+          enum: ["CREATED", "UPDATED", "DELETED"]
+          description: "Type of event that triggered the webhook."
         resource_type:
           type: string
           enum: ["ECOSYSTEM_PARTNER"]

--- a/server/application/src/main/resources/schemas/ecosystem_partner.schema.json
+++ b/server/application/src/main/resources/schemas/ecosystem_partner.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EcosystemPartner",
+  "type": "object",
+  "required": ["id", "event_id", "company_id", "category", "language", "created_at"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "event_id": { "type": "string", "format": "uuid" },
+    "company_id": { "type": "string", "format": "uuid" },
+    "category": { "$ref": "ecosystem_partner_category.schema.json" },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 },
+    "language": { "type": "string", "minLength": 2, "maxLength": 5 },
+    "emails": {
+      "type": "array",
+      "items": { "type": "string", "format": "email" }
+    },
+    "validated_at": { "type": ["string", "null"], "format": "date-time" },
+    "declined_at": { "type": ["string", "null"], "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/server/application/src/main/resources/schemas/ecosystem_partner_category.schema.json
+++ b/server/application/src/main/resources/schemas/ecosystem_partner_category.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EcosystemPartnerCategory",
+  "type": "object",
+  "required": ["id", "event_id", "name"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "event_id": { "type": "string", "format": "uuid" },
+    "name": { "type": "string", "minLength": 1, "maxLength": 100 },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 }
+  }
+}

--- a/server/application/src/main/resources/schemas/ecosystem_partner_item.schema.json
+++ b/server/application/src/main/resources/schemas/ecosystem_partner_item.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EcosystemPartnerItem",
+  "type": "object",
+  "required": ["id", "company_name", "category", "created_at"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "company_name": { "type": "string" },
+    "company_logo_url": { "type": ["string", "null"], "format": "uri" },
+    "category": { "$ref": "ecosystem_partner_category.schema.json" },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 },
+    "validated_at": { "type": ["string", "null"], "format": "date-time" },
+    "declined_at": { "type": ["string", "null"], "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/server/application/src/main/resources/schemas/public_ecosystem_partner.schema.json
+++ b/server/application/src/main/resources/schemas/public_ecosystem_partner.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PublicEcosystemPartner",
+  "type": "object",
+  "required": ["id", "company_name"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "company_name": { "type": "string" },
+    "logo_url": { "type": ["string", "null"], "format": "uri" },
+    "site_url": { "type": ["string", "null"], "format": "uri" }
+  }
+}

--- a/server/application/src/main/resources/schemas/public_ecosystem_partner_group.schema.json
+++ b/server/application/src/main/resources/schemas/public_ecosystem_partner_group.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PublicEcosystemPartnerGroup",
+  "type": "object",
+  "required": ["category", "partners"],
+  "properties": {
+    "category": { "type": "string" },
+    "partners": {
+      "type": "array",
+      "items": { "$ref": "public_ecosystem_partner.schema.json" }
+    }
+  }
+}

--- a/server/application/src/main/resources/schemas/register_ecosystem_partner.schema.json
+++ b/server/application/src/main/resources/schemas/register_ecosystem_partner.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RegisterEcosystemPartner",
+  "type": "object",
+  "required": ["company_id", "category_id"],
+  "additionalProperties": false,
+  "properties": {
+    "company_id": { "type": "string", "format": "uuid" },
+    "category_id": { "type": "string", "format": "uuid" },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 },
+    "language": { "type": "string", "minLength": 2, "maxLength": 5 },
+    "emails": {
+      "type": "array",
+      "items": { "type": "string", "format": "email" }
+    }
+  }
+}

--- a/server/application/src/main/resources/schemas/register_ecosystem_partner_category.schema.json
+++ b/server/application/src/main/resources/schemas/register_ecosystem_partner_category.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RegisterEcosystemPartnerCategory",
+  "type": "object",
+  "required": ["name"],
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": "string", "minLength": 1, "maxLength": 100 },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 }
+  }
+}

--- a/server/application/src/main/resources/schemas/update_ecosystem_partner.schema.json
+++ b/server/application/src/main/resources/schemas/update_ecosystem_partner.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UpdateEcosystemPartner",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "category_id": { "type": ["string", "null"], "format": "uuid" },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 },
+    "language": { "type": ["string", "null"], "minLength": 2, "maxLength": 5 },
+    "emails": {
+      "type": ["array", "null"],
+      "items": { "type": "string", "format": "email" }
+    }
+  }
+}

--- a/server/application/src/main/resources/schemas/update_ecosystem_partner_category.schema.json
+++ b/server/application/src/main/resources/schemas/update_ecosystem_partner_category.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UpdateEcosystemPartnerCategory",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": ["string", "null"], "minLength": 1, "maxLength": 100 },
+    "display_order": { "type": ["integer", "null"], "minimum": 0 }
+  }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/EcosystemPartnerLifecycleRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/EcosystemPartnerLifecycleRoutesTest.kt
@@ -1,0 +1,302 @@
+package fr.devlille.partners.connect.ecosystempartners
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.domain.RegisterPartnership
+import fr.devlille.partners.connect.partnership.domain.TextSelection
+import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipEntity
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedPackOptions
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringOption
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@Suppress("MaxLineLength")
+class EcosystemPartnerLifecycleRoutesTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Suppress("LongMethod") // Integration test requires comprehensive workflow validation
+    @Test
+    fun `full lifecycle - create category, submit, validate, list public, decline, listing drops it`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId, name = "ACME Media")
+            }
+        }
+
+        // 1. Create category
+        val createCategoryResponse = client.post("/orgs/$orgId/events/$eventId/ecosystem-partner-categories") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(
+                Json.encodeToString(
+                    RegisterEcosystemPartnerCategory.serializer(),
+                    RegisterEcosystemPartnerCategory(name = "Media", displayOrder = 1),
+                ),
+            )
+        }
+        assertEquals(HttpStatusCode.Created, createCategoryResponse.status)
+        val categoryId = json.parseToJsonElement(createCategoryResponse.bodyAsText())
+            .jsonObject["id"]!!
+            .jsonPrimitive
+            .content
+
+        // 2. Public submission
+        val submitResponse = client.post("/events/$eventId/ecosystem-partners") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                Json.encodeToString(
+                    RegisterEcosystemPartner.serializer(),
+                    RegisterEcosystemPartner(
+                        companyId = companyId.toString(),
+                        categoryId = categoryId,
+                        emails = listOf("contact@acme.test"),
+                    ),
+                ),
+            )
+        }
+        assertEquals(HttpStatusCode.Created, submitResponse.status)
+        val partnerId = json.parseToJsonElement(submitResponse.bodyAsText())
+            .jsonObject["id"]!!
+            .jsonPrimitive
+            .content
+
+        // 3. Public listing empty (not validated yet)
+        val publicBeforeValidate = client.get("/events/$eventId/ecosystem-partners")
+        assertEquals(HttpStatusCode.OK, publicBeforeValidate.status)
+        assertFalse(publicBeforeValidate.bodyAsText().contains("ACME Media"))
+
+        // 4. Validate
+        val validateResponse = client.post(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId/validate",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, validateResponse.status)
+
+        // 5. Public listing shows it
+        val publicAfterValidate = client.get("/events/$eventId/ecosystem-partners")
+        assertEquals(HttpStatusCode.OK, publicAfterValidate.status)
+        val publicAfterValidateBody = publicAfterValidate.bodyAsText()
+        assertTrue(publicAfterValidateBody.contains("ACME Media"))
+        assertTrue(publicAfterValidateBody.contains("Media"))
+
+        // 6. Decline
+        val declineResponse = client.post(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId/decline",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, declineResponse.status)
+
+        // 7. Public listing drops it
+        val publicAfterDecline = client.get("/events/$eventId/ecosystem-partners")
+        assertEquals(HttpStatusCode.OK, publicAfterDecline.status)
+        assertFalse(publicAfterDecline.bodyAsText().contains("ACME Media"))
+
+        // 8. Category in-use cannot be deleted
+        val deleteCategoryInUseResponse = client.delete(
+            "/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$categoryId",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.Conflict, deleteCategoryInUseResponse.status)
+
+        // 9. Delete partner
+        val deletePartnerResponse = client.delete(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.NoContent, deletePartnerResponse.status)
+
+        // 10. Now category can be deleted
+        val deleteCategoryResponse = client.delete(
+            "/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$categoryId",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.NoContent, deleteCategoryResponse.status)
+    }
+
+    @Test
+    fun `same company can have multiple categories on the same event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val mediaId = UUID.randomUUID()
+        val communityId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId, name = "ACME Media")
+                insertMockedEcosystemPartnerCategory(mediaId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartnerCategory(communityId, eventId = eventId, name = "Community")
+            }
+        }
+
+        val firstSubmission = client.post("/events/$eventId/ecosystem-partners") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                Json.encodeToString(
+                    RegisterEcosystemPartner.serializer(),
+                    RegisterEcosystemPartner(
+                        companyId = companyId.toString(),
+                        categoryId = mediaId.toString(),
+                    ),
+                ),
+            )
+        }
+        assertEquals(HttpStatusCode.Created, firstSubmission.status)
+
+        val secondSubmission = client.post("/events/$eventId/ecosystem-partners") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                Json.encodeToString(
+                    RegisterEcosystemPartner.serializer(),
+                    RegisterEcosystemPartner(
+                        companyId = companyId.toString(),
+                        categoryId = communityId.toString(),
+                    ),
+                ),
+            )
+        }
+        assertEquals(HttpStatusCode.Created, secondSubmission.status)
+
+        val listResponse = client.get("/orgs/$orgId/events/$eventId/ecosystem-partners") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, listResponse.status)
+        val list = json.parseToJsonElement(listResponse.bodyAsText()).jsonArray
+        assertEquals(2, list.size)
+    }
+
+    @Suppress("LongMethod") // Integration test requires comprehensive workflow validation
+    @Test
+    fun `same company can have classic partnership and ecosystem partner on the same event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val optionId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId, name = "ACME Media")
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedSponsoringOption(optionId, eventId)
+                insertMockedPackOptions(packId, optionId, required = false)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+            }
+        }
+
+        // 1. Classic partnership
+        val classicResponse = client.post("/events/$eventId/partnerships") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                Json.encodeToString(
+                    RegisterPartnership.serializer(),
+                    RegisterPartnership(
+                        packId = packId.toString(),
+                        companyId = companyId.toString(),
+                        contactName = "John Doe",
+                        contactRole = "Marketing Manager",
+                        language = "en",
+                        phone = "+33600000000",
+                        emails = listOf("partner@example.com"),
+                        optionSelections = listOf(TextSelection(optionId = optionId.toString())),
+                    ),
+                ),
+            )
+        }
+        assertEquals(HttpStatusCode.Created, classicResponse.status)
+        val partnershipId = UUID.fromString(
+            json.parseToJsonElement(classicResponse.bodyAsText())
+                .jsonObject["id"]!!
+                .jsonPrimitive
+                .content,
+        )
+
+        // 2. Ecosystem partner (light)
+        val ecosystemResponse = client.post("/events/$eventId/ecosystem-partners") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                Json.encodeToString(
+                    RegisterEcosystemPartner.serializer(),
+                    RegisterEcosystemPartner(
+                        companyId = companyId.toString(),
+                        categoryId = categoryId.toString(),
+                    ),
+                ),
+            )
+        }
+        assertEquals(HttpStatusCode.Created, ecosystemResponse.status)
+        val ecosystemPartnerId = UUID.fromString(
+            json.parseToJsonElement(ecosystemResponse.bodyAsText())
+                .jsonObject["id"]!!
+                .jsonPrimitive
+                .content,
+        )
+
+        // 3. Both rows exist and reference the same company
+        transaction {
+            val partnership = PartnershipEntity.findById(partnershipId)
+            assertNotNull(partnership)
+            val ecosystemPartner = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            assertNotNull(ecosystemPartner)
+            assertEquals(companyId, partnership.company.id.value)
+            assertEquals(companyId, ecosystemPartner.company.id.value)
+        }
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/factories/EcosystemPartner.factory.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/factories/EcosystemPartner.factory.kt
@@ -1,0 +1,36 @@
+package fr.devlille.partners.connect.ecosystempartners.factories
+
+import fr.devlille.partners.connect.companies.infrastructure.db.CompanyEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoryEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import kotlinx.datetime.LocalDateTime
+import java.util.UUID
+
+@Suppress("LongParameterList")
+fun insertMockedEcosystemPartner(
+    id: UUID = UUID.randomUUID(),
+    eventId: UUID,
+    companyId: UUID,
+    categoryId: UUID,
+    displayOrder: Int? = null,
+    language: String = "en",
+    validatedAt: LocalDateTime? = null,
+    declinedAt: LocalDateTime? = null,
+): EcosystemPartnerEntity {
+    val event = EventEntity.findById(eventId)
+        ?: error("Event $eventId must exist before creating an ecosystem partner")
+    val company = CompanyEntity.findById(companyId)
+        ?: error("Company $companyId must exist before creating an ecosystem partner")
+    val category = EcosystemPartnerCategoryEntity.findById(categoryId)
+        ?: error("Category $categoryId must exist before creating an ecosystem partner")
+    return EcosystemPartnerEntity.new(id) {
+        this.event = event
+        this.company = company
+        this.category = category
+        this.displayOrder = displayOrder
+        this.language = language
+        this.validatedAt = validatedAt
+        this.declinedAt = declinedAt
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/factories/EcosystemPartnerCategory.factory.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/factories/EcosystemPartnerCategory.factory.kt
@@ -1,0 +1,20 @@
+package fr.devlille.partners.connect.ecosystempartners.factories
+
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerCategoryEntity
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import java.util.UUID
+
+fun insertMockedEcosystemPartnerCategory(
+    id: UUID = UUID.randomUUID(),
+    eventId: UUID,
+    name: String = id.toString(),
+    displayOrder: Int? = null,
+): EcosystemPartnerCategoryEntity {
+    val event = EventEntity.findById(eventId)
+        ?: error("Event $eventId must exist before creating an ecosystem partner category")
+    return EcosystemPartnerCategoryEntity.new(id) {
+        this.event = event
+        this.name = name
+        this.displayOrder = displayOrder
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/factories/EcosystemPartnerEmail.factory.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/factories/EcosystemPartnerEmail.factory.kt
@@ -1,0 +1,18 @@
+package fr.devlille.partners.connect.ecosystempartners.factories
+
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEmailEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import java.util.UUID
+
+fun insertMockedEcosystemPartnerEmail(
+    id: UUID = UUID.randomUUID(),
+    ecosystemPartnerId: UUID,
+    email: String = "$id@mock.test",
+): EcosystemPartnerEmailEntity {
+    val partner = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+        ?: error("Ecosystem partner $ecosystemPartnerId must exist before adding an email")
+    return EcosystemPartnerEmailEntity.new(id) {
+        this.ecosystemPartner = partner
+        this.email = email
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRouteDeleteTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRouteDeleteTest.kt
@@ -1,0 +1,107 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerCategoryRouteDeleteTest {
+    @Test
+    fun `DELETE removes an unused category`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catId, eventId = eventId, name = "Media")
+            }
+        }
+
+        val response = client.delete("/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$catId") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 409 when an ecosystem partner uses the category`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catId, eventId = eventId, name = "Media")
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = catId,
+                )
+            }
+        }
+
+        val response = client.delete("/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$catId") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 404 when category belongs to a different event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val otherEventId = UUID.randomUUID()
+        val catId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedFutureEvent(otherEventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catId, eventId = otherEventId, name = "Media")
+            }
+        }
+
+        val response = client.delete("/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$catId") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRouteGetTest.kt
@@ -1,0 +1,87 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerCategoryRouteGetTest {
+    @Test
+    fun `GET orgs returns categories ordered by display_order then name`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catA = UUID.randomUUID()
+        val catB = UUID.randomUUID()
+        val catC = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                // Display order: 2, 1, null. Sorted: 1 (B), 2 (A), null (C)
+                insertMockedEcosystemPartnerCategory(catA, eventId = eventId, name = "Alpha", displayOrder = 2)
+                insertMockedEcosystemPartnerCategory(catB, eventId = eventId, name = "Beta", displayOrder = 1)
+                insertMockedEcosystemPartnerCategory(catC, eventId = eventId, name = "Gamma", displayOrder = null)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/ecosystem-partner-categories") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(3, body.size)
+        assertEquals("Beta", body[0].jsonObject["name"]!!.jsonPrimitive.content)
+        assertEquals("Alpha", body[1].jsonObject["name"]!!.jsonPrimitive.content)
+        assertEquals("Gamma", body[2].jsonObject["name"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `GET public returns categories without authentication`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catA = UUID.randomUUID()
+        val catB = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catA, eventId = eventId, name = "Zeta", displayOrder = 5)
+                insertMockedEcosystemPartnerCategory(catB, eventId = eventId, name = "Alpha", displayOrder = 1)
+            }
+        }
+
+        val response = client.get("/events/$eventId/ecosystem-partner-categories")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(2, body.size)
+        assertEquals("Alpha", body[0].jsonObject["name"]!!.jsonPrimitive.content)
+        assertEquals("Zeta", body[1].jsonObject["name"]!!.jsonPrimitive.content)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRoutePostTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRoutePostTest.kt
@@ -1,0 +1,78 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerCategoryRoutePostTest {
+    @Test
+    fun `POST creates a category`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+            }
+        }
+
+        val body = RegisterEcosystemPartnerCategory(name = "Media", displayOrder = 1)
+        val response = client.post("/orgs/$orgId/events/$eventId/ecosystem-partner-categories") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(Json.encodeToString(RegisterEcosystemPartnerCategory.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+    }
+
+    @Test
+    fun `POST returns 409 when name already exists for the same event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val existingCatId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(existingCatId, eventId = eventId, name = "Media")
+            }
+        }
+
+        val body = RegisterEcosystemPartnerCategory(name = "Media")
+        val response = client.post("/orgs/$orgId/events/$eventId/ecosystem-partner-categories") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(Json.encodeToString(RegisterEcosystemPartnerCategory.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRoutePutTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerCategoryRoutePutTest.kt
@@ -1,0 +1,117 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerCategoryRoutePutTest {
+    @Test
+    fun `PUT updates the category name`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catId, eventId = eventId, name = "Media")
+            }
+        }
+
+        val body = UpdateEcosystemPartnerCategory(name = "Press")
+        val response = client.put("/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$catId") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(Json.encodeToString(UpdateEcosystemPartnerCategory.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals("Press", json["name"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `PUT returns 409 when renaming to an existing name`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catA = UUID.randomUUID()
+        val catB = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catA, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartnerCategory(catB, eventId = eventId, name = "Press")
+            }
+        }
+
+        val body = UpdateEcosystemPartnerCategory(name = "Press")
+        val response = client.put("/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$catA") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(Json.encodeToString(UpdateEcosystemPartnerCategory.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 when category belongs to a different event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val otherEventId = UUID.randomUUID()
+        val catId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedFutureEvent(otherEventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catId, eventId = otherEventId, name = "Media")
+            }
+        }
+
+        val body = UpdateEcosystemPartnerCategory(name = "Press")
+        val response = client.put("/orgs/$orgId/events/$eventId/ecosystem-partner-categories/$catId") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody(Json.encodeToString(UpdateEcosystemPartnerCategory.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDeclineRoutePostTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDeclineRoutePostTest.kt
@@ -1,0 +1,110 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EcosystemPartnerDeclineRoutePostTest {
+    @Test
+    fun `POST decline sets declinedAt and clears validatedAt`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val response = client.post(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId/decline",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val entity = EcosystemPartnerEntity.findById(partnerId)
+            assertNotNull(entity)
+            assertNotNull(entity.declinedAt)
+            assertNull(entity.validatedAt)
+        }
+    }
+
+    @Test
+    fun `POST decline clears a previous validation`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+            }
+        }
+
+        val response = client.post(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId/decline",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val entity = EcosystemPartnerEntity.findById(partnerId)
+            assertNotNull(entity)
+            assertNull(entity.validatedAt)
+            assertNotNull(entity.declinedAt)
+        }
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDeleteRouteDeleteTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDeleteRouteDeleteTest.kt
@@ -1,0 +1,100 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerEmail
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEmailEntity
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EcosystemPartnerDeleteRouteDeleteTest {
+    @Test
+    fun `DELETE removes the partner and cascades email rows`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+                insertMockedEcosystemPartnerEmail(ecosystemPartnerId = partnerId, email = "a@example.com")
+                insertMockedEcosystemPartnerEmail(ecosystemPartnerId = partnerId, email = "b@example.com")
+            }
+        }
+
+        val response = client.delete("/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+        val remainingEmails = transaction {
+            EcosystemPartnerEmailEntity.listByEcosystemPartner(partnerId)
+        }
+        assertTrue(remainingEmails.isEmpty())
+    }
+
+    @Test
+    fun `DELETE returns 404 when partner belongs to a different event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val otherEventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedFutureEvent(otherEventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = otherEventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = otherEventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val response = client.delete("/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerListRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerListRouteGetTest.kt
@@ -1,0 +1,152 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerListRouteGetTest {
+    @Test
+    fun `GET lists all non-declined partners by default`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val company1 = UUID.randomUUID()
+        val company2 = UUID.randomUUID()
+        val company3 = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedCompany(company1)
+                insertMockedCompany(company2)
+                insertMockedCompany(company3)
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company1,
+                    categoryId = categoryId,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company2,
+                    categoryId = categoryId,
+                )
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company3,
+                    categoryId = categoryId,
+                    declinedAt = LocalDateTime(2026, 1, 2, 0, 0),
+                )
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/ecosystem-partners") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(2, body.size)
+    }
+
+    @Test
+    fun `GET filtered by category_id`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catA = UUID.randomUUID()
+        val catB = UUID.randomUUID()
+        val company1 = UUID.randomUUID()
+        val company2 = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(catA, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartnerCategory(catB, eventId = eventId, name = "Press")
+                insertMockedCompany(company1)
+                insertMockedCompany(company2)
+                insertMockedEcosystemPartner(eventId = eventId, companyId = company1, categoryId = catA)
+                insertMockedEcosystemPartner(eventId = eventId, companyId = company2, categoryId = catB)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/ecosystem-partners?filter[category_id]=$catA") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(1, body.size)
+    }
+
+    @Test
+    fun `GET filtered by validated=true`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val company1 = UUID.randomUUID()
+        val company2 = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedCompany(company1)
+                insertMockedCompany(company2)
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company1,
+                    categoryId = categoryId,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company2,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/events/$eventId/ecosystem-partners?filter[validated]=true") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(1, body.size)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRegisterRoutePostTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRegisterRoutePostTest.kt
@@ -1,0 +1,93 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EcosystemPartnerRegisterRoutePostTest {
+    @Test
+    fun `POST creates an ecosystem partner submission`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+            }
+        }
+
+        val body = RegisterEcosystemPartner(
+            companyId = companyId.toString(),
+            categoryId = categoryId.toString(),
+            language = "en",
+            emails = listOf("partner@example.com"),
+        )
+        val response = client.post("/events/$eventId/ecosystem-partners") {
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(RegisterEcosystemPartner.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("\"id\""))
+    }
+
+    @Test
+    fun `POST returns 409 when company already registered for that category`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val body = RegisterEcosystemPartner(
+            companyId = companyId.toString(),
+            categoryId = categoryId.toString(),
+            language = "en",
+        )
+        val response = client.post("/events/$eventId/ecosystem-partners") {
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(RegisterEcosystemPartner.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRouteGetTest.kt
@@ -1,0 +1,79 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerRouteGetTest {
+    @Test
+    fun `GET returns 200 with the partner`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val response = client.get("/events/$eventId/ecosystem-partners/$partnerId")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `GET returns 404 when partner belongs to a different event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val otherEventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedFutureEvent(otherEventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = otherEventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = otherEventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val response = client.get("/events/$eventId/ecosystem-partners/$partnerId")
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutePutTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutePutTest.kt
@@ -1,0 +1,135 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerEmail
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEmailEntity
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EcosystemPartnerRoutePutTest {
+    @Test
+    fun `PUT updates emails on an unvalidated partner`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+                insertMockedEcosystemPartnerEmail(ecosystemPartnerId = partnerId, email = "old@example.com")
+            }
+        }
+
+        val body = UpdateEcosystemPartner(emails = listOf("new@x.test"))
+        val response = client.put("/events/$eventId/ecosystem-partners/$partnerId") {
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(UpdateEcosystemPartner.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val updatedEmails = transaction {
+            EcosystemPartnerEmailEntity.listByEcosystemPartner(partnerId).map { it.email }
+        }
+        assertEquals(listOf("new@x.test"), updatedEmails)
+    }
+
+    @Test
+    fun `PUT returns 409 when partner is validated`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+            }
+        }
+
+        val body = UpdateEcosystemPartner(emails = listOf("new@x.test"))
+        val response = client.put("/events/$eventId/ecosystem-partners/$partnerId") {
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(UpdateEcosystemPartner.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 when partner belongs to a different event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val otherEventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedFutureEvent(otherEventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = otherEventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = otherEventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val body = UpdateEcosystemPartner(emails = listOf("new@x.test"))
+        val response = client.put("/events/$eventId/ecosystem-partners/$partnerId") {
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(UpdateEcosystemPartner.serializer(), body))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerValidateRoutePostTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerValidateRoutePostTest.kt
@@ -1,0 +1,110 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EcosystemPartnerValidateRoutePostTest {
+    @Test
+    fun `POST validate sets validatedAt and clears declinedAt`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                )
+            }
+        }
+
+        val response = client.post(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId/validate",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val entity = EcosystemPartnerEntity.findById(partnerId)
+            assertNotNull(entity)
+            assertNotNull(entity.validatedAt)
+            assertNull(entity.declinedAt)
+        }
+    }
+
+    @Test
+    fun `POST validate clears a previous decline`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val partnerId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedEcosystemPartner(
+                    id = partnerId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    categoryId = categoryId,
+                    declinedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+            }
+        }
+
+        val response = client.post(
+            "/orgs/$orgId/events/$eventId/ecosystem-partners/$partnerId/validate",
+        ) {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        transaction {
+            val entity = EcosystemPartnerEntity.findById(partnerId)
+            assertNotNull(entity)
+            assertNull(entity.declinedAt)
+            assertNotNull(entity.validatedAt)
+        }
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/PublicEcosystemPartnersRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/PublicEcosystemPartnersRouteGetTest.kt
@@ -1,0 +1,137 @@
+package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartner
+import fr.devlille.partners.connect.ecosystempartners.factories.insertMockedEcosystemPartnerCategory
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PublicEcosystemPartnersRouteGetTest {
+    @Test
+    fun `GET returns only validated non-declined partners grouped by category`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val company1 = UUID.randomUUID()
+        val company2 = UUID.randomUUID()
+        val company3 = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedEcosystemPartnerCategory(categoryId, eventId = eventId, name = "Media")
+                insertMockedCompany(company1)
+                insertMockedCompany(company2)
+                insertMockedCompany(company3)
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company1,
+                    categoryId = categoryId,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company2,
+                    categoryId = categoryId,
+                )
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company3,
+                    categoryId = categoryId,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                    declinedAt = LocalDateTime(2026, 1, 2, 0, 0),
+                )
+            }
+        }
+
+        val response = client.get("/events/$eventId/ecosystem-partners")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(1, body.size)
+        val partners = body[0].jsonObject["partners"]!!.jsonArray
+        assertEquals(1, partners.size)
+    }
+
+    @Test
+    fun `GET returns groups in displayOrder then name`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val catA = UUID.randomUUID()
+        val catB = UUID.randomUUID()
+        val company1 = UUID.randomUUID()
+        val company2 = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                // catA displayOrder=2 (Alpha), catB displayOrder=1 (Beta) -> Beta should come first
+                insertMockedEcosystemPartnerCategory(catA, eventId = eventId, name = "Alpha", displayOrder = 2)
+                insertMockedEcosystemPartnerCategory(catB, eventId = eventId, name = "Beta", displayOrder = 1)
+                insertMockedCompany(company1)
+                insertMockedCompany(company2)
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company1,
+                    categoryId = catA,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+                insertMockedEcosystemPartner(
+                    eventId = eventId,
+                    companyId = company2,
+                    categoryId = catB,
+                    validatedAt = LocalDateTime(2026, 1, 1, 0, 0),
+                )
+            }
+        }
+
+        val response = client.get("/events/$eventId/ecosystem-partners")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(2, body.size)
+        assertEquals("Beta", body[0].jsonObject["category"]!!.jsonPrimitive.content)
+        assertEquals("Alpha", body[1].jsonObject["category"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `GET returns empty list for an event with no validated partners`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+            }
+        }
+
+        val response = client.get("/events/$eventId/ecosystem-partners")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(0, body.size)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
@@ -26,6 +26,7 @@ import fr.devlille.partners.connect.tickets.infrastructure.bindings.ticketingMod
 import fr.devlille.partners.connect.users.infrastructure.bindings.userModule
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
+import fr.devlille.partners.connect.webhooks.domain.WebhookResourceType
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.server.application.Application
 import io.mockk.every
@@ -99,7 +100,12 @@ fun Application.moduleMocked(
     mockWebhook: Module = module {
         single<WebhookRepository> {
             object : WebhookRepository {
-                override suspend fun sendWebhooks(eventSlug: String, partnershipId: UUID, eventType: WebhookEventType) {
+                override suspend fun sendWebhooks(
+                    eventSlug: String,
+                    resourceType: WebhookResourceType,
+                    resourceId: UUID,
+                    eventType: WebhookEventType,
+                ) {
                     // Mock implementation - do nothing
                 }
             }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
@@ -8,6 +8,7 @@ import fr.devlille.partners.connect.billing.domain.BillingGateway
 import fr.devlille.partners.connect.billing.infrastructure.bindings.billingModule
 import fr.devlille.partners.connect.companies.infrastructure.bindings.companyModule
 import fr.devlille.partners.connect.digest.infrastructure.bindings.digestModule
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.bindings.ecosystemPartnerModule
 import fr.devlille.partners.connect.events.infrastructure.bindings.eventModule
 import fr.devlille.partners.connect.integrations.infrastructure.bindings.integrationModule
 import fr.devlille.partners.connect.internal.infrastructure.bindings.mapsModule
@@ -120,6 +121,7 @@ fun Application.moduleMocked(
                 sponsoringModule,
                 companyModule,
                 partnershipModule,
+                ecosystemPartnerModule,
                 providerModule,
                 notificationModule,
                 billingModule,


### PR DESCRIPTION
## Summary

- Adds a new `ecosystempartners/` server module that lets organisers curate non-contractual partners (community, media, host, institutional, …) on an event page. Companies self-submit; organisers validate or decline; only validated entries appear publicly.
- Adds 3 new tables (`event_ecosystem_partner_categories`, `ecosystem_partners`, `ecosystem_partner_emails`), 9 API endpoints, 4 notification variants + 24 templates (email/Slack, FR/EN), and a `WebhookEcosystemPartnerPlugin` wiring.
- Refactors `WebhookPayload` into a sealed class with `partnership` and `ecosystem_partner` variants so the same delivery pipeline serves both — the gateway now takes `(resourceType, resourceId)`. Common JSON fields stay at the same path for backward compatibility.

## What's in scope

- Organiser-managed per-event categories (CRUD).
- Public submission flow on `/events/{eventSlug}/ecosystem-partners` (mirrors the classic partnership pattern).
- Organiser validate/decline + curation list with `filter[category_id]`, `filter[validated]`, `filter[declined]`.
- Public listing endpoint that returns validated entries grouped by category (`display_order` asc nulls last, then name).
- Lifecycle notifications via the existing `NotificationRepository.sendMessage(variables)` pipeline (`Submitted` / `Validated` / `Declined` / `Removed`).
- Webhook lifecycle events (`CREATED` / `UPDATED` / `DELETED`) using the polymorphic payload.

## Explicitly out of scope (future specs)

- Ticket generation, communication plan, social-media publication, support-video, job offers, and Q&A flows for ecosystem partners (these remain classic-partnership-only).
- Frontend implementation (lives in `../front/`).

## Notable design calls

- Same company can hold a classic partnership AND one or more ecosystem partnerships on the same event (different aggregates, different unique keys).
- Same company can sit in multiple categories on the same event (unique key is `(event, company, category)`).
- Edit-after-validate is locked (409); organisers must `decline` first to re-edit.
- Category deletion is blocked (409) when any partner — validated, unvalidated, or declined — references it.

## Spec & plan

Local docs (gitignored): `server/docs/superpowers/specs/2026-05-16-ecosystem-partner-design.md` and `server/docs/superpowers/plans/2026-05-16-ecosystem-partner.md`.

## Test plan

- [ ] `./gradlew check --no-daemon` — confirms full suite (632 tests) passes, ktlint + detekt clean
- [ ] `npm run validate` — OpenAPI spec validates
- [ ] Manual: hit `POST /events/{slug}/ecosystem-partners` with a real company id and verify the row appears in `/orgs/.../ecosystem-partners` (unvalidated)
- [ ] Manual: `POST /orgs/.../validate` → `GET /events/{slug}/ecosystem-partners` shows the partner grouped by category
- [ ] Manual: `POST /orgs/.../decline` → public listing drops the partner
- [ ] Manual: delete the partner, then delete the category — both succeed in order
- [ ] Manual: register a classic partnership AND an ecosystem partner for the same `(event, company)` pair — both rows coexist
- [ ] Webhook receivers: verify the new `resource_type` discriminator surfaces in both partnership and ecosystem-partner payloads; consumers reading only `event`/`company`/`event_type` keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)