### PR TITLE
fix(front): send null for unused company fields when creating a partner

### DIFF
--- a/front/pages/orgs/[slug]/events/[eventSlug]/partners/create.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/partners/create.vue
@@ -213,18 +213,16 @@ async function onSave() {
     saving.value = true;
     error.value = null;
 
-    // Step 1: create the legal entity (company)
+    // Step 1: create the legal entity (company). For ecosystem partners we
+    // only collect name + site URL; head_office, siret, and vat stay null so
+    // we don't trip the API's pattern validation (empty string does not match
+    // the SIRET / VAT regex and is not null either).
     const companyData: CreateCompany = {
       name: form.company_name,
-      head_office: {
-        address: "",
-        city: "",
-        zip_code: "",
-        country: "",
-      },
-      siret: "",
-      vat: "",
-      site_url: form.site_url || "",
+      head_office: null,
+      siret: null,
+      vat: null,
+      site_url: form.site_url || null,
     };
     const companyResponse = await postCompanies(companyData);
     const companyId = companyResponse.data.id;


### PR DESCRIPTION
## Summary

Hotfix for the partner-creation flow.

Calling `POST /companies` from `partners/create.vue` was sending `siret: ''`, `vat: ''`, and a `head_office` of empty strings. The server validates `siret` and `vat` as `anyOf: [{pattern}, {null}]` — empty string is a string but does not match the regex, so the request was rejected with:

```
{
  "errors": [
    "string does not match pattern '^\\d{14}$'",
    "element is not a null",
    "string does not match pattern '^[A-Z]{2}[0-9A-Z]+$'",
    "element is not a null"
  ]
}
```

For ecosystem partners we only collect `name` + `site_url`, so this PR explicitly sends `null` for `head_office`, `siret`, and `vat` instead of empty strings.

## Known follow-up

`sponsors/create.vue` has the same anti-pattern (lines 269–280 currently). It will fail the same way the next time someone creates a sponsor — to be fixed in a separate PR.

## Test plan

- [ ] Manual: create a partner with name + URL only → company created, partner row created, auto-validated, redirect to the detail page
- [ ] Confirm Sentry no longer logs the schema-validation 400 from `/api/companies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)