### PR TITLE
fix(flyer): expose flyer columns in pack GET response

### DIFF
--- a/front/pages/orgs/[slug]/events/[eventSlug]/packs/[packId]/index.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/packs/[packId]/index.vue
@@ -42,14 +42,6 @@
 import { getEventBySlug, getOrgsEventsPacks, putOrgsEventsPacks, postOrgsEventsPacksOptions, type SponsoringPack, type CreateSponsoringPack, type SponsoringOption } from "~/utils/api";
 import authMiddleware from "~/middleware/auth";
 
-type PackWithFlyer = SponsoringPack & {
-  flyer_template_url?: string | null;
-  flyer_zone_x?: number | null;
-  flyer_zone_y?: number | null;
-  flyer_zone_width?: number | null;
-  flyer_zone_height?: number | null;
-};
-
 const route = useRoute();
 const router = useRouter();
 const { footerLinks } = useDashboardLinks();
@@ -69,7 +61,7 @@ const eventSlug = computed(() => {
 });
 const packId = computed(() => route.params.packId as string);
 
-const pack = ref<PackWithFlyer | null>(null);
+const pack = ref<SponsoringPack | null>(null);
 const loading = ref(true);
 const error = ref<string | null>(null);
 const eventName = ref<string>('');

--- a/front/utils/api.ts
+++ b/front/utils/api.ts
@@ -733,6 +733,16 @@ export interface SponsoringPackSchema {
   max_quantity?: number | null;
   required_options: SponsoringOptionSchema[];
   optional_options: SponsoringOptionSchema[];
+  /** @nullable */
+  flyer_template_url?: string | null;
+  /** @nullable */
+  flyer_zone_x?: number | null;
+  /** @nullable */
+  flyer_zone_y?: number | null;
+  /** @nullable */
+  flyer_zone_width?: number | null;
+  /** @nullable */
+  flyer_zone_height?: number | null;
 }
 
 export type SponsoringPack = SponsoringPackSchema;

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/sponsoring/application/mappers/SponsoringPackEntityWithTranslations.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/sponsoring/application/mappers/SponsoringPackEntityWithTranslations.ext.kt
@@ -19,5 +19,10 @@ internal fun SponsoringPackEntity.toDomainWithAllTranslations(
         maxQuantity = this.maxQuantity,
         requiredOptions = requiredOptionEntities.map { option -> option.toDomainWithAllTranslations() },
         optionalOptions = optionalOptionEntities.map { option -> option.toDomainWithAllTranslations() },
+        flyerTemplateUrl = this.flyerTemplateUrl,
+        flyerZoneX = this.flyerZoneX,
+        flyerZoneY = this.flyerZoneY,
+        flyerZoneWidth = this.flyerZoneWidth,
+        flyerZoneHeight = this.flyerZoneHeight,
     )
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/sponsoring/domain/SponsoringPackWithTranslations.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/sponsoring/domain/SponsoringPackWithTranslations.kt
@@ -15,4 +15,14 @@ data class SponsoringPackWithTranslations(
     val requiredOptions: List<SponsoringOptionWithTranslations>,
     @SerialName("optional_options")
     val optionalOptions: List<SponsoringOptionWithTranslations>,
+    @SerialName("flyer_template_url")
+    val flyerTemplateUrl: String? = null,
+    @SerialName("flyer_zone_x")
+    val flyerZoneX: Int? = null,
+    @SerialName("flyer_zone_y")
+    val flyerZoneY: Int? = null,
+    @SerialName("flyer_zone_width")
+    val flyerZoneWidth: Int? = null,
+    @SerialName("flyer_zone_height")
+    val flyerZoneHeight: Int? = null,
 )

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -7241,6 +7241,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/sponsoring_option.schema'
+        flyer_template_url:
+          type:
+            - string
+            - 'null'
+        flyer_zone_x:
+          type:
+            - integer
+            - 'null'
+        flyer_zone_y:
+          type:
+            - integer
+            - 'null'
+        flyer_zone_width:
+          type:
+            - integer
+            - 'null'
+        flyer_zone_height:
+          type:
+            - integer
+            - 'null'
       required:
         - id
         - name

--- a/server/application/src/main/resources/schemas/sponsoring_pack.schema.json
+++ b/server/application/src/main/resources/schemas/sponsoring_pack.schema.json
@@ -28,6 +28,21 @@
       "items": {
         "$ref": "sponsoring_option.schema.json"
       }
+    },
+    "flyer_template_url": {
+      "type": ["string", "null"]
+    },
+    "flyer_zone_x": {
+      "type": ["integer", "null"]
+    },
+    "flyer_zone_y": {
+      "type": ["integer", "null"]
+    },
+    "flyer_zone_width": {
+      "type": ["integer", "null"]
+    },
+    "flyer_zone_height": {
+      "type": ["integer", "null"]
     }
   },
   "required": [

--- a/server/application/src/main/resources/schemas/sponsoring_pack_with_translations.schema.json
+++ b/server/application/src/main/resources/schemas/sponsoring_pack_with_translations.schema.json
@@ -34,6 +34,26 @@
         "$ref": "sponsoring_option_with_translations.schema.json"
       },
       "description": "Optional add-on options with all translations"
+    },
+    "flyer_template_url": {
+      "type": ["string", "null"],
+      "description": "URL of the uploaded PNG flyer template, or null when the pack is not flyer-enabled"
+    },
+    "flyer_zone_x": {
+      "type": ["integer", "null"],
+      "description": "X coordinate of the logo zone in template pixels"
+    },
+    "flyer_zone_y": {
+      "type": ["integer", "null"],
+      "description": "Y coordinate of the logo zone in template pixels"
+    },
+    "flyer_zone_width": {
+      "type": ["integer", "null"],
+      "description": "Width of the logo zone in template pixels"
+    },
+    "flyer_zone_height": {
+      "type": ["integer", "null"],
+      "description": "Height of the logo zone in template pixels"
     }
   },
   "required": [


### PR DESCRIPTION
The PUT /flyer-template endpoint writes the five flyer_* columns to \`sponsoring_packs\` correctly, but the org-side GET /packs response (read by the pack edit page) never returned them. On every page reload the \`FlyerTemplateConfig\` component initialised with empty state and showed the drop-zone UI again, even though the data was persisted server-side. The user perceived this as "the flyer and the zone isn't saved."

## Changes

**Backend** (\`fix(server): expose flyer columns in pack GET response\`):

- Add \`flyerTemplateUrl\`, \`flyerZoneX\`, \`flyerZoneY\`, \`flyerZoneWidth\`, \`flyerZoneHeight\` to the \`SponsoringPackWithTranslations\` domain class (all \`Int?\` / \`String?\`, defaulted to null).
- Update \`SponsoringPackEntity.toDomainWithAllTranslations\` to read the five entity columns into the new fields.
- Add the same fields to \`sponsoring_pack.schema.json\` and \`sponsoring_pack_with_translations.schema.json\`, then rebundle \`documentation.yaml\`.

**Frontend** (\`fix(front): use typed flyer fields on pack now that schema exposes them\`):

- Regenerate \`utils/api.ts\` via orval against the updated local \`documentation.yaml\` (config temporarily switched to local file, then reverted).
- Remove the local \`PackWithFlyer\` intersection type from \`pages/.../packs/[packId]/index.vue\` — \`SponsoringPackSchema\` now natively includes the flyer fields.

## Test plan

- [x] \`./gradlew :application:test\` — all server tests pass.
- [x] \`cd front && pnpm test:run\` — 1289/1289 pass.
- [x] \`cd front && pnpm lint\` — clean (1 pre-existing warning in \`types/sponsors.ts\`, unrelated).
- [x] \`cd front && git diff orval.config.ts\` — empty (config reverted to baseline remote URL).
- [ ] Manual smoke: upload a flyer template on a pack → click "Save template" → reload the page → confirm the preview + zone overlay are restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)