### PR TITLE
fix(flyer): cross-pack contamination + suggestion-approved partnerships

### DIFF
--- a/front/pages/orgs/[slug]/events/[eventSlug]/packs/[packId]/index.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/packs/[packId]/index.vue
@@ -25,6 +25,7 @@
           @save="onSave"
         />
         <FlyerTemplateConfig
+          :key="packId"
           :org-slug="orgSlug"
           :event-slug="eventSlug"
           :pack-id="packId"

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/application/DigestRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/application/DigestRepositoryExposed.kt
@@ -17,6 +17,7 @@ import fr.devlille.partners.connect.partnership.infrastructure.db.BillingEntity
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipEntity
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipSupportVideoEntity
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipsTable
+import fr.devlille.partners.connect.partnership.infrastructure.db.validatedPack
 import fr.devlille.partners.connect.sponsoring.infrastructure.db.hasFlyerTemplate
 import io.ktor.server.plugins.NotFoundException
 import kotlinx.datetime.LocalDate
@@ -118,9 +119,8 @@ class DigestRepositoryExposed : DigestRepository {
         PartnershipEntity
             .find { PartnershipsTable.eventId eq eventId }
             .filter { partnership ->
-                partnership.validatedAt != null &&
-                    partnership.communicationSupportUrl == null &&
-                    partnership.selectedPack?.hasFlyerTemplate() == true
+                partnership.communicationSupportUrl == null &&
+                    partnership.validatedPack()?.hasFlyerTemplate() == true
             }
             .map { DigestEntry(it.company.name, buildLink(eventSlug, it.id.value)) }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/FlyerGenerationRepositoryImpl.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/application/FlyerGenerationRepositoryImpl.kt
@@ -8,6 +8,7 @@ import fr.devlille.partners.connect.internal.infrastructure.bucket.Storage
 import fr.devlille.partners.connect.partnership.domain.FlyerGenerationRepository
 import fr.devlille.partners.connect.partnership.domain.GeneratedFlyer
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.validatedPack
 import fr.devlille.partners.connect.sponsoring.domain.FlyerZone
 import fr.devlille.partners.connect.sponsoring.infrastructure.db.hasFlyerTemplate
 import io.ktor.client.HttpClient
@@ -47,11 +48,8 @@ class FlyerGenerationRepositoryImpl(
         if (partnership.event.id != event.id) {
             throw NotFoundException("Partnership $partnershipId not found in event $eventSlug")
         }
-        if (partnership.validatedAt == null) {
-            throw ConflictException("Partnership must be validated before generating a flyer")
-        }
-        val pack = partnership.selectedPack
-            ?: throw ConflictException("Partnership has no selected pack")
+        val pack = partnership.validatedPack()
+            ?: throw ConflictException("Partnership must be validated before generating a flyer")
         if (!pack.hasFlyerTemplate()) {
             throw ConflictException("Pack ${pack.id.value} is not flyer-enabled")
         }


### PR DESCRIPTION
Three bugs reported after the previous flyer fixes landed. Two are fixed here; the third is investigated below with a likely cause and a no-code mitigation.

## Bug 1: same flyer template appears on every pack

\`FlyerTemplateConfig.vue\` reads \`props.initialTemplateUrl\` and \`props.initialZone\` **once at setup time** into local refs (\`previewUrl\`, \`zone\`). When the user navigates between pack edit pages (\`/packs/A\` → \`/packs/B\`), Vue reuses the same component instance because its position in the tree is unchanged — props update but the local refs keep pack A's values, so pack B's edit page shows pack A's template overlay.

**Fix:** \`:key=\"packId\"\` on \`<FlyerTemplateConfig>\` in the parent page forces a fresh mount per pack, so setup-time initialisation re-runs against the new pack's data.

## Bug 2: "Partnership not validated" on partnerships that ARE validated

The backend \`FlyerGenerationRepositoryImpl\` was checking \`partnership.validatedAt != null\`. But the codebase has **two** validation flows:

1. **Direct validation** — organiser validates → sets \`validatedAt\`. ✓ check passes
2. **Suggestion approval** — organiser proposes a pack → partner approves → sets \`suggestionApprovedAt\` but **not** \`validatedAt\`. ✗ check fails

The canonical "is this partnership validated, and which pack is the approved one?" helper is \`partnership.validatedPack()\` (defined in \`PartnershipEntity.kt\`), which handles both flows. The fix switches the flyer-generation precondition (and the digest eligibility query) to use this helper.

Also corrected as a side-effect: the generator was reading \`pack.flyerTemplateUrl\` from \`partnership.selectedPack\`, but the actual validated pack may be the *suggestion* pack — which has its own (possibly different) flyer template. Now uses \`validatedPack()\` as the source of the template, matching organiser intent.

## Bug 3: still seeing translation keys

The \`i18n.config.ts\` on \`main\` contains the \`flyer.*\` namespace under \`messages.{fr,en,es}\` (verified at lines 128 / 284 / 441). Component templates reference those keys correctly. **At the source level the fix is in place.**

Most likely cause for what you're seeing: **Nuxt's \`@nuxtjs/i18n\` pre-compiles messages at build time** (\`compilation: { strictMessage: false }\` in \`nuxt.config.ts\`). HMR for \`i18n.config.ts\` is notoriously flaky — a config change after \`pnpm dev\` was already running usually doesn't take effect until you restart the dev server. **Try \`pnpm dev\` from a fresh terminal**; that should resolve it.

If keys are still showing after a restart, that points to a deeper issue (locale mismatch, browser cookie, or unplugin caching). Happy to dig further with the network tab + \`localStorage\` output in that case.

## Test plan

- [x] \`./gradlew :application:test :application:ktlintCheck :application:detekt\` — green.
- [x] \`cd front && pnpm test:run && pnpm lint\` — 1289/1289 pass, lint clean.
- [ ] Manual smoke after merge:
  - Configure a flyer template on pack A → save → navigate to pack B's edit page → the flyer template section should be **empty** for pack B.
  - On a partnership validated via suggestion approval → click "Générer le flyer" → request should succeed (not 409).
  - Restart \`pnpm dev\` → reload the org communication page → the button label and disabled-state tooltips should now show the French text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)