### PR TITLE
fix(front): post-merge fixes for flyer feature

### DIFF
--- a/front/components/FlyerZonePicker.vue
+++ b/front/components/FlyerZonePicker.vue
@@ -12,7 +12,9 @@
         ref="image"
         :src="templateUrl"
         class="block max-w-full h-auto"
+        draggable="false"
         @load="onImageLoad"
+        @dragstart.prevent
         alt="Flyer template preview"
       />
       <div
@@ -115,6 +117,8 @@ let dragStart: { x: number; y: number } | null = null;
 
 function onMouseDown(event: MouseEvent) {
   if (!container.value) return;
+  // Prevent the browser's native image-drag gesture (and any focus/selection side-effects).
+  event.preventDefault();
   const rect = container.value.getBoundingClientRect();
   dragStart = { x: event.clientX - rect.left, y: event.clientY - rect.top };
 }

--- a/front/pages/orgs/[slug]/events/[eventSlug]/communication.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/communication.vue
@@ -418,14 +418,6 @@ import { useStandaloneCommunicationModal } from '~/composables/useStandaloneComm
 import FilterPanel from '~/components/sponsors/FilterPanel.vue';
 import ActiveFilters from '~/components/sponsors/ActiveFilters.vue';
 import type { PartnershipsMetadata } from '~/types/sponsors';
-import { useSponsorsStore } from "~/stores/sponsors";
-
-const sponsorsStore = useSponsorsStore();
-
-function partnershipFor(item: { partnership_id?: string | null }) {
-  if (!item.partnership_id) return undefined;
-  return sponsorsStore.sponsors.find((s) => s.id === item.partnership_id);
-}
 
 const route = useRoute();
 const toast = useToast();
@@ -463,6 +455,11 @@ const unfilteredCommunicationPlan = ref<CommunicationPlanSchema>({
   unplanned: []
 });
 const partnerships = ref<PartnershipItemSchema[]>([]);
+
+function partnershipFor(item: { partnership_id?: string | null }) {
+  if (!item.partnership_id) return undefined;
+  return partnerships.value.find((s) => s.id === item.partnership_id);
+}
 const loading = ref(true);
 const error = ref<string | null>(null);
 const eventName = ref<string>('');


### PR DESCRIPTION
Two follow-up fixes for the partnership flyer feature, found during manual smoke after #196 merged.

## Summary

- **`partnershipFor` was reading from an empty Pinia store.** The org communication page fetches partnerships into a local \`partnerships\` ref, but never populates \`useSponsorsStore().sponsors\`. The lookup helper introduced in #196 was reading from the store and returning \`undefined\` for every item, which silently hid the \`<GenerateFlyerButton>\` behind its \`v-if=\"partnership\"\` guard. Point the helper at the local ref where the data actually lives.
- **\`<img>\` was hijacking mousedown for native drag-and-drop.** Browsers default to a drag-and-drop gesture (with a ghost preview) when the user mousedowns on an \`<img>\`. Inside the \`FlyerZonePicker\`, that hijacked the picker's own \`mousemove\`/\`mouseup\` handlers and the user couldn't draw the zone rectangle. Disable image dragging via \`draggable=\"false\"\` + \`@dragstart.prevent\` on the image, and call \`event.preventDefault()\` on \`mousedown\` to stop any other native gestures.

## Test plan

- [x] \`cd front && pnpm test:run tests/components/FlyerZonePicker.test.ts\` — both tests pass.
- [x] \`cd front && pnpm lint\` — clean (1 pre-existing warning in \`types/sponsors.ts\` unchanged).
- [ ] Manual smoke on a running dev server:
  - Open \`/orgs/{slug}/events/{eventSlug}/communication\` after a fresh page reload.
  - Confirm each partnership-linked card now shows a "Générer le flyer" button next to "Planifier" and "Ajouter".
  - On a partnership without \`validated_pack_id\`, the button is disabled with a French \"not yet validated\" tooltip.
  - On a pack edit page with an uploaded template, click-and-drag on the preview image actually draws the zone rectangle rather than triggering a browser drag-and-drop ghost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)