### PR TITLE
feat(front): clickable communication cards open per-sponsor page

### DIFF
--- a/front/components/CommunicationCard.vue
+++ b/front/components/CommunicationCard.vue
@@ -1,5 +1,18 @@
 <template>
-  <div class="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
+  <div
+    class="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow"
+    :class="
+      item.partnership_id
+        ? 'cursor-pointer hover:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-400'
+        : ''
+    "
+    :role="item.partnership_id ? 'link' : undefined"
+    :tabindex="item.partnership_id ? 0 : undefined"
+    :aria-label="item.partnership_id ? `Ouvrir la communication de ${item.title}` : undefined"
+    @click="onCardClick"
+    @keydown.enter="onCardClick"
+    @keydown.space.prevent="onCardClick"
+  >
     <!-- Header avec titre -->
     <div class="flex items-start justify-between mb-3">
       <div class="flex-1">
@@ -32,7 +45,7 @@
         variant="ghost"
         color="neutral"
         icon="i-heroicons-calendar"
-        @click="$emit('schedule', item)"
+        @click.stop="$emit('schedule', item)"
       >
         {{ status === 'done' ? 'Reprogrammer' : item.publication_date ? 'Modifier la date' : 'Planifier' }}
       </UButton>
@@ -42,7 +55,7 @@
         variant="ghost"
         color="neutral"
         icon="i-heroicons-photo"
-        @click="$emit('upload', item)"
+        @click.stop="$emit('upload', item)"
       >
         {{ item.support_url ? 'Changer' : 'Ajouter' }}
       </UButton>
@@ -52,6 +65,7 @@
         :org-slug="orgSlug"
         :event-slug="eventSlug"
         :partnership-id="partnership.id"
+        @click.stop
       />
     </div>
 
@@ -62,7 +76,7 @@
         variant="ghost"
         color="neutral"
         icon="i-heroicons-pencil"
-        @click="$emit('edit', item)"
+        @click.stop="$emit('edit', item)"
       >
         Modifier
       </UButton>
@@ -72,7 +86,7 @@
         variant="ghost"
         color="error"
         icon="i-heroicons-trash"
-        @click="$emit('delete', item)"
+        @click.stop="$emit('delete', item)"
       >
         Supprimer
       </UButton>
@@ -99,6 +113,15 @@ defineEmits<{
   edit: [item: CommunicationItemSchema];
   delete: [item: CommunicationItemSchema];
 }>();
+
+const router = useRouter();
+
+function onCardClick() {
+  if (!props.item.partnership_id) return;
+  router.push(
+    `/orgs/${props.orgSlug}/events/${props.eventSlug}/sponsors/${props.item.partnership_id}/communication`,
+  );
+}
 
 const statusLabel = computed(() => {
   switch (props.status) {
@@ -131,7 +154,7 @@ function formatDate(dateString: string) {
   return new Intl.DateTimeFormat('fr-FR', {
     year: 'numeric',
     month: 'long',
-    day: 'numeric'
+    day: 'numeric',
   }).format(date);
 }
 </script>

--- a/front/tests/components/CommunicationCard.test.ts
+++ b/front/tests/components/CommunicationCard.test.ts
@@ -220,4 +220,38 @@ describe("CommunicationCard", () => {
       expect(wrapper.text()).toContain("Non planifiée");
     });
   });
+
+  describe("Clickable surface", () => {
+    it("exposes a link-shaped root when partnership_id is set", () => {
+      const wrapper = mount(CommunicationCard, {
+        props: {
+          item: partnershipItem,
+          status: "unplanned",
+          orgSlug: "test-org",
+          eventSlug: "test-event",
+        },
+      });
+
+      const root = wrapper.element as HTMLElement;
+      expect(root.getAttribute("role")).toBe("link");
+      expect(root.getAttribute("tabindex")).toBe("0");
+      expect(root.getAttribute("aria-label")).toContain("Acme Corp");
+    });
+
+    it("does not expose link semantics for standalone communications", () => {
+      const wrapper = mount(CommunicationCard, {
+        props: {
+          item: standaloneItem,
+          status: "unplanned",
+          orgSlug: "test-org",
+          eventSlug: "test-event",
+        },
+      });
+
+      const root = wrapper.element as HTMLElement;
+      expect(root.getAttribute("role")).toBeNull();
+      expect(root.getAttribute("tabindex")).toBeNull();
+      expect(wrapper.find('[role="link"]').exists()).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
On the org communication page (\`/orgs/.../events/.../communication\`), each \`CommunicationCard\` now navigates to \`/orgs/.../sponsors/{partnership_id}/communication\` when clicked. That destination page already renders the download link for the partnership's visual support, so this PR is purely a navigation enhancement — no new endpoints or data plumbing.

## What's clickable, what isn't

| Card type | Clickable? | Target |
|---|---|---|
| Partnership-linked (\`item.partnership_id\` set) | Yes | \`/orgs/{slug}/events/{eventSlug}/sponsors/{partnership_id}/communication\` |
| Standalone communication (\`partnership_id\` null) | No | — (no partnership detail page exists) |

The gating is applied at the DOM level: only partnership-linked cards get \`role="link"\`, \`tabindex="0"\`, \`aria-label\`, \`cursor-pointer\`, and the click + keyboard handlers. Standalone cards remain unchanged.

## Inner buttons

The 5 action buttons inside the card (Planifier / Ajouter / Générer le flyer / Modifier / Supprimer) all use \`@click.stop\` so clicking them fires their own emit/handler without also triggering the card navigation. Verified by code structure (\`.stop\` modifiers added on all internal buttons in the partnership-linked branch).

## Accessibility

- \`role="link"\` so screen readers announce the card as a navigable surface.
- \`tabindex="0"\` so keyboard users can focus the card.
- \`@keydown.enter\` and \`@keydown.space.prevent\` handlers so Enter/Space trigger navigation, matching native link behaviour.
- \`aria-label\` derived from the item title (e.g. "Ouvrir la communication de Acme Corp").
- Focus ring (\`focus:ring-2 focus:ring-primary-400\`) for visible keyboard focus.

## Why not \`<NuxtLink>\`?

A \`<NuxtLink>\` renders as \`<a>\`, and HTML doesn't allow interactive content (buttons) inside \`<a>\`. The card has 3-5 inner buttons depending on partnership/standalone status. Using \`@click\` + \`useRouter().push()\` on a focusable \`<div>\` is the correct shape for this composition.

## Test plan

- [x] \`cd front && pnpm test:run\` — 1291/1291 pass (2 new DOM-semantic tests on \`CommunicationCard\`).
- [x] \`cd front && pnpm lint\` — clean (1 pre-existing warning unchanged).
- [ ] Manual smoke:
  - Click anywhere on a partnership-linked card (NOT on an inner button) → page navigates to the per-sponsor communication page.
  - Click on the "Planifier", "Ajouter", "Générer le flyer" buttons → modal opens / flyer generates without triggering navigation.
  - Click on a standalone communication card → nothing happens; "Modifier" / "Supprimer" still work as before.
  - Keyboard: Tab to a partnership card, Enter or Space → navigates. Tab again, Enter on an inner button → button's action fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)