### PR TITLE
feat(server): dedicated repository + plugin for ecosystem partner notifications

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerNotificationRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/application/EcosystemPartnerNotificationRepositoryExposed.kt
@@ -1,0 +1,159 @@
+package fr.devlille.partners.connect.ecosystempartners.application
+
+import com.slack.api.Slack
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerLifecycleEvent
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerNotificationRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEmailEntity
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.db.EcosystemPartnerEntity
+import fr.devlille.partners.connect.events.domain.EventRepository
+import fr.devlille.partners.connect.integrations.domain.IntegrationProvider
+import fr.devlille.partners.connect.integrations.domain.IntegrationUsage
+import fr.devlille.partners.connect.integrations.infrastructure.db.IntegrationEntity
+import fr.devlille.partners.connect.integrations.infrastructure.db.IntegrationsTable
+import fr.devlille.partners.connect.integrations.infrastructure.db.MailjetIntegrationsTable
+import fr.devlille.partners.connect.integrations.infrastructure.db.SlackIntegrationsTable
+import fr.devlille.partners.connect.integrations.infrastructure.db.get
+import fr.devlille.partners.connect.internal.infrastructure.resources.readResourceFile
+import fr.devlille.partners.connect.notifications.infrastructure.providers.Contact
+import fr.devlille.partners.connect.notifications.infrastructure.providers.MailjetBody
+import fr.devlille.partners.connect.notifications.infrastructure.providers.MailjetProvider
+import fr.devlille.partners.connect.notifications.infrastructure.providers.Message
+import io.ktor.server.plugins.NotFoundException
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+
+/**
+ * Dispatches ecosystem partner lifecycle notifications by talking to the raw
+ * Mailjet and Slack providers directly. Bypasses the partnership-centric
+ * `NotificationRepository` / `MailjetNotificationGateway` so we don't have to
+ * fabricate a classic partnership row for every ecosystem partner email.
+ */
+class EcosystemPartnerNotificationRepositoryExposed(
+    private val eventRepository: EventRepository,
+    private val mailjetProvider: MailjetProvider,
+    private val slack: Slack,
+) : EcosystemPartnerNotificationRepository {
+    override suspend fun notify(
+        eventSlug: String,
+        ecosystemPartnerId: UUID,
+        lifecycle: EcosystemPartnerLifecycleEvent,
+    ) {
+        val context = transaction { loadContext(eventSlug, ecosystemPartnerId) }
+        val eventWithOrganisation = eventRepository.getBySlug(eventSlug)
+        val populate: (String) -> String = { content ->
+            populateTemplate(content, context, eventWithOrganisation)
+        }
+
+        val integrations = transaction {
+            IntegrationEntity
+                .find {
+                    IntegrationsTable.eventId eq context.eventId and
+                        (IntegrationsTable.usage eq IntegrationUsage.NOTIFICATION)
+                }
+                .toList()
+                .map { it.id.value to it.provider }
+        }
+
+        integrations.forEach { (integrationId, provider) ->
+            when (provider) {
+                IntegrationProvider.MAILJET -> sendMailjet(
+                    integrationId = integrationId,
+                    lifecycle = lifecycle,
+                    context = context,
+                    populate = populate,
+                )
+                IntegrationProvider.SLACK -> sendSlack(
+                    integrationId = integrationId,
+                    lifecycle = lifecycle,
+                    context = context,
+                    populate = populate,
+                )
+                else -> Unit
+            }
+        }
+    }
+
+    private suspend fun sendMailjet(
+        integrationId: UUID,
+        lifecycle: EcosystemPartnerLifecycleEvent,
+        context: NotificationContext,
+        populate: (String) -> String,
+    ) {
+        if (context.partnerEmails.isEmpty()) return
+        val headerPath = "/notifications/email/${lifecycle.templateName}/header.${context.language}.txt"
+        val contentPath = "/notifications/email/${lifecycle.templateName}/content.${context.language}.html"
+        val subject = runCatching { populate(readResourceFile(headerPath)) }.getOrNull()
+        val htmlBody = runCatching { populate(readResourceFile(contentPath)) }.getOrNull()
+        if (subject == null || htmlBody == null) return
+        val config = transaction { MailjetIntegrationsTable[integrationId] }
+        val body = MailjetBody(
+            messages = listOf(
+                Message(
+                    from = Contact(email = context.eventContactEmail, name = context.eventName),
+                    to = context.partnerEmails.map { Contact(email = it, name = null) },
+                    cc = null,
+                    subject = "[${context.eventName}][${context.companyName}] $subject",
+                    htmlPart = htmlBody,
+                ),
+            ),
+        )
+        mailjetProvider.send(body, config)
+    }
+
+    private fun sendSlack(
+        integrationId: UUID,
+        lifecycle: EcosystemPartnerLifecycleEvent,
+        context: NotificationContext,
+        populate: (String) -> String,
+    ) {
+        val path = "/notifications/slack/${lifecycle.templateName}/${context.language}.md"
+        val message = runCatching { populate(readResourceFile(path)) }.getOrNull() ?: return
+        val config = transaction { SlackIntegrationsTable[integrationId] }
+        slack.methods(config.token).chatPostMessage {
+            it.channel(config.channel).text(message)
+        }
+    }
+
+    private fun loadContext(eventSlug: String, ecosystemPartnerId: UUID): NotificationContext {
+        val entity = EcosystemPartnerEntity.findById(ecosystemPartnerId)
+            ?: throw NotFoundException("Ecosystem partner $ecosystemPartnerId not found")
+        if (entity.event.slug != eventSlug) {
+            throw NotFoundException("Ecosystem partner $ecosystemPartnerId does not belong to event $eventSlug")
+        }
+        val emails = EcosystemPartnerEmailEntity
+            .listByEcosystemPartner(ecosystemPartnerId)
+            .map { it.email }
+        return NotificationContext(
+            eventId = entity.event.id.value,
+            eventName = entity.event.name,
+            eventContactEmail = entity.event.contactEmail,
+            companyName = entity.company.name,
+            categoryName = entity.category.name,
+            language = entity.language,
+            partnerEmails = emails,
+        )
+    }
+
+    private fun populateTemplate(
+        content: String,
+        context: NotificationContext,
+        eventWithOrganisation: fr.devlille.partners.connect.events.domain.EventWithOrganisation,
+    ): String = content
+        .replace("{{event_name}}", context.eventName)
+        .replace("{{event_contact}}", context.eventContactEmail)
+        .replace("{{company_name}}", context.companyName)
+        .replace("{{category_name}}", context.categoryName)
+        .replace("{{public_event_url}}", publicEventUrl(eventWithOrganisation))
+
+    private data class NotificationContext(
+        val eventId: UUID,
+        val eventName: String,
+        val eventContactEmail: String,
+        val companyName: String,
+        val categoryName: String,
+        val language: String,
+        val partnerEmails: List<String>,
+    )
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerNotificationRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/domain/EcosystemPartnerNotificationRepository.kt
@@ -1,0 +1,34 @@
+package fr.devlille.partners.connect.ecosystempartners.domain
+
+import java.util.UUID
+
+/**
+ * Lifecycle events that trigger a notification for an ecosystem partner.
+ * Each value maps to a notification template directory under
+ * `notifications/{email|slack}/ecosystem_partner_<templateName>/`.
+ */
+enum class EcosystemPartnerLifecycleEvent(val templateName: String) {
+    SUBMITTED("ecosystem_partner_submitted"),
+    VALIDATED("ecosystem_partner_validated"),
+    DECLINED("ecosystem_partner_declined"),
+    REMOVED("ecosystem_partner_removed"),
+}
+
+/**
+ * Dispatches ecosystem partner lifecycle notifications through the
+ * configured notification integrations for an event (Mailjet, Slack).
+ *
+ * This is intentionally separate from the partnership-centric
+ * `NotificationRepository.sendMessage(variables)` pipeline: ecosystem
+ * partners do not have a classic `PartnershipEntity`, and re-using the
+ * Mailjet gateway's partnership lookup would either crash or require a
+ * compromised abstraction. Treating ecosystem partner notifications as
+ * their own domain concern keeps both pipelines focused.
+ */
+interface EcosystemPartnerNotificationRepository {
+    suspend fun notify(
+        eventSlug: String,
+        ecosystemPartnerId: UUID,
+        lifecycle: EcosystemPartnerLifecycleEvent,
+    )
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerDecisionRoutes.kt
@@ -1,16 +1,12 @@
 package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
 
-import fr.devlille.partners.connect.companies.domain.CompanyRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerDecisionRepository
-import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
-import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
-import fr.devlille.partners.connect.events.domain.EventRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerLifecycleEvent
 import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.NotificationEcosystemPartnerPlugin
 import fr.devlille.partners.connect.internal.infrastructure.ktor.WebhookEcosystemPartnerPlugin
-import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
-import fr.devlille.partners.connect.notifications.domain.NotificationRepository
-import fr.devlille.partners.connect.notifications.domain.NotificationVariables
+import fr.devlille.partners.connect.internal.infrastructure.ktor.ecosystemPartnerLifecycle
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -20,52 +16,31 @@ import org.koin.ktor.ext.inject
 
 fun Route.ecosystemPartnerDecisionRoutes() {
     val repository by inject<EcosystemPartnerDecisionRepository>()
-    val ecosystemPartnerRepository by inject<EcosystemPartnerRepository>()
-    val eventRepository by inject<EventRepository>()
-    val companyRepository by inject<CompanyRepository>()
-    val notificationRepository by inject<NotificationRepository>()
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/validate") {
         install(AuthorizedOrganisationPlugin)
+        install(NotificationEcosystemPartnerPlugin)
         install(WebhookEcosystemPartnerPlugin)
 
         post {
             val eventSlug = call.parameters.eventSlug
             val id = call.parameters.ecosystemPartnerId
             val result = repository.validate(eventSlug, id)
-            val partner = ecosystemPartnerRepository.getById(eventSlug, id)
-            val event = eventRepository.getBySlug(eventSlug)
-            val company = companyRepository.getById(partner.companyId.toUUID())
-            val variables = NotificationVariables.EcosystemPartnerValidated(
-                language = partner.language,
-                event = event,
-                company = company,
-                categoryName = partner.category.name,
-                publicEventUrl = publicEventUrl(event),
-            )
-            notificationRepository.sendMessage(variables)
+            call.attributes.ecosystemPartnerLifecycle = EcosystemPartnerLifecycleEvent.VALIDATED
             call.respond(HttpStatusCode.OK, mapOf("id" to result.toString()))
         }
     }
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners/{ecosystemPartnerId}/decline") {
         install(AuthorizedOrganisationPlugin)
+        install(NotificationEcosystemPartnerPlugin)
         install(WebhookEcosystemPartnerPlugin)
 
         post {
             val eventSlug = call.parameters.eventSlug
             val id = call.parameters.ecosystemPartnerId
             val result = repository.decline(eventSlug, id)
-            val partner = ecosystemPartnerRepository.getById(eventSlug, id)
-            val event = eventRepository.getBySlug(eventSlug)
-            val company = companyRepository.getById(partner.companyId.toUUID())
-            val variables = NotificationVariables.EcosystemPartnerDeclined(
-                language = partner.language,
-                event = event,
-                company = company,
-                categoryName = partner.category.name,
-            )
-            notificationRepository.sendMessage(variables)
+            call.attributes.ecosystemPartnerLifecycle = EcosystemPartnerLifecycleEvent.DECLINED
             call.respond(HttpStatusCode.OK, mapOf("id" to result.toString()))
         }
     }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/api/EcosystemPartnerRoutes.kt
@@ -1,19 +1,15 @@
 package fr.devlille.partners.connect.ecosystempartners.infrastructure.api
 
-import fr.devlille.partners.connect.companies.domain.CompanyRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerFilters
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerLifecycleEvent
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerNotificationRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.RegisterEcosystemPartner
 import fr.devlille.partners.connect.ecosystempartners.domain.UpdateEcosystemPartner
-import fr.devlille.partners.connect.ecosystempartners.domain.publicEventUrl
-import fr.devlille.partners.connect.events.domain.EventRepository
 import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
 import fr.devlille.partners.connect.internal.infrastructure.ktor.WebhookEcosystemPartnerPlugin
 import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
-import fr.devlille.partners.connect.internal.infrastructure.uuid.toUUID
-import fr.devlille.partners.connect.notifications.domain.NotificationRepository
-import fr.devlille.partners.connect.notifications.domain.NotificationVariables
 import fr.devlille.partners.connect.partnership.infrastructure.api.toBooleanStrict
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookRepository
@@ -36,9 +32,7 @@ fun Route.ecosystemPartnerRoutes() {
 
 private fun Route.publicEcosystemPartnerRoutes() {
     val repository by inject<EcosystemPartnerRepository>()
-    val eventRepository by inject<EventRepository>()
-    val companyRepository by inject<CompanyRepository>()
-    val notificationRepository by inject<NotificationRepository>()
+    val notificationRepository by inject<EcosystemPartnerNotificationRepository>()
     val webhookRepository by inject<WebhookRepository>()
 
     route("/events/{eventSlug}/ecosystem-partners") {
@@ -48,17 +42,7 @@ private fun Route.publicEcosystemPartnerRoutes() {
                 schema = "register_ecosystem_partner.schema.json",
             )
             val id = repository.register(eventSlug, request)
-            val partner = repository.getById(eventSlug, id)
-            val event = eventRepository.getBySlug(eventSlug)
-            val company = companyRepository.getById(request.companyId.toUUID())
-            val variables = NotificationVariables.EcosystemPartnerSubmitted(
-                language = request.language,
-                event = event,
-                company = company,
-                categoryName = partner.category.name,
-                publicEventUrl = publicEventUrl(event),
-            )
-            notificationRepository.sendMessage(variables)
+            notificationRepository.notify(eventSlug, id, EcosystemPartnerLifecycleEvent.SUBMITTED)
             webhookRepository.sendWebhooks(
                 eventSlug = eventSlug,
                 resourceType = WebhookResourceType.ECOSYSTEM_PARTNER,
@@ -104,9 +88,7 @@ private fun Route.publicEcosystemPartnerListingRoute() {
 
 private fun Route.orgsEcosystemPartnerRoutes() {
     val repository by inject<EcosystemPartnerRepository>()
-    val eventRepository by inject<EventRepository>()
-    val companyRepository by inject<CompanyRepository>()
-    val notificationRepository by inject<NotificationRepository>()
+    val notificationRepository by inject<EcosystemPartnerNotificationRepository>()
     val webhookRepository by inject<WebhookRepository>()
 
     route("/orgs/{orgSlug}/events/{eventSlug}/ecosystem-partners") {
@@ -130,16 +112,9 @@ private fun Route.orgsEcosystemPartnerRoutes() {
         delete {
             val eventSlug = call.parameters.eventSlug
             val id = call.parameters.ecosystemPartnerId
-            val partner = repository.getById(eventSlug, id)
-            val event = eventRepository.getBySlug(eventSlug)
-            val company = companyRepository.getById(partner.companyId.toUUID())
-            val variables = NotificationVariables.EcosystemPartnerRemoved(
-                language = partner.language,
-                event = event,
-                company = company,
-                categoryName = partner.category.name,
-            )
-            notificationRepository.sendMessage(variables)
+            // Notify + fire webhook BEFORE deleting so the repository can still
+            // read the partner row to build its payload.
+            notificationRepository.notify(eventSlug, id, EcosystemPartnerLifecycleEvent.REMOVED)
             webhookRepository.sendWebhooks(
                 eventSlug = eventSlug,
                 resourceType = WebhookResourceType.ECOSYSTEM_PARTNER,

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/bindings/EcosystemPartnerModule.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ecosystempartners/infrastructure/bindings/EcosystemPartnerModule.kt
@@ -2,9 +2,11 @@ package fr.devlille.partners.connect.ecosystempartners.infrastructure.bindings
 
 import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerCategoryRepositoryExposed
 import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerDecisionRepositoryExposed
+import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerNotificationRepositoryExposed
 import fr.devlille.partners.connect.ecosystempartners.application.EcosystemPartnerRepositoryExposed
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerCategoryRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerDecisionRepository
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerNotificationRepository
 import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerRepository
 import org.koin.dsl.module
 
@@ -12,4 +14,11 @@ val ecosystemPartnerModule = module {
     single<EcosystemPartnerCategoryRepository> { EcosystemPartnerCategoryRepositoryExposed() }
     single<EcosystemPartnerRepository> { EcosystemPartnerRepositoryExposed() }
     single<EcosystemPartnerDecisionRepository> { EcosystemPartnerDecisionRepositoryExposed() }
+    single<EcosystemPartnerNotificationRepository> {
+        EcosystemPartnerNotificationRepositoryExposed(
+            eventRepository = get(),
+            mailjetProvider = get(),
+            slack = get(),
+        )
+    }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/NotificationEcosystemPartnerPlugin.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/NotificationEcosystemPartnerPlugin.kt
@@ -1,0 +1,50 @@
+package fr.devlille.partners.connect.internal.infrastructure.ktor
+
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerLifecycleEvent
+import fr.devlille.partners.connect.ecosystempartners.domain.EcosystemPartnerNotificationRepository
+import fr.devlille.partners.connect.ecosystempartners.infrastructure.api.ecosystemPartnerId
+import fr.devlille.partners.connect.events.infrastructure.api.eventSlug
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
+import org.koin.ktor.ext.inject
+
+/**
+ * Triggers an ecosystem partner lifecycle notification after the route
+ * responds. The route handler must set the lifecycle event before
+ * `call.respond(...)` — for example:
+ *
+ * ```
+ * call.attributes.ecosystemPartnerLifecycle = EcosystemPartnerLifecycleEvent.VALIDATED
+ * call.respond(HttpStatusCode.OK, ...)
+ * ```
+ *
+ * Routes whose execution removes the partner (DELETE) or that don't have
+ * an `ecosystemPartnerId` in the path yet (POST create) call the
+ * repository directly instead of relying on this plugin.
+ */
+val NotificationEcosystemPartnerPlugin = createRouteScopedPlugin(name = "NotificationEcosystemPartnerPlugin") {
+    val repository by application.inject<EcosystemPartnerNotificationRepository>()
+
+    onCallRespond { call ->
+        val lifecycle = call.attributes.ecosystemPartnerLifecycleOrNull ?: return@onCallRespond
+        val eventSlug = call.parameters.eventSlug
+        val ecosystemPartnerId = call.parameters.ecosystemPartnerId
+        repository.notify(eventSlug, ecosystemPartnerId, lifecycle)
+    }
+}
+
+private object NotificationEcosystemPartnerPluginKeys {
+    val LifecycleKey = AttributeKey<EcosystemPartnerLifecycleEvent>(
+        "EcosystemPartnerNotificationLifecycle",
+    )
+}
+
+var Attributes.ecosystemPartnerLifecycle: EcosystemPartnerLifecycleEvent
+    get() = this[NotificationEcosystemPartnerPluginKeys.LifecycleKey]
+    set(value) {
+        this.put(NotificationEcosystemPartnerPluginKeys.LifecycleKey, value)
+    }
+
+private val Attributes.ecosystemPartnerLifecycleOrNull: EcosystemPartnerLifecycleEvent?
+    get() = this.getOrNull(NotificationEcosystemPartnerPluginKeys.LifecycleKey)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/notifications/domain/NotificationVariables.kt
@@ -361,67 +361,8 @@ sealed interface NotificationVariables {
         }
     }
 
-    data class EcosystemPartnerSubmitted(
-        override val language: String,
-        override val event: EventWithOrganisation,
-        override val company: Company,
-        val categoryName: String,
-        val publicEventUrl: String,
-    ) : NotificationVariables {
-        override val usageName: String = "ecosystem_partner_submitted"
-
-        override fun populate(content: String): String = content
-            .replace("{{event_name}}", event.event.name)
-            .replace("{{event_contact}}", event.event.contact.email)
-            .replace("{{company_name}}", company.name)
-            .replace("{{category_name}}", categoryName)
-            .replace("{{public_event_url}}", publicEventUrl)
-    }
-
-    data class EcosystemPartnerValidated(
-        override val language: String,
-        override val event: EventWithOrganisation,
-        override val company: Company,
-        val categoryName: String,
-        val publicEventUrl: String,
-    ) : NotificationVariables {
-        override val usageName: String = "ecosystem_partner_validated"
-
-        override fun populate(content: String): String = content
-            .replace("{{event_name}}", event.event.name)
-            .replace("{{event_contact}}", event.event.contact.email)
-            .replace("{{company_name}}", company.name)
-            .replace("{{category_name}}", categoryName)
-            .replace("{{public_event_url}}", publicEventUrl)
-    }
-
-    data class EcosystemPartnerDeclined(
-        override val language: String,
-        override val event: EventWithOrganisation,
-        override val company: Company,
-        val categoryName: String,
-    ) : NotificationVariables {
-        override val usageName: String = "ecosystem_partner_declined"
-
-        override fun populate(content: String): String = content
-            .replace("{{event_name}}", event.event.name)
-            .replace("{{event_contact}}", event.event.contact.email)
-            .replace("{{company_name}}", company.name)
-            .replace("{{category_name}}", categoryName)
-    }
-
-    data class EcosystemPartnerRemoved(
-        override val language: String,
-        override val event: EventWithOrganisation,
-        override val company: Company,
-        val categoryName: String,
-    ) : NotificationVariables {
-        override val usageName: String = "ecosystem_partner_removed"
-
-        override fun populate(content: String): String = content
-            .replace("{{event_name}}", event.event.name)
-            .replace("{{event_contact}}", event.event.contact.email)
-            .replace("{{company_name}}", company.name)
-            .replace("{{category_name}}", categoryName)
-    }
+    // Ecosystem partner lifecycle notifications live in their own dispatch
+    // pipeline — see `ecosystempartners.domain.EcosystemPartnerNotificationRepository`
+    // and `NotificationEcosystemPartnerPlugin`. They do not flow through the
+    // partnership-centric `NotificationRepository.sendMessage(variables)` path.
 }


### PR DESCRIPTION
## Summary

Re-architects the ecosystem partner notification path so it stops piggy-backing on the partnership-centric `MailjetNotificationGateway`. (Replaces the earlier type-branching hotfix on this PR.)

The previous server-side notification flow ran every variant through `MailjetNotificationGateway.send`, which looked up a classic `PartnershipEntity` by `company_id` to build the destination — and threw `NotFoundException` when the row was missing. Ecosystem partners don't have a classic partnership row, so the entire lifecycle (submitted / validated / declined / removed) was broken in production.

## Architecture

- **New domain interface** `EcosystemPartnerNotificationRepository` (+ `EcosystemPartnerLifecycleEvent` enum) owns the dispatch contract for the four lifecycle events.
- **New implementation** `EcosystemPartnerNotificationRepositoryExposed` talks to the raw `MailjetProvider` and `Slack` clients directly. Looks up notification integrations for the event, renders the per-lifecycle template from `notifications/{email,slack}/ecosystem_partner_<lifecycle>/`, and sends. No partnership lookup, ever.
- **New Ktor plugin** `NotificationEcosystemPartnerPlugin` mirrors the existing `NotificationPartnershipPlugin`: routes set `call.attributes.ecosystemPartnerLifecycle` before responding and the plugin fires `repository.notify(...)` on `onCallRespond`. Used for validate/decline.
- **POST submit and DELETE remove** call `repository.notify(...)` directly because the path either lacks `ecosystemPartnerId` (POST) or the row is gone by the time `onCallRespond` fires (DELETE).

## Reverted

- The type-branching `is NotificationVariables.EcosystemPartnerNotification` branch in `MailjetNotificationGateway`.
- The four `NotificationVariables.EcosystemPartner*` variants and the `EcosystemPartnerNotification` sealed marker, which were polluting the partnership-centric `NotificationVariables` sealed hierarchy.

## Test plan

- [x] `./gradlew check` clean — all 632 tests pass, ktlint + detekt clean
- [x] `npm run validate` clean
- [ ] Manual: create a partner (POST) → submitted email reaches partner contacts; webhook fires CREATED
- [ ] Manual: validate (POST /validate) → validated email reaches partner contacts; webhook fires UPDATED via plugin
- [ ] Manual: decline (POST /decline) → declined email reaches partner contacts; webhook fires UPDATED via plugin
- [ ] Manual: delete (DELETE) → removed email reaches partner contacts; webhook fires DELETED; row is deleted afterwards
- [ ] Classic partnership notifications still send (validate, decline, agreement) — `MailjetNotificationGateway` is byte-identical to its state before #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)