### PR TITLE
refactor(front): trust backend for flyer precondition errors

### DIFF
--- a/front/components/CommunicationCard.vue
+++ b/front/components/CommunicationCard.vue
@@ -47,14 +47,11 @@
         {{ item.support_url ? 'Changer' : 'Ajouter' }}
       </UButton>
 
-      <!-- has-logo is delegated to the backend (409 toast) — PartnershipItemSchema does not surface company media. -->
       <GenerateFlyerButton
         v-if="partnership"
         :org-slug="orgSlug"
         :event-slug="eventSlug"
         :partnership-id="partnership.id"
-        :is-validated="!!partnership.validated_pack_id"
-        :has-logo="true"
       />
     </div>
 

--- a/front/components/GenerateFlyerButton.vue
+++ b/front/components/GenerateFlyerButton.vue
@@ -5,8 +5,6 @@
     color="neutral"
     icon="i-heroicons-paint-brush"
     :loading="generating"
-    :disabled="disabled"
-    :title="disabledReason ?? undefined"
     @click="handleClick"
   >
     {{ $t("flyer.generate.button") }}
@@ -21,8 +19,6 @@ interface Props {
   orgSlug: string;
   eventSlug: string;
   partnershipId: string;
-  isValidated: boolean;
-  hasLogo: boolean;
 }
 
 const props = defineProps<Props>();
@@ -33,16 +29,8 @@ const sponsorsStore = useSponsorsStore();
 
 const generating = ref(false);
 
-const disabledReason = computed(() => {
-  if (!props.isValidated) return t("flyer.generate.disabled.notValidated");
-  if (!props.hasLogo) return t("flyer.generate.disabled.noLogo");
-  return null;
-});
-
-const disabled = computed(() => disabledReason.value !== null || generating.value);
-
 async function handleClick() {
-  if (disabled.value) return;
+  if (generating.value) return;
   generating.value = true;
   try {
     const response = await postOrgsEventsPartnershipsFlyer(

--- a/front/i18n.config.ts
+++ b/front/i18n.config.ts
@@ -158,10 +158,6 @@ export default defineI18nConfig(() => ({
           button: "Générer le flyer",
           success: "Flyer généré et attaché au support de communication",
           failure: "Échec de la génération du flyer",
-          disabled: {
-            notValidated: "Le partenariat n'est pas encore validé",
-            noLogo: "L'entreprise n'a pas encore fourni de logo",
-          },
         },
         errors: {
           generic: "Une erreur est survenue. Veuillez réessayer.",
@@ -314,10 +310,6 @@ export default defineI18nConfig(() => ({
           button: "Generate flyer",
           success: "Flyer generated and attached to the communication support",
           failure: "Failed to generate flyer",
-          disabled: {
-            notValidated: "Partnership is not yet validated",
-            noLogo: "Company has no logo yet",
-          },
         },
         errors: {
           generic: "Something went wrong. Please try again.",
@@ -471,10 +463,6 @@ export default defineI18nConfig(() => ({
           button: "Generar flyer",
           success: "Flyer generado y adjuntado al soporte de comunicación",
           failure: "Error al generar el flyer",
-          disabled: {
-            notValidated: "La asociación aún no ha sido validada",
-            noLogo: "La empresa aún no ha proporcionado un logo",
-          },
         },
         errors: {
           generic: "Se produjo un error. Por favor, inténtelo de nuevo.",

--- a/front/plugins/i18n.ts
+++ b/front/plugins/i18n.ts
@@ -181,10 +181,6 @@ export default defineNuxtPlugin((nuxtApp) => {
         button: "Générer le flyer",
         success: "Flyer généré et attaché au support de communication",
         failure: "Échec de la génération du flyer",
-        disabled: {
-          notValidated: "Le partenariat n'est pas encore validé",
-          noLogo: "L'entreprise n'a pas encore fourni de logo",
-        },
       },
       errors: {
         generic: "Une erreur est survenue. Veuillez réessayer.",
@@ -359,10 +355,6 @@ export default defineNuxtPlugin((nuxtApp) => {
         button: "Generate flyer",
         success: "Flyer generated and attached to the communication support",
         failure: "Failed to generate flyer",
-        disabled: {
-          notValidated: "Partnership is not yet validated",
-          noLogo: "Company has no logo yet",
-        },
       },
       errors: {
         generic: "Something went wrong. Please try again.",
@@ -538,10 +530,6 @@ export default defineNuxtPlugin((nuxtApp) => {
         button: "Generar flyer",
         success: "Flyer generado y adjuntado al soporte de comunicación",
         failure: "Error al generar el flyer",
-        disabled: {
-          notValidated: "La asociación aún no ha sido validada",
-          noLogo: "La empresa aún no ha proporcionado un logo",
-        },
       },
       errors: {
         generic: "Se produjo un error. Por favor, inténtelo de nuevo.",


### PR DESCRIPTION
Simplify the Generate flyer button's enable/disable logic to a single in-flight check, relying on the backend's 409 responses (surfaced as toasts) for every precondition.

## Before

\`GenerateFlyerButton\` evaluated two preconditions client-side:

- \`isValidated\`: bound to \`!!partnership.validated_pack_id\`. Disabled the button with a "not validated" tooltip when the partnership had no validated pack.
- \`hasLogo\`: hardcoded to \`true\` because \`PartnershipItemSchema\` doesn't expose logo information. Never disabled in practice.

Plus a third precondition (\`pack flyer-enabled\`) which was already only checked server-side and surfaced via 409 + toast.

So the button gave one out of three preconditions a preview, with the other two falling through to backend errors. The split was inconsistent and the validation proxy (\`validated_pack_id\`) was a partial match for the backend's actual check (\`validatedPack() != null\`, which now covers both the direct-validation and suggestion-approval flows after #201).

## After

The button is **always enabled** except while a generation request is in flight. All three preconditions — validation, logo, pack flyer-enabled — are reported via the backend's 409 \`ConflictException\` message, surfaced as a toast with the exact backend reason. One code path, no client-side proxy, no schema duplication.

## Changes

- \`components/GenerateFlyerButton.vue\`: drop the \`isValidated\` / \`hasLogo\` props, the \`disabledReason\` computed, and the \`:disabled\` / \`:title\` bindings on the \`<UButton>\`. Only \`:loading="generating"\` remains, which both shows the spinner and blocks re-click.
- \`components/CommunicationCard.vue\`: stop passing the two removed props (and remove the now-stale code comment that justified the \`has-logo\` hardcode).
- \`i18n.config.ts\` and \`plugins/i18n.ts\`: remove the orphan \`flyer.generate.disabled.{notValidated,noLogo}\` keys from all three locales (fr/en/es).

## Test plan

- [x] \`cd front && pnpm test:run\` — 1289/1289 pass.
- [x] \`cd front && pnpm lint\` — clean (one pre-existing warning unrelated).
- [x] \`grep\` for \`isValidated\`, \`hasLogo\`, \`is-validated\`, \`has-logo\`, \`flyer.generate.disabled\` — no remaining references.
- [ ] Manual smoke:
  - Click the button on an un-validated partnership → backend returns 409 "Partnership must be validated" → toast appears.
  - Click the button on a partnership whose company has no logo → backend returns 409 "Company has no logo" → toast appears.
  - Click on a happy-path partnership → success toast + flyer URL updates in the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)