### PR TITLE
fix(front): wire flyer translations to runtime i18n config

### DIFF
--- a/front/i18n.config.ts
+++ b/front/i18n.config.ts
@@ -125,6 +125,48 @@ export default defineI18nConfig(() => ({
           noLocation: "Non assigné",
         },
       },
+      flyer: {
+        templateSection: {
+          title: "Modèle de flyer",
+          help: "Téléchargez un modèle PNG et délimitez la zone où le logo du partenaire sera composé.",
+        },
+        upload: {
+          dropPng: "Cliquez pour sélectionner ou glissez-déposez un PNG",
+          errors: {
+            notPng: "Seuls les fichiers PNG sont acceptés",
+            tooLarge: "Le fichier ne doit pas dépasser 10 Mo",
+          },
+        },
+        zone: {
+          widthLabel: "Largeur",
+          heightLabel: "Hauteur",
+          errors: {
+            outOfBounds: "La zone doit être positive et tenir dans le modèle",
+          },
+        },
+        save: {
+          button: "Enregistrer le modèle",
+          success: "Modèle enregistré",
+          failure: "Échec de l'enregistrement du modèle",
+        },
+        clear: {
+          button: "Supprimer le modèle",
+          success: "Modèle supprimé",
+          failure: "Échec de la suppression du modèle",
+        },
+        generate: {
+          button: "Générer le flyer",
+          success: "Flyer généré et attaché au support de communication",
+          failure: "Échec de la génération du flyer",
+          disabled: {
+            notValidated: "Le partenariat n'est pas encore validé",
+            noLogo: "L'entreprise n'a pas encore fourni de logo",
+          },
+        },
+        errors: {
+          generic: "Une erreur est survenue. Veuillez réessayer.",
+        },
+      },
     },
     en: {
       common: {
@@ -237,6 +279,48 @@ export default defineI18nConfig(() => ({
           },
           noSponsors: "No validated Pack Silver or Pack Gold sponsor for this event.",
           noLocation: "Unassigned",
+        },
+      },
+      flyer: {
+        templateSection: {
+          title: "Flyer template",
+          help: "Upload a PNG template and outline the zone where the partner logo will be composed.",
+        },
+        upload: {
+          dropPng: "Click to select or drag and drop a PNG",
+          errors: {
+            notPng: "Only PNG files are accepted",
+            tooLarge: "File must not exceed 10 MB",
+          },
+        },
+        zone: {
+          widthLabel: "Width",
+          heightLabel: "Height",
+          errors: {
+            outOfBounds: "Zone must be positive and fit inside the template",
+          },
+        },
+        save: {
+          button: "Save template",
+          success: "Template saved",
+          failure: "Failed to save template",
+        },
+        clear: {
+          button: "Remove template",
+          success: "Template removed",
+          failure: "Failed to remove template",
+        },
+        generate: {
+          button: "Generate flyer",
+          success: "Flyer generated and attached to the communication support",
+          failure: "Failed to generate flyer",
+          disabled: {
+            notValidated: "Partnership is not yet validated",
+            noLogo: "Company has no logo yet",
+          },
+        },
+        errors: {
+          generic: "Something went wrong. Please try again.",
         },
       },
     },
@@ -352,6 +436,48 @@ export default defineI18nConfig(() => ({
           },
           noSponsors: "Ningún patrocinador Pack Silver o Pack Gold validado para este evento.",
           noLocation: "Sin asignar",
+        },
+      },
+      flyer: {
+        templateSection: {
+          title: "Plantilla del flyer",
+          help: "Cargue una plantilla PNG y delimite la zona donde se compondrá el logo del socio.",
+        },
+        upload: {
+          dropPng: "Haga clic para seleccionar o arrastre y suelte un PNG",
+          errors: {
+            notPng: "Solo se aceptan archivos PNG",
+            tooLarge: "El archivo no debe superar los 10 MB",
+          },
+        },
+        zone: {
+          widthLabel: "Ancho",
+          heightLabel: "Alto",
+          errors: {
+            outOfBounds: "La zona debe ser positiva y caber dentro de la plantilla",
+          },
+        },
+        save: {
+          button: "Guardar plantilla",
+          success: "Plantilla guardada",
+          failure: "Error al guardar la plantilla",
+        },
+        clear: {
+          button: "Eliminar plantilla",
+          success: "Plantilla eliminada",
+          failure: "Error al eliminar la plantilla",
+        },
+        generate: {
+          button: "Generar flyer",
+          success: "Flyer generado y adjuntado al soporte de comunicación",
+          failure: "Error al generar el flyer",
+          disabled: {
+            notValidated: "La asociación aún no ha sido validada",
+            noLogo: "La empresa aún no ha proporcionado un logo",
+          },
+        },
+        errors: {
+          generic: "Se produjo un error. Por favor, inténtelo de nuevo.",
         },
       },
     },

--- a/front/locales/en-US.json
+++ b/front/locales/en-US.json
@@ -147,47 +147,5 @@
       "noSponsors": "No validated Pack Silver or Pack Gold sponsor for this event.",
       "noLocation": "Unassigned"
     }
-  },
-  "flyer": {
-    "templateSection": {
-      "title": "Flyer template",
-      "help": "Upload a PNG template and outline the zone where the partner logo will be composed."
-    },
-    "upload": {
-      "dropPng": "Click to select or drag and drop a PNG",
-      "errors": {
-        "notPng": "Only PNG files are accepted",
-        "tooLarge": "File must not exceed 10 MB"
-      }
-    },
-    "zone": {
-      "widthLabel": "Width",
-      "heightLabel": "Height",
-      "errors": {
-        "outOfBounds": "Zone must be positive and fit inside the template"
-      }
-    },
-    "save": {
-      "button": "Save template",
-      "success": "Template saved",
-      "failure": "Failed to save template"
-    },
-    "clear": {
-      "button": "Remove template",
-      "success": "Template removed",
-      "failure": "Failed to remove template"
-    },
-    "generate": {
-      "button": "Generate flyer",
-      "success": "Flyer generated and attached to the communication support",
-      "failure": "Failed to generate flyer",
-      "disabled": {
-        "notValidated": "Partnership is not yet validated",
-        "noLogo": "Company has no logo yet"
-      }
-    },
-    "errors": {
-      "generic": "Something went wrong. Please try again."
-    }
   }
 }

--- a/front/locales/es-ES.json
+++ b/front/locales/es-ES.json
@@ -97,47 +97,5 @@
       "noSponsors": "Ningún patrocinador Pack Silver o Pack Gold validado para este evento.",
       "noLocation": "Sin asignar"
     }
-  },
-  "flyer": {
-    "templateSection": {
-      "title": "Flyer template",
-      "help": "Upload a PNG template and outline the zone where the partner logo will be composed."
-    },
-    "upload": {
-      "dropPng": "Click to select or drag and drop a PNG",
-      "errors": {
-        "notPng": "Only PNG files are accepted",
-        "tooLarge": "File must not exceed 10 MB"
-      }
-    },
-    "zone": {
-      "widthLabel": "Width",
-      "heightLabel": "Height",
-      "errors": {
-        "outOfBounds": "Zone must be positive and fit inside the template"
-      }
-    },
-    "save": {
-      "button": "Save template",
-      "success": "Template saved",
-      "failure": "Failed to save template"
-    },
-    "clear": {
-      "button": "Remove template",
-      "success": "Template removed",
-      "failure": "Failed to remove template"
-    },
-    "generate": {
-      "button": "Generate flyer",
-      "success": "Flyer generated and attached to the communication support",
-      "failure": "Failed to generate flyer",
-      "disabled": {
-        "notValidated": "Partnership is not yet validated",
-        "noLogo": "Company has no logo yet"
-      }
-    },
-    "errors": {
-      "generic": "Something went wrong. Please try again."
-    }
   }
 }

--- a/front/locales/fr-FR.json
+++ b/front/locales/fr-FR.json
@@ -277,47 +277,5 @@
       "noSponsors": "Aucun sponsor Pack Silver ou Pack Gold validé pour cet événement.",
       "noLocation": "Non assigné"
     }
-  },
-  "flyer": {
-    "templateSection": {
-      "title": "Modèle de flyer",
-      "help": "Téléchargez un modèle PNG et délimitez la zone où le logo du partenaire sera composé."
-    },
-    "upload": {
-      "dropPng": "Cliquez pour sélectionner ou glissez-déposez un PNG",
-      "errors": {
-        "notPng": "Seuls les fichiers PNG sont acceptés",
-        "tooLarge": "Le fichier ne doit pas dépasser 10 Mo"
-      }
-    },
-    "zone": {
-      "widthLabel": "Largeur",
-      "heightLabel": "Hauteur",
-      "errors": {
-        "outOfBounds": "La zone doit être positive et tenir dans le modèle"
-      }
-    },
-    "save": {
-      "button": "Enregistrer le modèle",
-      "success": "Modèle enregistré",
-      "failure": "Échec de l'enregistrement du modèle"
-    },
-    "clear": {
-      "button": "Supprimer le modèle",
-      "success": "Modèle supprimé",
-      "failure": "Échec de la suppression du modèle"
-    },
-    "generate": {
-      "button": "Générer le flyer",
-      "success": "Flyer généré et attaché au support de communication",
-      "failure": "Échec de la génération du flyer",
-      "disabled": {
-        "notValidated": "Le partenariat n'est pas encore validé",
-        "noLogo": "L'entreprise n'a pas encore fourni de logo"
-      }
-    },
-    "errors": {
-      "generic": "Une erreur est survenue. Veuillez réessayer."
-    }
   }
 }


### PR DESCRIPTION
The flyer UI was rendering literal key paths (e.g. \"flyer.generate.button\") instead of translated text because the keys lived in the wrong place.

## Root cause

The frontend has two parallel storage shapes for i18n content that don't talk to each other:

- **\`i18n.config.ts\`** — the file Vue i18n actually loads (referenced by \`vueI18n: \"./i18n.config.ts\"\` in nuxt.config). Locale keys are short codes (\`fr\`, \`en\`, \`es\`).
- **\`locales/{fr-FR,en-US,es-ES}.json\`** — JSON files with full locale codes. Used by the \`scripts/check-i18n.ts\` static checker but **NOT loaded by Vue i18n at runtime**.

The original flyer i18n work added keys only to the JSON files. The runtime i18n had nothing to look up, so every \`\$t(\"flyer.*\")\` call returned the key path string verbatim.

## Changes

1. **\`fix(front): add flyer translations to runtime i18n config\`** — port the full \`flyer\` namespace into \`messages.{fr,en,es}\` in \`i18n.config.ts\`. Spanish gets actual Spanish translations to match the convention used by neighbouring sections.
2. **\`chore(front): remove orphan flyer keys from locales/*.json\`** — drop the now-duplicate \`flyer\` block from the three JSON files so there's only one source of truth for runtime translations. The checker script keeps working for the rest of the file contents.

## Test plan

- [x] \`cd front && pnpm test:run\` — 1289/1289 pass.
- [x] \`cd front && pnpm lint\` — clean (1 pre-existing warning unchanged).
- [ ] Manual smoke: reload \`/orgs/{slug}/events/{eventSlug}/communication\` → confirm the "Générer le flyer" button now shows the French label (and the disabled-state tooltip shows "Le partenariat n'est pas encore validé"). Same for the flyer template section on the pack edit page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)