### PR TITLE
feat(server): add self-hosted LLM chat endpoints

### DIFF
--- a/.github/workflows/cd-server.yaml
+++ b/.github/workflows/cd-server.yaml
@@ -71,6 +71,7 @@ jobs:
             echo "postgres_user=${{ secrets.EXPOSED_DB_USER }}" >> $GITHUB_OUTPUT
             echo "postgres_password=${{ secrets.EXPOSED_DB_PASSWORD }}" >> $GITHUB_OUTPUT
             echo "qonto_base_url=https://thirdparty.qonto.com" >> $GITHUB_OUTPUT
+            echo "ollama_base_url=${{ secrets.OLLAMA_BASE_URL }}" >> $GITHUB_OUTPUT
           else
             echo "id=${{ secrets.CLEVERCLOUD_APP_ID_PP }}" >> $GITHUB_OUTPUT
             echo "url_server=${{ secrets.CLEVERCLOUD_BASE_URL_PP }}" >> $GITHUB_OUTPUT
@@ -106,6 +107,7 @@ jobs:
           EXPOSED_DB_USER: ${{ steps.app.outputs.postgres_user }}
           EXPOSED_DB_PASSWORD: ${{ steps.app.outputs.postgres_password }}
           QONTO_BASE_URL: ${{ steps.app.outputs.qonto_base_url }}
+          OLLAMA_BASE_URL: ${{ steps.app.outputs.ollama_base_url }}
           GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
         run: |
           clever env set APP_FOLDER "server" --app $CLEVER_APP_ID
@@ -127,6 +129,9 @@ jobs:
           clever env set EXPOSED_DB_USER "$EXPOSED_DB_USER" --app $CLEVER_APP_ID
           clever env set EXPOSED_DB_PASSWORD "$EXPOSED_DB_PASSWORD" --app $CLEVER_APP_ID
           clever env set QONTO_BASE_URL "$QONTO_BASE_URL" --app $CLEVER_APP_ID
+          if [ -n "$OLLAMA_BASE_URL" ]; then
+            clever env set OLLAMA_BASE_URL "$OLLAMA_BASE_URL" --app $CLEVER_APP_ID
+          fi
           clever env set GOOGLE_APPLICATION_CREDENTIALS_JSON "$GOOGLE_APPLICATION_CREDENTIALS_JSON" --app $CLEVER_APP_ID
 
       - name: Set image tag for deployment

--- a/server/application/build.gradle.kts
+++ b/server/application/build.gradle.kts
@@ -18,6 +18,8 @@ application {
 
 tasks.withType<ShadowJar> {
     archiveClassifier.set("all")
+    // Koog brings in well over 65 535 zip entries — required to fit them all into a single jar.
+    isZip64 = true
     manifest {
         attributes["Main-Class"] = mainKlass
     }
@@ -48,6 +50,7 @@ dependencies {
     implementation(libs.flexmark)
     implementation(libs.mustache)
     implementation(libs.json.schema.validator)
+    implementation(libs.koog.ktor)
     testImplementation(kotlin("test"))
     testImplementation(libs.ktor.server.test)
     testImplementation(libs.ktor.client.mock)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
@@ -1,6 +1,8 @@
 package fr.devlille.partners.connect
 
 import fr.devlille.partners.connect.agenda.infrastructure.bindings.agendaModule
+import fr.devlille.partners.connect.ai.infrastructure.api.aiRoutes
+import fr.devlille.partners.connect.ai.infrastructure.bindings.aiModule
 import fr.devlille.partners.connect.auth.infrastructure.api.authRoutes
 import fr.devlille.partners.connect.auth.infrastructure.bindings.authModule
 import fr.devlille.partners.connect.auth.infrastructure.plugins.configureSecurity
@@ -21,6 +23,7 @@ import fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenExcepti
 import fr.devlille.partners.connect.internal.infrastructure.api.PayloadTooLargeException
 import fr.devlille.partners.connect.internal.infrastructure.api.RequestBodyValidationException
 import fr.devlille.partners.connect.internal.infrastructure.api.ResponseException
+import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
 import fr.devlille.partners.connect.internal.infrastructure.api.UnauthorizedException
 import fr.devlille.partners.connect.internal.infrastructure.api.UnsupportedMediaTypeException
 import fr.devlille.partners.connect.internal.infrastructure.api.UserSession
@@ -105,6 +108,7 @@ data class ApplicationConfig(
         providerModule,
         webhookModule,
         digestModule,
+        aiModule,
     ),
 )
 
@@ -148,6 +152,7 @@ fun Application.module(config: ApplicationConfig = ApplicationConfig()) {
         integrationRoutes()
         providersRoutes()
         digestRoutes()
+        aiRoutes()
     }
 }
 
@@ -281,6 +286,15 @@ private fun Application.configureStatusPage() {
                 status = HttpStatusCode.PayloadTooLarge,
                 message = ResponseException(
                     message = cause.message ?: "413 Payload Too Large",
+                    stack = cause.cause?.stackTraceToString(),
+                ),
+            )
+        }
+        exception<ServiceUnavailableException> { call, cause ->
+            call.respond(
+                status = HttpStatusCode.ServiceUnavailable,
+                message = ResponseException(
+                    message = cause.message ?: "503 Service Unavailable",
                     stack = cause.cause?.stackTraceToString(),
                 ),
             )

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/application/LlmRepositoryDefault.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/application/LlmRepositoryDefault.kt
@@ -1,0 +1,44 @@
+package fr.devlille.partners.connect.ai.application
+
+import fr.devlille.partners.connect.ai.domain.ChatRequest
+import fr.devlille.partners.connect.ai.domain.ChatResponse
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.ai.domain.LlmRepository
+import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.server.plugins.BadRequestException
+import java.net.ConnectException
+
+private const val DEFAULT_MODEL = "gemma3:1b"
+
+class LlmRepositoryDefault(
+    private val gateway: LlmGateway,
+) : LlmRepository {
+    override suspend fun chat(request: ChatRequest): ChatResponse {
+        if (request.prompt.isBlank()) throw BadRequestException("prompt must not be blank")
+        val modelName = request.model ?: DEFAULT_MODEL
+        val response = withOllamaErrorHandling {
+            gateway.chat(request.prompt, request.system, modelName)
+        }
+        return ChatResponse(model = modelName, response = response)
+    }
+
+    override suspend fun listModels(): List<String> =
+        withOllamaErrorHandling { gateway.listOllamaModels() }
+
+    // Map upstream 4xx/5xx to 503 — partners-connect made the request, so the caller can't fix it.
+    private suspend fun <T> withOllamaErrorHandling(block: suspend () -> T): T =
+        try {
+            block()
+        } catch (e: ConnectException) {
+            throw ServiceUnavailableException("LLM backend is unreachable", e)
+        } catch (e: ConnectTimeoutException) {
+            throw ServiceUnavailableException("LLM backend timed out", e)
+        } catch (e: ServerResponseException) {
+            throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
+        } catch (e: ClientRequestException) {
+            throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
+        }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/ChatRequest.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/ChatRequest.kt
@@ -1,0 +1,10 @@
+package fr.devlille.partners.connect.ai.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChatRequest(
+    val prompt: String,
+    val model: String? = null,
+    val system: String? = null,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/ChatResponse.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/ChatResponse.kt
@@ -1,0 +1,9 @@
+package fr.devlille.partners.connect.ai.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChatResponse(
+    val model: String,
+    val response: String,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/LlmGateway.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/LlmGateway.kt
@@ -1,0 +1,11 @@
+package fr.devlille.partners.connect.ai.domain
+
+interface LlmGateway {
+    suspend fun chat(
+        userPrompt: String,
+        system: String?,
+        modelName: String,
+    ): String
+
+    suspend fun listOllamaModels(): List<String>
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/LlmRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/domain/LlmRepository.kt
@@ -1,0 +1,7 @@
+package fr.devlille.partners.connect.ai.domain
+
+interface LlmRepository {
+    suspend fun chat(request: ChatRequest): ChatResponse
+
+    suspend fun listModels(): List<String>
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiRoutes.kt
@@ -1,0 +1,83 @@
+package fr.devlille.partners.connect.ai.infrastructure.api
+
+import fr.devlille.partners.connect.ai.domain.ChatRequest
+import fr.devlille.partners.connect.ai.domain.ChatResponse
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
+import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.inject
+import org.slf4j.LoggerFactory
+import java.net.ConnectException
+
+private const val DEFAULT_MODEL = "gemma3:1b"
+private val logger = LoggerFactory.getLogger("ai.AiRoutes")
+
+fun Route.aiRoutes() {
+    val gateway by inject<LlmGateway>()
+
+    route("/orgs/{orgSlug}/ai") {
+        install(AuthorizedOrganisationPlugin)
+
+        get("/models") {
+            val models = withOllamaErrorHandling { gateway.listOllamaModels() }
+            call.respond(HttpStatusCode.OK, models)
+        }
+
+        post("/chat") {
+            val req = call.receive<ChatRequest>(schema = "ai_chat_request.schema.json")
+            if (req.prompt.isBlank()) throw BadRequestException("prompt must not be blank")
+
+            val modelName = req.model ?: DEFAULT_MODEL
+            val started = System.currentTimeMillis()
+            val response = withOllamaErrorHandling {
+                gateway.chat(req.prompt, req.system, modelName)
+            }
+            val latency = System.currentTimeMillis() - started
+
+            logger.info(
+                "ai.chat ok model={} prompt_chars={} response_chars={} latency_ms={}",
+                modelName,
+                req.prompt.length,
+                response.length,
+                latency,
+            )
+
+            call.respond(HttpStatusCode.OK, ChatResponse(model = modelName, response = response))
+        }
+    }
+}
+
+// The shared `HttpClient` from `networkClientModule` is configured with
+// `expectSuccess = true` and a `HttpResponseValidator` that rethrows 401 as
+// `UnauthorizedException`. The gateway's `/api/tags` call goes through that
+// client, so any non-2xx from Ollama would otherwise surface as the wrong
+// status to the caller (401 or 500). Map all of those to 503 — Ollama's
+// HTTP status is a property of the upstream, not of the partners-connect API.
+//
+// (The chat path uses Koog's own `OllamaClient`, which has its own HTTP stack;
+// these catches don't apply to it, but the `ConnectException` /
+// `ConnectTimeoutException` cases still do.)
+private suspend fun <T> withOllamaErrorHandling(block: suspend () -> T): T =
+    try {
+        block()
+    } catch (e: ConnectException) {
+        throw ServiceUnavailableException("LLM backend is unreachable", e)
+    } catch (e: ConnectTimeoutException) {
+        throw ServiceUnavailableException("LLM backend timed out", e)
+    } catch (e: ServerResponseException) {
+        throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
+    } catch (e: ClientRequestException) {
+        throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
+    }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiRoutes.kt
@@ -1,83 +1,31 @@
 package fr.devlille.partners.connect.ai.infrastructure.api
 
 import fr.devlille.partners.connect.ai.domain.ChatRequest
-import fr.devlille.partners.connect.ai.domain.ChatResponse
-import fr.devlille.partners.connect.ai.domain.LlmGateway
-import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
+import fr.devlille.partners.connect.ai.domain.LlmRepository
 import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
 import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
-import io.ktor.client.network.sockets.ConnectTimeoutException
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
-import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import org.koin.ktor.ext.inject
-import org.slf4j.LoggerFactory
-import java.net.ConnectException
-
-private const val DEFAULT_MODEL = "gemma3:1b"
-private val logger = LoggerFactory.getLogger("ai.AiRoutes")
 
 fun Route.aiRoutes() {
-    val gateway by inject<LlmGateway>()
+    val repository by inject<LlmRepository>()
 
     route("/orgs/{orgSlug}/ai") {
         install(AuthorizedOrganisationPlugin)
 
         get("/models") {
-            val models = withOllamaErrorHandling { gateway.listOllamaModels() }
-            call.respond(HttpStatusCode.OK, models)
+            call.respond(HttpStatusCode.OK, repository.listModels())
         }
 
         post("/chat") {
-            val req = call.receive<ChatRequest>(schema = "ai_chat_request.schema.json")
-            if (req.prompt.isBlank()) throw BadRequestException("prompt must not be blank")
-
-            val modelName = req.model ?: DEFAULT_MODEL
-            val started = System.currentTimeMillis()
-            val response = withOllamaErrorHandling {
-                gateway.chat(req.prompt, req.system, modelName)
-            }
-            val latency = System.currentTimeMillis() - started
-
-            logger.info(
-                "ai.chat ok model={} prompt_chars={} response_chars={} latency_ms={}",
-                modelName,
-                req.prompt.length,
-                response.length,
-                latency,
-            )
-
-            call.respond(HttpStatusCode.OK, ChatResponse(model = modelName, response = response))
+            val request = call.receive<ChatRequest>(schema = "ai_chat_request.schema.json")
+            call.respond(HttpStatusCode.OK, repository.chat(request))
         }
     }
 }
-
-// The shared `HttpClient` from `networkClientModule` is configured with
-// `expectSuccess = true` and a `HttpResponseValidator` that rethrows 401 as
-// `UnauthorizedException`. The gateway's `/api/tags` call goes through that
-// client, so any non-2xx from Ollama would otherwise surface as the wrong
-// status to the caller (401 or 500). Map all of those to 503 — Ollama's
-// HTTP status is a property of the upstream, not of the partners-connect API.
-//
-// (The chat path uses Koog's own `OllamaClient`, which has its own HTTP stack;
-// these catches don't apply to it, but the `ConnectException` /
-// `ConnectTimeoutException` cases still do.)
-private suspend fun <T> withOllamaErrorHandling(block: suspend () -> T): T =
-    try {
-        block()
-    } catch (e: ConnectException) {
-        throw ServiceUnavailableException("LLM backend is unreachable", e)
-    } catch (e: ConnectTimeoutException) {
-        throw ServiceUnavailableException("LLM backend timed out", e)
-    } catch (e: ServerResponseException) {
-        throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
-    } catch (e: ClientRequestException) {
-        throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
-    }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/bindings/AiModule.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/bindings/AiModule.kt
@@ -2,7 +2,9 @@ package fr.devlille.partners.connect.ai.infrastructure.bindings
 
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
+import fr.devlille.partners.connect.ai.application.LlmRepositoryDefault
 import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.ai.domain.LlmRepository
 import fr.devlille.partners.connect.ai.infrastructure.gateways.OllamaLlmGateway
 import fr.devlille.partners.connect.internal.infrastructure.system.SystemVarEnv
 import io.ktor.client.HttpClient
@@ -17,4 +19,5 @@ val aiModule = module {
             ollamaBaseUrl = ollamaBaseUrl,
         )
     }
+    single<LlmRepository> { LlmRepositoryDefault(get()) }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/bindings/AiModule.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/bindings/AiModule.kt
@@ -1,0 +1,20 @@
+package fr.devlille.partners.connect.ai.infrastructure.bindings
+
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.ollama.client.OllamaClient
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.ai.infrastructure.gateways.OllamaLlmGateway
+import fr.devlille.partners.connect.internal.infrastructure.system.SystemVarEnv
+import io.ktor.client.HttpClient
+import org.koin.dsl.module
+
+val aiModule = module {
+    single<LlmGateway> {
+        val ollamaBaseUrl = SystemVarEnv.Llm.ollamaBaseUrl
+        OllamaLlmGateway(
+            executor = SingleLLMPromptExecutor(OllamaClient(baseUrl = ollamaBaseUrl)),
+            http = get<HttpClient>(),
+            ollamaBaseUrl = ollamaBaseUrl,
+        )
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/gateways/OllamaLlmGateway.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/ai/infrastructure/gateways/OllamaLlmGateway.kt
@@ -1,0 +1,53 @@
+package fr.devlille.partners.connect.ai.infrastructure.gateways
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private const val DEFAULT_CONTEXT_LENGTH = 8192L
+
+class OllamaLlmGateway(
+    private val executor: SingleLLMPromptExecutor,
+    private val http: HttpClient,
+    private val ollamaBaseUrl: String,
+) : LlmGateway {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun chat(
+        userPrompt: String,
+        system: String?,
+        modelName: String,
+    ): String {
+        val model = LLModel(
+            provider = LLMProvider.Ollama,
+            id = modelName,
+            capabilities = listOf(LLMCapability.Temperature),
+            contextLength = DEFAULT_CONTEXT_LENGTH,
+        )
+        val chatPrompt = prompt("ai-chat") {
+            system?.let { system(it) }
+            user(userPrompt)
+        }
+        val messages = executor.execute(chatPrompt, model)
+        return messages.joinToString("\n") { it.content }
+    }
+
+    override suspend fun listOllamaModels(): List<String> {
+        val body = http.get("$ollamaBaseUrl/api/tags").bodyAsText()
+        return json.decodeFromString<OllamaTagsResponse>(body).models.map { it.name }
+    }
+
+    @Serializable
+    private data class OllamaTagsResponse(val models: List<OllamaTag> = emptyList())
+
+    @Serializable
+    private data class OllamaTag(val name: String)
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/api/ServiceUnavailableException.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/api/ServiceUnavailableException.kt
@@ -1,0 +1,6 @@
+package fr.devlille.partners.connect.internal.infrastructure.api
+
+class ServiceUnavailableException(
+    message: String,
+    cause: Throwable? = null,
+) : Throwable(message, cause)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/ApplicationCall.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/ktor/ApplicationCall.ext.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.Json
 val schemas by lazy {
     JsonSchemaLoader.create()
         .register(readResourceFile("/schemas/address.schema.json"), SchemaType.DRAFT_7)
+        .register(readResourceFile("/schemas/ai_chat_request.schema.json"), SchemaType.DRAFT_7)
         .register(readResourceFile("/schemas/attach_options_to_pack.schema.json"), SchemaType.DRAFT_7)
         .register(readResourceFile("/schemas/billing_contact.schema.json"), SchemaType.DRAFT_7)
         .register(readResourceFile("/schemas/booth_location_request.schema.json"), SchemaType.DRAFT_7)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/system/SystemVarEnv.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/system/SystemVarEnv.kt
@@ -30,4 +30,8 @@ object SystemVarEnv {
     object QontoProvider {
         val baseUrl: String = System.getenv("QONTO_BASE_URL") ?: "https://thirdparty.qonto.com"
     }
+
+    object Llm {
+        val ollamaBaseUrl: String = System.getenv("OLLAMA_BASE_URL") ?: "http://localhost:11434"
+    }
 }

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -2357,6 +2357,88 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/ai/chat:
+    post:
+      summary: Send a prompt to the self-hosted LLM
+      operationId: postOrgsAiChat
+      description: Single round-trip chat call backed by the organisation-scoped Ollama LLM. Defaults to `gemma3:1b`; pass `model` to override per request. Requires organisation membership.
+      tags:
+        - ai
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Organization slug
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ai_chat_request.schema'
+      responses:
+        '200':
+          description: OK - Generated response from the LLM
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ai_chat_response.schema'
+        '400':
+          description: Bad Request - Invalid body or empty/blank prompt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '401':
+          description: Unauthorized - Missing/invalid authentication or no organisation membership
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '503':
+          description: Service Unavailable - LLM backend unreachable or returned an error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /orgs/{orgSlug}/ai/models:
+    get:
+      summary: List models pulled into the Ollama instance
+      operationId: getOrgsAiModels
+      description: Returns the list of model names currently available on the Ollama backend, so the caller can pick a valid `model` value for `/ai/chat`. Requires organisation membership.
+      tags:
+        - ai
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orgSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Organization slug
+      responses:
+        '200':
+          description: OK - List of available model names
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ai_model_list.schema'
+        '401':
+          description: Unauthorized - Missing/invalid authentication or no organisation membership
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '503':
+          description: Service Unavailable - LLM backend unreachable or returned an error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
   /orgs/{orgSlug}/events:
     get:
       summary: Get organization details
@@ -6074,6 +6156,12 @@ components:
       $ref: '#/components/schemas/partnership_qanda_summary.schema'
     PartnershipQandaSummaryList:
       $ref: '#/components/schemas/partnership_qanda_summary_list.schema'
+    ChatRequest:
+      $ref: '#/components/schemas/ai_chat_request.schema'
+    ChatResponse:
+      $ref: '#/components/schemas/ai_chat_response.schema'
+    LlmModelList:
+      $ref: '#/components/schemas/ai_model_list.schema'
     user_session.schema:
       $id: user_session.schema.json
       type: object
@@ -8715,6 +8803,43 @@ components:
           description: Provider email address
       required: []
       additionalProperties: false
+    ai_chat_request.schema:
+      $schema: http://json-schema.org/draft-07/schema#
+      type: object
+      required:
+        - prompt
+      properties:
+        prompt:
+          type: string
+          minLength: 1
+        model:
+          type:
+            - string
+            - 'null'
+        system:
+          type:
+            - string
+            - 'null'
+      additionalProperties: false
+    ai_chat_response.schema:
+      $id: ai_chat_response.schema.json
+      $schema: http://json-schema.org/draft-07/schema#
+      type: object
+      properties:
+        model:
+          type: string
+        response:
+          type: string
+      required:
+        - model
+        - response
+      additionalProperties: false
+    ai_model_list.schema:
+      $id: ai_model_list.schema.json
+      $schema: http://json-schema.org/draft-07/schema#
+      type: array
+      items:
+        type: string
     create_event.schema:
       $id: event.schema.json
       type: object

--- a/server/application/src/main/resources/openapi/openapi.yaml
+++ b/server/application/src/main/resources/openapi/openapi.yaml
@@ -2346,6 +2346,88 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/ai/chat:
+    post:
+      summary: "Send a prompt to the self-hosted LLM"
+      operationId: "postOrgsAiChat"
+      description: "Single round-trip chat call backed by the organisation-scoped Ollama LLM. Defaults to `gemma3:1b`; pass `model` to override per request. Requires organisation membership."
+      tags:
+        - ai
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "Organization slug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatRequest"
+      responses:
+        "200":
+          description: "OK - Generated response from the LLM"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatResponse"
+        "400":
+          description: "Bad Request - Invalid body or empty/blank prompt"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: "Unauthorized - Missing/invalid authentication or no organisation membership"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "Service Unavailable - LLM backend unreachable or returned an error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /orgs/{orgSlug}/ai/models:
+    get:
+      summary: "List models pulled into the Ollama instance"
+      operationId: "getOrgsAiModels"
+      description: "Returns the list of model names currently available on the Ollama backend, so the caller can pick a valid `model` value for `/ai/chat`. Requires organisation membership."
+      tags:
+        - ai
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: "orgSlug"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "Organization slug"
+      responses:
+        "200":
+          description: "OK - List of available model names"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LlmModelList"
+        "401":
+          description: "Unauthorized - Missing/invalid authentication or no organisation membership"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "Service Unavailable - LLM backend unreachable or returned an error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /orgs/{orgSlug}/events:
     get:
       summary: "Get organization details"
@@ -6054,3 +6136,9 @@ components:
       $ref: "../schemas/partnership_qanda_summary.schema.json"
     PartnershipQandaSummaryList:
       $ref: "../schemas/partnership_qanda_summary_list.schema.json"
+    ChatRequest:
+      $ref: "../schemas/ai_chat_request.schema.json"
+    ChatResponse:
+      $ref: "../schemas/ai_chat_response.schema.json"
+    LlmModelList:
+      $ref: "../schemas/ai_model_list.schema.json"

--- a/server/application/src/main/resources/schemas/ai_chat_request.schema.json
+++ b/server/application/src/main/resources/schemas/ai_chat_request.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["prompt"],
+  "properties": {
+    "prompt": { "type": "string", "minLength": 1 },
+    "model":  { "type": ["string", "null"] },
+    "system": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/server/application/src/main/resources/schemas/ai_chat_response.schema.json
+++ b/server/application/src/main/resources/schemas/ai_chat_response.schema.json
@@ -1,0 +1,11 @@
+{
+  "$id": "ai_chat_response.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "model": { "type": "string" },
+    "response": { "type": "string" }
+  },
+  "required": ["model", "response"],
+  "additionalProperties": false
+}

--- a/server/application/src/main/resources/schemas/ai_model_list.schema.json
+++ b/server/application/src/main/resources/schemas/ai_model_list.schema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "ai_model_list.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": { "type": "string" }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/AiRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/AiRoutesTest.kt
@@ -1,0 +1,174 @@
+package fr.devlille.partners.connect.ai
+
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.net.ConnectException
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AiRoutesTest {
+    @Test
+    fun `authenticated organiser hits chat and gets fake response`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(
+                userId = userId,
+                llmGateway = FakeLlmGateway(response = "end-to-end response"),
+            )
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val chatResponse = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"Hello","system":"Be terse"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, chatResponse.status)
+        val body = Json.parseToJsonElement(chatResponse.bodyAsText()).jsonObject
+        assertEquals("end-to-end response", body["response"]?.jsonPrimitive?.content)
+
+        val modelsResponse = client.get("/orgs/$orgId/ai/models") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, modelsResponse.status)
+        assertEquals(listOf("gemma3:1b"), Json.decodeFromString<List<String>>(modelsResponse.bodyAsText()))
+    }
+
+    @Test
+    fun `chat returns 503 when LLM backend is unreachable`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(
+                userId = userId,
+                llmGateway = FakeLlmGateway(throws = ConnectException("connection refused")),
+            )
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"Hello"}""")
+        }
+
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+    }
+
+    @Test
+    fun `models returns 503 when Ollama responds with 5xx`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(
+                userId = userId,
+                llmGateway = ResponseStatusThrowingGateway(HttpStatusCode.InternalServerError),
+            )
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/ai/models") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+    }
+
+    @Test
+    fun `models returns 503 when Ollama responds with 4xx`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(
+                userId = userId,
+                llmGateway = ResponseStatusThrowingGateway(HttpStatusCode.Unauthorized),
+            )
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/ai/models") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+    }
+}
+
+/**
+ * Fires a real HTTP call against a Ktor `MockEngine` that returns the configured status,
+ * so the call surfaces `ClientRequestException` (4xx) or `ServerResponseException` (5xx)
+ * exactly as Koog's `OllamaClient` and the shared `HttpClient` would.
+ */
+private class ResponseStatusThrowingGateway(
+    private val status: HttpStatusCode,
+) : LlmGateway {
+    private val client = HttpClient(
+        MockEngine { _ ->
+            respond(
+                content = "upstream error",
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString()),
+            )
+        },
+    ) {
+        expectSuccess = true
+    }
+
+    override suspend fun chat(
+        userPrompt: String,
+        system: String?,
+        modelName: String,
+    ): String {
+        client.get("https://ollama.test/api/generate")
+        error("MockEngine should have thrown before this point")
+    }
+
+    override suspend fun listOllamaModels(): List<String> {
+        client.get("https://ollama.test/api/tags")
+        error("MockEngine should have thrown before this point")
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/AiRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/AiRoutesTest.kt
@@ -138,11 +138,7 @@ class AiRoutesTest {
     }
 }
 
-/**
- * Fires a real HTTP call against a Ktor `MockEngine` that returns the configured status,
- * so the call surfaces `ClientRequestException` (4xx) or `ServerResponseException` (5xx)
- * exactly as Koog's `OllamaClient` and the shared `HttpClient` would.
- */
+// Surfaces a real `ClientRequestException` / `ServerResponseException` for the configured status.
 private class ResponseStatusThrowingGateway(
     private val status: HttpStatusCode,
 ) : LlmGateway {

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/FakeLlmGateway.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/FakeLlmGateway.kt
@@ -1,0 +1,18 @@
+package fr.devlille.partners.connect.ai
+
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+
+class FakeLlmGateway(
+    private val response: String = "fake response",
+    private val models: List<String> = listOf("gemma3:1b"),
+    private val throws: Throwable? = null,
+) : LlmGateway {
+    override suspend fun chat(
+        userPrompt: String,
+        system: String?,
+        modelName: String,
+    ): String = throws?.let { throw it } ?: response
+
+    override suspend fun listOllamaModels(): List<String> =
+        throws?.let { throw it } ?: models
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/application/LlmRepositoryDefaultTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/application/LlmRepositoryDefaultTest.kt
@@ -1,0 +1,92 @@
+package fr.devlille.partners.connect.ai.application
+
+import fr.devlille.partners.connect.ai.FakeLlmGateway
+import fr.devlille.partners.connect.ai.factories.createChatRequest
+import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.BadRequestException
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import java.net.ConnectException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LlmRepositoryDefaultTest {
+    @Test
+    fun `chat throws BadRequestException when prompt is blank`() = runBlocking {
+        val repo = LlmRepositoryDefault(FakeLlmGateway())
+        assertFailsWith<BadRequestException> {
+            repo.chat(createChatRequest(prompt = "   "))
+        }
+    }
+
+    @Test
+    fun `chat defaults to gemma3 1b when model is null`() = runBlocking {
+        val repo = LlmRepositoryDefault(FakeLlmGateway(response = "hi"))
+        val response = repo.chat(createChatRequest(prompt = "hello", model = null))
+        assertEquals("gemma3:1b", response.model)
+        assertEquals("hi", response.response)
+    }
+
+    @Test
+    fun `chat passes through caller-provided model`() = runBlocking {
+        val repo = LlmRepositoryDefault(FakeLlmGateway(response = "hi"))
+        val response = repo.chat(createChatRequest(prompt = "hello", model = "llama3.2:3b"))
+        assertEquals("llama3.2:3b", response.model)
+    }
+
+    @Test
+    fun `chat maps ConnectException to ServiceUnavailableException`() = runBlocking {
+        val repo = LlmRepositoryDefault(FakeLlmGateway(throws = ConnectException("refused")))
+        assertFailsWith<ServiceUnavailableException> {
+            repo.chat(createChatRequest(prompt = "hello"))
+        }
+        Unit
+    }
+
+    @Test
+    fun `chat maps ServerResponseException to ServiceUnavailableException`() = runBlocking {
+        val response = mockk<HttpResponse>(relaxed = true)
+        every { response.status } returns HttpStatusCode.InternalServerError
+        val repo = LlmRepositoryDefault(
+            FakeLlmGateway(throws = ServerResponseException(response, "boom")),
+        )
+        assertFailsWith<ServiceUnavailableException> {
+            repo.chat(createChatRequest(prompt = "hello"))
+        }
+        Unit
+    }
+
+    @Test
+    fun `chat maps ClientRequestException to ServiceUnavailableException`() = runBlocking {
+        val response = mockk<HttpResponse>(relaxed = true)
+        every { response.status } returns HttpStatusCode.Unauthorized
+        val repo = LlmRepositoryDefault(
+            FakeLlmGateway(throws = ClientRequestException(response, "no")),
+        )
+        assertFailsWith<ServiceUnavailableException> {
+            repo.chat(createChatRequest(prompt = "hello"))
+        }
+        Unit
+    }
+
+    @Test
+    fun `listModels delegates to gateway`() = runBlocking {
+        val repo = LlmRepositoryDefault(FakeLlmGateway(models = listOf("gemma3:1b", "llama3.2:3b")))
+        assertEquals(listOf("gemma3:1b", "llama3.2:3b"), repo.listModels())
+    }
+
+    @Test
+    fun `listModels maps ConnectException to ServiceUnavailableException`() = runBlocking {
+        val repo = LlmRepositoryDefault(FakeLlmGateway(throws = ConnectException("refused")))
+        assertFailsWith<ServiceUnavailableException> {
+            repo.listModels()
+        }
+        Unit
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/factories/Chat.factory.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/factories/Chat.factory.kt
@@ -1,0 +1,9 @@
+package fr.devlille.partners.connect.ai.factories
+
+import fr.devlille.partners.connect.ai.domain.ChatRequest
+
+fun createChatRequest(
+    prompt: String = "Hello",
+    model: String? = null,
+    system: String? = null,
+): ChatRequest = ChatRequest(prompt = prompt, model = model, system = system)

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiChatRoutePostTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiChatRoutePostTest.kt
@@ -1,0 +1,213 @@
+package fr.devlille.partners.connect.ai.infrastructure.api
+
+import fr.devlille.partners.connect.ai.FakeLlmGateway
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AiChatRoutePostTest {
+    @Test
+    fun `POST chat returns 200 with model and response`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId, llmGateway = FakeLlmGateway(response = "hi from test"))
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"Hello"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals("gemma3:1b", body["model"]?.jsonPrimitive?.content)
+        assertEquals("hi from test", body["response"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `POST chat uses requested model when provided`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"Hello","model":"llama3.2:3b"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals("llama3.2:3b", body["model"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `POST chat returns 400 when prompt is empty string`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":""}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST chat returns 400 when prompt is whitespace only`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"   "}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST chat returns 400 when body has unknown property`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"Hello","unexpected":"field"}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST chat returns 400 when prompt is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST chat returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"prompt":"Hello"}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `POST chat returns 401 when user lacks org permission`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                // NO permission inserted
+            }
+        }
+
+        val response = client.post("/orgs/$orgId/ai/chat") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer valid")
+            setBody("""{"prompt":"Hello"}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiChatRoutePostTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiChatRoutePostTest.kt
@@ -198,7 +198,6 @@ class AiChatRoutePostTest {
             transaction {
                 insertMockedUser(userId)
                 insertMockedOrganisationEntity(orgId)
-                // NO permission inserted
             }
         }
 

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiModelsRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiModelsRouteGetTest.kt
@@ -95,7 +95,6 @@ class AiModelsRouteGetTest {
             transaction {
                 insertMockedUser(userId)
                 insertMockedOrganisationEntity(orgId)
-                // NO permission inserted
             }
         }
 

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiModelsRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/api/AiModelsRouteGetTest.kt
@@ -1,0 +1,108 @@
+package fr.devlille.partners.connect.ai.infrastructure.api
+
+import fr.devlille.partners.connect.ai.FakeLlmGateway
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AiModelsRouteGetTest {
+    @Test
+    fun `GET models returns 200 with array of model names`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(
+                userId = userId,
+                llmGateway = FakeLlmGateway(models = listOf("gemma3:1b", "llama3.2:3b")),
+            )
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/ai/models") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val models = Json.decodeFromString<List<String>>(response.bodyAsText())
+        assertEquals(listOf("gemma3:1b", "llama3.2:3b"), models)
+    }
+
+    @Test
+    fun `GET models returns 200 with empty array when Ollama has no models`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId, llmGateway = FakeLlmGateway(models = emptyList()))
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/ai/models") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(emptyList(), Json.decodeFromString<List<String>>(response.bodyAsText()))
+    }
+
+    @Test
+    fun `GET models returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/ai/models")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET models returns 401 when user lacks org permission`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId = userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                // NO permission inserted
+            }
+        }
+
+        val response = client.get("/orgs/$orgId/ai/models") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/gateways/OllamaLlmGatewayTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/ai/infrastructure/gateways/OllamaLlmGatewayTest.kt
@@ -1,0 +1,121 @@
+package fr.devlille.partners.connect.ai.infrastructure.gateways
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.model.LLMChoice
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OllamaLlmGatewayTest {
+    @Test
+    fun `listOllamaModels parses ollama tags response into model name list`() = runBlocking {
+        val client = HttpClient(
+            MockEngine { _ ->
+                respond(
+                    content = """{"models":[{"name":"gemma3:1b"},{"name":"llama3.2:3b"}]}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val gateway = OllamaLlmGateway(
+            executor = SingleLLMPromptExecutor(StubLLMClient()),
+            http = client,
+            ollamaBaseUrl = "https://ollama.test",
+        )
+
+        val models = gateway.listOllamaModels()
+
+        assertEquals(listOf("gemma3:1b", "llama3.2:3b"), models)
+    }
+
+    @Test
+    fun `listOllamaModels returns empty list when ollama has no models`() = runBlocking {
+        val client = HttpClient(
+            MockEngine { _ ->
+                respond(
+                    content = """{"models":[]}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val gateway = OllamaLlmGateway(
+            executor = SingleLLMPromptExecutor(StubLLMClient()),
+            http = client,
+            ollamaBaseUrl = "https://ollama.test",
+        )
+
+        val models = gateway.listOllamaModels()
+
+        assertEquals(emptyList(), models)
+    }
+
+    @Test
+    fun `chat joins all response message contents with newlines`() = runBlocking {
+        val responses = listOf(
+            Message.Assistant(content = "Hello", metaInfo = ResponseMetaInfo(timestamp = Clock.System.now())),
+            Message.Assistant(content = "world", metaInfo = ResponseMetaInfo(timestamp = Clock.System.now())),
+        )
+        val gateway = OllamaLlmGateway(
+            executor = SingleLLMPromptExecutor(StubLLMClient(responses)),
+            http = HttpClient(MockEngine { _ -> respond("") }),
+            ollamaBaseUrl = "https://ollama.test",
+        )
+
+        val response = gateway.chat(userPrompt = "Hi", system = null, modelName = "gemma3:1b")
+
+        assertEquals("Hello\nworld", response)
+    }
+
+    @Test
+    fun `chat returns empty string when LLM returns no response messages`() = runBlocking {
+        val gateway = OllamaLlmGateway(
+            executor = SingleLLMPromptExecutor(StubLLMClient(emptyList())),
+            http = HttpClient(MockEngine { _ -> respond("") }),
+            ollamaBaseUrl = "https://ollama.test",
+        )
+
+        val response = gateway.chat(userPrompt = "Hi", system = "Be terse", modelName = "gemma3:1b")
+
+        assertEquals("", response)
+    }
+}
+
+private class StubLLMClient(
+    private val responses: List<Message.Response> = listOf(
+        Message.Assistant(content = "stub", metaInfo = ResponseMetaInfo(timestamp = Clock.System.now())),
+    ),
+) : LLMClient {
+    override suspend fun execute(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+    ): List<Message.Response> = responses
+
+    override suspend fun executeMultipleChoices(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+    ): List<LLMChoice> = throw UnsupportedOperationException()
+
+    override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult =
+        throw UnsupportedOperationException()
+
+    override fun llmProvider(): LLMProvider = LLMProvider.Ollama
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
@@ -5,6 +5,7 @@ import fr.devlille.partners.connect.ApplicationConfig
 import fr.devlille.partners.connect.agenda.infrastructure.bindings.agendaModule
 import fr.devlille.partners.connect.ai.FakeLlmGateway
 import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.ai.infrastructure.bindings.aiModule
 import fr.devlille.partners.connect.auth.infrastructure.bindings.authModule
 import fr.devlille.partners.connect.billing.domain.BillingGateway
 import fr.devlille.partners.connect.billing.infrastructure.bindings.billingModule
@@ -137,6 +138,7 @@ fun Application.moduleMocked(
                 agendaModule,
                 integrationModule,
                 digestModule,
+                aiModule,
                 mockNetwork,
                 mockSlack,
                 mockStorage,

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/ApplicationMock.kt
@@ -3,6 +3,8 @@ package fr.devlille.partners.connect.internal
 import com.slack.api.Slack
 import fr.devlille.partners.connect.ApplicationConfig
 import fr.devlille.partners.connect.agenda.infrastructure.bindings.agendaModule
+import fr.devlille.partners.connect.ai.FakeLlmGateway
+import fr.devlille.partners.connect.ai.domain.LlmGateway
 import fr.devlille.partners.connect.auth.infrastructure.bindings.authModule
 import fr.devlille.partners.connect.billing.domain.BillingGateway
 import fr.devlille.partners.connect.billing.infrastructure.bindings.billingModule
@@ -39,11 +41,13 @@ import java.util.UUID
  * @param nbProductsForTickets The number of products to be returned by the mock network engine for tickets.
  * @param storage The storage instance to be used in the module. Defaults to a mock instance.
  */
+@Suppress("LongParameterList")
 fun Application.moduleSharedDb(
     userId: UUID,
     nbProductsForTickets: Int = 0,
     storage: Storage = mockk(),
     slack: Slack = mockk(),
+    llmGateway: LlmGateway = FakeLlmGateway(),
 ) {
     moduleMocked(
         databaseUrl = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",
@@ -55,6 +59,9 @@ fun Application.moduleSharedDb(
         },
         mockSlack = module {
             single<Slack> { slack }
+        },
+        mockAi = module {
+            single<LlmGateway> { llmGateway }
         },
     )
 }
@@ -104,6 +111,9 @@ fun Application.moduleMocked(
             }
         }
     },
+    mockAi: Module = module {
+        single<LlmGateway> { FakeLlmGateway() }
+    },
 ) {
     module(
         ApplicationConfig(
@@ -133,6 +143,7 @@ fun Application.moduleMocked(
                 mockGeocode,
                 mockBillingIntegration,
                 mockWebhook,
+                mockAi,
             ),
         ),
     )

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ mockk = "1.14.5"
 postgresql = "42.7.1"
 imgscalr = "4.2"
 shadow = "9.0.0-rc1"
+koog = "0.5.1"
 
 [libraries]
 apache-xmlgraphics-batik-transcoder = { module = "org.apache.xmlgraphics:batik-transcoder", version.ref = "apache-xmlgraphics-batik" }
@@ -82,6 +83,12 @@ google-maps = { module = "com.google.maps:google-maps-services", version.ref = "
 imgscalr = { module = "org.imgscalr:imgscalr-lib", version.ref = "imgscalr" }
 
 json-schema-validator = { module = "io.github.optimumcode:json-schema-validator", version.ref = "json-schema-validator" }
+
+# Koog — LLM client framework. Use the umbrella ktor artifact for transitive coverage
+# of OllamaClient, SingleLLMPromptExecutor, and the prompt DSL.
+# We do NOT use the install(Koog) Ktor plugin (we wire Koog manually via Koin),
+# but pulling koog-ktor is the simplest way to get all the executor + client classes.
+koog-ktor = { module = "ai.koog:koog-ktor", version.ref = "koog" }
 
 # Libraries can be bundled together for easier import
 [bundles]

--- a/server/specs/026-llm-chat-integration/plan.md
+++ b/server/specs/026-llm-chat-integration/plan.md
@@ -1,0 +1,825 @@
+# Implementation Plan: 026-llm-chat-integration
+
+This plan is the technical companion to [`spec.md`](./spec.md). Read the spec first.
+
+It is written so a Claude instance opened in `partners-connect/server/` (and in the sibling `cortex/` workspace for the deployment-side) can execute the work without needing access to the original brainstorming conversation.
+
+---
+
+## 1. Architecture summary
+
+```
+┌───────────────────────────────────────────────────────────┐
+│  partners-connect/server  (Ktor app, this workspace)       │
+│                                                            │
+│   App.kt                                                   │
+│    └── routing { ... aiRoutes() }                          │
+│                                                            │
+│   fr.devlille.partners.connect.ai/                         │
+│    ├── domain/        ChatRequest, ChatResponse, ...       │
+│    ├── infrastructure/                                     │
+│    │   ├── api/       AiRoutes.kt  (POST /chat, GET /models)│
+│    │   ├── gateways/  OllamaLlmGateway.kt  (Koog wrapper)  │
+│    │   └── bindings/  AiModule.kt  (Koin)                  │
+│    └── (no db/ — feature is stateless in v1)               │
+│                                                            │
+│   talks HTTP to ──────────┐                                │
+└───────────────────────────┼────────────────────────────────┘
+                            │
+                            ▼
+┌───────────────────────────────────────────────────────────┐
+│  cortex  (sibling workspace, owned separately)      │
+│                                                            │
+│   ollama/Dockerfile  ← FROM ollama/ollama + pre-pull       │
+│                        gemma3:1b at build time             │
+│   Dockerfile.deploy  ← pulls from GHCR                     │
+│   .github/workflows/build-push.yaml  (→ ghcr.io)           │
+│   .github/workflows/deploy.yaml  (clever-tools)            │
+└───────────────────────────────────────────────────────────┘
+```
+
+Two completely separate deploys, joined at runtime by the env var `OLLAMA_BASE_URL` on the partners-connect side.
+
+---
+
+## 2. Koog 0.5.1 API gotchas
+
+A prototype was built against Koog 0.5.1 and validated end-to-end against `gemma3:1b` and `llama3.2:3b`. Two documented APIs do NOT exist (or are private) in the published 0.5.1 artifact — work around them as follows. **Do not waste time trying the documented form; the docs lag the artifact.**
+
+### 2.1 `OllamaClient.listModels()` is private
+
+Compile error: `Cannot access 'suspend fun listModels(): OllamaModelsListResponseDTO': it is private in 'ai/koog/prompt/executor/ollama/client/OllamaClient'.`
+
+**Workaround**: call Ollama's REST API directly. Ollama exposes `GET /api/tags` which is stable and well-documented at the Ollama level.
+
+```kotlin
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+private data class OllamaTagsResponse(val models: List<OllamaTag> = emptyList())
+
+@Serializable
+private data class OllamaTag(val name: String)
+
+private val json = Json { ignoreUnknownKeys = true }
+
+suspend fun listOllamaModels(http: HttpClient, baseUrl: String): List<String> {
+    val body = http.get("$baseUrl/api/tags").bodyAsText()
+    return json.decodeFromString<OllamaTagsResponse>(body).models.map { it.name }
+}
+```
+
+Reuse the existing `ktor-client-core` + `ktor-client-java` from the `ktor-client` bundle (already in the version catalog) — no new client dependency needed.
+
+### 2.2 `OllamaClient.createDynamicModel(name)` does not exist
+
+Compile error: `Unresolved reference 'createDynamicModel'`.
+
+**Workaround**: construct `LLModel` manually. `OllamaModels.Meta.LLAMA_3_2` and friends are just pre-built `LLModel` instances — building one ourselves for any model name Ollama knows about is the supported path.
+
+```kotlin
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+
+fun ollamaModel(name: String): LLModel = LLModel(
+    provider = LLMProvider.Ollama,
+    id = name,
+    capabilities = listOf(LLMCapability.Temperature),
+    contextLength = DEFAULT_CONTEXT_LENGTH,
+)
+
+private const val DEFAULT_CONTEXT_LENGTH = 8192L
+```
+
+`contextLength` is required in 0.5.1 (another undocumented change vs the README examples). 8192 is a safe default that all small Ollama models support.
+
+### 2.3 Local development
+
+You have two options for running Ollama locally during development. Pick **option A** unless you need a fully Docker-isolated stack — the partners-connect server defaults `OLLAMA_BASE_URL` to `http://localhost:11434`, so a native daemon needs zero extra config.
+
+#### Option A — Native Ollama (recommended)
+
+Ollama runs as a host-level service and partners-connect (started via `./gradlew run` or Compose) reaches it on the loopback interface.
+
+1. **Install Ollama once** (skip if already installed — check with `which ollama`):
+
+   ```sh
+   brew install ollama
+   # or, on Linux:  curl -fsSL https://ollama.com/install.sh | sh
+   ```
+
+2. **Start the daemon.** Homebrew installs a launchd agent:
+
+   ```sh
+   brew services start ollama
+   ```
+
+   On Linux, run `ollama serve` in a separate terminal (or wire systemd).
+
+3. **Pull the default model** (~815 MB, one-time):
+
+   ```sh
+   ollama pull gemma3:1b
+   ```
+
+4. **Verify Ollama itself responds:**
+
+   ```sh
+   curl -s http://localhost:11434/api/tags | jq '.models[].name'
+   ```
+
+5. **Boot partners-connect** without setting `OLLAMA_BASE_URL`. The default in `SystemVarEnv.Llm` matches the running daemon.
+
+#### Option B — Docker Compose Ollama
+
+Use this only if you need every dependency containerised. Add this service to `server/docker-compose.yml`:
+
+```yaml
+  ollama:
+    image: ollama/ollama:latest
+    container_name: partners-connect-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_models:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+Append `ollama_models:` under the `volumes:` block at the bottom so pulled models survive `docker compose down`. Then:
+
+```sh
+docker compose up -d ollama
+docker compose exec ollama ollama pull gemma3:1b
+```
+
+When the partners-connect app **also runs inside Compose**, override the env var so it resolves the container DNS name instead of `localhost`:
+
+```yaml
+  app:
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+```
+
+When the partners-connect app runs on the host (`./gradlew run`), keep the default — it will reach the published `11434` port on the loopback.
+
+#### Smoke test — both layers
+
+Run these in order. If layer 1 works but layer 2 returns `503`, the partners-connect server can't reach Ollama — check `OLLAMA_BASE_URL` resolution (host vs container DNS).
+
+```sh
+# Layer 1 — Ollama itself (bypass partners-connect)
+curl -s http://localhost:11434/api/tags
+
+# Layer 2 — partners-connect → Ollama through the new gateway
+curl -s -X POST http://localhost:8080/orgs/<orgSlug>/ai/chat \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer <token>" \
+  -d '{"prompt":"Reply with: hello"}'
+```
+
+#### Security note
+
+The gateway talks to Ollama over plain HTTP with no authentication. This is safe in exactly two scenarios:
+
+- **Locally**, where Ollama listens on the loopback interface (`127.0.0.1`) and is not exposed.
+- **In production**, where Clever Cloud's network group keeps Ollama on a private network with no public domain (see § 6.8 step 3).
+
+**Never set `OLLAMA_HOST=0.0.0.0:11434` on a public host** — every Ollama API would be exposed to the internet without auth.
+
+---
+
+## 3. Version catalog additions
+
+File: `gradle/libs.versions.toml`
+
+```toml
+[versions]
+# ... existing entries ...
+koog = "0.5.1"
+
+[libraries]
+# ... existing entries ...
+
+# Koog — LLM client framework. Use the umbrella ktor artifact for transitive coverage
+# of OllamaClient, SingleLLMPromptExecutor, and the prompt DSL.
+# We do NOT use the install(Koog) Ktor plugin (we wire Koog manually via Koin),
+# but pulling koog-ktor is the simplest way to get all the executor + client classes.
+koog-ktor = { module = "ai.koog:koog-ktor", version.ref = "koog" }
+```
+
+Then add the dependency in `application/build.gradle.kts`:
+
+```kotlin
+dependencies {
+    // ... existing ...
+    implementation(libs.koog.ktor)
+}
+```
+
+> **Why not the targeted artifacts (`ai.koog:prompt-executor-ollama-client`, etc.)?**
+> Their exact Maven coordinates are not 100 % confirmed in the published 0.5.1 BOM, and the umbrella `koog-ktor` brings everything we need transitively. Bytecode bloat is small. If a follow-up wants to slim deps, that's the right time to reverse-engineer the targeted artifacts.
+
+---
+
+## 4. File-by-file implementation (partners-connect side)
+
+All paths are relative to `application/src/main/kotlin/fr/devlille/partners/connect/`.
+
+### 4.1 `ai/domain/ChatRequest.kt`
+
+```kotlin
+package fr.devlille.partners.connect.ai.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChatRequest(
+    val prompt: String,
+    val model: String? = null,
+    val system: String? = null,
+)
+```
+
+### 4.2 `ai/domain/ChatResponse.kt`
+
+```kotlin
+package fr.devlille.partners.connect.ai.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChatResponse(
+    val model: String,
+    val response: String,
+)
+```
+
+### 4.4 `ai/domain/LlmGateway.kt`
+
+> (Section 4.3 intentionally omitted — the numbering is kept stable so downstream § 4.x references don't shift.)
+
+```kotlin
+package fr.devlille.partners.connect.ai.domain
+
+interface LlmGateway {
+    suspend fun chat(
+        userPrompt: String,
+        system: String?,
+        modelName: String,
+    ): String
+
+    suspend fun listOllamaModels(): List<String>
+}
+```
+
+### 4.5 `ai/infrastructure/gateways/OllamaLlmGateway.kt`
+
+This is where Koog lives. Patterns to follow:
+
+- Construct `MultiLLMPromptExecutor` once at startup (in the Koin module), inject it here.
+- Inject a `HttpClient` for the `/api/tags` call.
+- All public methods are `suspend` — they call into Koog's coroutine-based API.
+
+> **Naming note** — the chat parameter is `userPrompt` (not `prompt`) to avoid shadowing the Koog DSL builder `ai.koog.prompt.dsl.prompt(...)`. Match this in the interface (§ 4.4).
+
+```kotlin
+package fr.devlille.partners.connect.ai.infrastructure.gateways
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private const val DEFAULT_CONTEXT_LENGTH = 8192L
+
+class OllamaLlmGateway(
+    private val executor: SingleLLMPromptExecutor,
+    private val http: HttpClient,
+    private val ollamaBaseUrl: String,
+) : LlmGateway {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun chat(
+        userPrompt: String,
+        system: String?,
+        modelName: String,
+    ): String {
+        val model = LLModel(
+            provider = LLMProvider.Ollama,
+            id = modelName,
+            capabilities = listOf(LLMCapability.Temperature),
+            contextLength = DEFAULT_CONTEXT_LENGTH,
+        )
+        val chatPrompt = prompt("ai-chat") {
+            system?.let { system(it) }
+            user(userPrompt)
+        }
+        val messages = executor.execute(chatPrompt, model)
+        return messages.joinToString("\n") { it.content }
+    }
+
+    override suspend fun listOllamaModels(): List<String> {
+        val body = http.get("$ollamaBaseUrl/api/tags").bodyAsText()
+        return json.decodeFromString<OllamaTagsResponse>(body).models.map { it.name }
+    }
+
+    @Serializable
+    private data class OllamaTagsResponse(val models: List<OllamaTag> = emptyList())
+
+    @Serializable
+    private data class OllamaTag(val name: String)
+}
+```
+
+**Error mapping** — wrap the gateway calls in `AiRoutes.kt` (not here). Catch Koog/Ktor client connectivity errors and re-throw as `ServiceUnavailableException` (see § 4.7 for where to add it).
+
+### 4.6 `ai/infrastructure/bindings/AiModule.kt`
+
+> **Type note** — `SingleLLMPromptExecutor` is declared in Koog 0.5.1 as
+> `SingleLLMPromptExecutor(llmClient: LLMClient)`. Since the feature only targets Ollama, this single-client executor is the right fit.
+
+```kotlin
+package fr.devlille.partners.connect.ai.infrastructure.bindings
+
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.ollama.client.OllamaClient
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.ai.infrastructure.gateways.OllamaLlmGateway
+import fr.devlille.partners.connect.internal.infrastructure.system.SystemVarEnv
+import io.ktor.client.HttpClient
+import org.koin.dsl.module
+
+val aiModule = module {
+    single<LlmGateway> {
+        val ollamaBaseUrl = SystemVarEnv.Llm.ollamaBaseUrl
+        OllamaLlmGateway(
+            executor = SingleLLMPromptExecutor(OllamaClient(baseUrl = ollamaBaseUrl)),
+            http = get<HttpClient>(),
+            ollamaBaseUrl = ollamaBaseUrl,
+        )
+    }
+}
+```
+
+> **Note on the `HttpClient`**: it's already provided by `networkClientModule` in `internal/infrastructure/bindings/`. Don't create a new one.
+
+> **Note on `SystemVarEnv.Llm`**: you'll need to add a nested object to `internal/infrastructure/system/SystemVarEnv.kt`. See § 4.8.
+
+### 4.7 `ai/infrastructure/api/AiRoutes.kt`
+
+> **Import notes**
+> - `BadRequestException` is `io.ktor.server.plugins.BadRequestException` (Ktor framework type — there is no project-local one). It is already wired to 400 in `App.kt`'s `configureStatusPage()`.
+> - There is no `EmptyStringValidationException` in this codebase. For an empty/blank `prompt`, throw `BadRequestException("prompt must not be blank")` directly — matches the existing pattern in `FlyerTemplateRepositoryExposed.kt`. The JSON schema's `"minLength": 1` will also reject `""` at the schema layer, so this branch only catches whitespace-only strings that slip past `minLength`.
+> - `ServiceUnavailableException` does **not** exist yet — § 4.7b adds it.
+
+```kotlin
+package fr.devlille.partners.connect.ai.infrastructure.api
+
+import fr.devlille.partners.connect.ai.domain.ChatRequest
+import fr.devlille.partners.connect.ai.domain.ChatResponse
+import fr.devlille.partners.connect.ai.domain.LlmGateway
+import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
+import fr.devlille.partners.connect.internal.infrastructure.ktor.AuthorizedOrganisationPlugin
+import fr.devlille.partners.connect.internal.infrastructure.ktor.receive
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import java.net.ConnectException
+import org.koin.ktor.ext.inject
+import org.slf4j.LoggerFactory
+
+private const val DEFAULT_MODEL = "gemma3:1b"
+private val logger = LoggerFactory.getLogger("ai.AiRoutes")
+
+fun Route.aiRoutes() {
+    val gateway by inject<LlmGateway>()
+
+    route("/orgs/{orgSlug}/ai") {
+        install(AuthorizedOrganisationPlugin)
+
+        get("/models") {
+            val models = withOllamaErrorHandling { gateway.listOllamaModels() }
+            call.respond(HttpStatusCode.OK, models)
+        }
+
+        post("/chat") {
+            val req = call.receive<ChatRequest>(schema = "ai_chat_request.schema.json")
+            if (req.prompt.isBlank()) throw BadRequestException("prompt must not be blank")
+
+            val modelName = req.model ?: DEFAULT_MODEL
+            val started = System.currentTimeMillis()
+            val response = withOllamaErrorHandling {
+                gateway.chat(req.prompt, req.system, modelName)
+            }
+            val latency = System.currentTimeMillis() - started
+
+            logger.info(
+                "ai.chat ok model={} prompt_chars={} response_chars={} latency_ms={}",
+                modelName, req.prompt.length, response.length, latency,
+            )
+
+            call.respond(HttpStatusCode.OK, ChatResponse(model = modelName, response = response))
+        }
+    }
+}
+
+// The shared `HttpClient` from `networkClientModule` is configured with
+// `expectSuccess = true` and a `HttpResponseValidator` that rethrows 401 as
+// `UnauthorizedException`. The gateway's `/api/tags` call goes through that
+// client, so any non-2xx from Ollama would otherwise surface as the wrong
+// status to the caller (401 or 500). Map all of those to 503 — Ollama's
+// HTTP status is a property of the upstream, not of the partners-connect API.
+//
+// (The chat path uses Koog's own `OllamaClient`, which has its own HTTP stack;
+// these catches don't apply to it, but the `ConnectException` /
+// `ConnectTimeoutException` cases still do.)
+private suspend fun <T> withOllamaErrorHandling(block: suspend () -> T): T =
+    try {
+        block()
+    } catch (e: ConnectException) {
+        throw ServiceUnavailableException("LLM backend is unreachable", e)
+    } catch (e: ConnectTimeoutException) {
+        throw ServiceUnavailableException("LLM backend timed out", e)
+    } catch (e: ServerResponseException) {
+        throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
+    } catch (e: ClientRequestException) {
+        throw ServiceUnavailableException("LLM backend returned ${e.response.status}", e)
+    }
+```
+
+> **Route convention** — declared as `Route.aiRoutes()` (matches `sponsoringRoutes()`, `providersRoutes()`, etc., which are called inside the `routing { }` block in `App.kt`). The newer `Application.digestRoutes()` style opens its own `routing { }` block; we deliberately do **not** follow that style to avoid nested `routing` blocks.
+
+### 4.7b `internal/infrastructure/api/ServiceUnavailableException.kt`
+
+New file — mirrors `ConflictException.kt` exactly. Two-arg constructor because the gateway re-throws with a wrapped cause.
+
+```kotlin
+package fr.devlille.partners.connect.internal.infrastructure.api
+
+class ServiceUnavailableException(
+    message: String,
+    cause: Throwable? = null,
+) : Throwable(message, cause)
+```
+
+And add the 503 mapping inside `Application.configureStatusPage()` in `App.kt`, alongside the existing `exception<ConflictException> { ... }` block:
+
+```kotlin
+exception<ServiceUnavailableException> { call, cause ->
+    call.respond(
+        status = HttpStatusCode.ServiceUnavailable,
+        message = ResponseException(
+            message = cause.message ?: "503 Service Unavailable",
+            stack = cause.cause?.stackTraceToString(),
+        ),
+    )
+}
+```
+
+Add the import at the top of `App.kt`:
+
+```kotlin
+import fr.devlille.partners.connect.internal.infrastructure.api.ServiceUnavailableException
+```
+
+### 4.8 `internal/infrastructure/system/SystemVarEnv.kt`
+
+Add a nested `Llm` object alongside the existing `Exposed`, `Crypto`, `GoogleProvider`, `QontoProvider`. The actual convention in the file is `val xxx: String = System.getenv("KEY") ?: "default"` (eagerly evaluated `val`, no helper indirection — see lines 10-32 of `SystemVarEnv.kt`).
+
+```kotlin
+object Llm {
+    val ollamaBaseUrl: String = System.getenv("OLLAMA_BASE_URL") ?: "http://localhost:11434"
+}
+```
+
+### 4.9 JSON schema
+
+`application/src/main/resources/schemas/ai_chat_request.schema.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["prompt"],
+  "properties": {
+    "prompt": { "type": "string", "minLength": 1 },
+    "model":  { "type": ["string", "null"] },
+    "system": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}
+```
+
+Then register the schema in `internal/infrastructure/ktor/ApplicationCall.ext.kt` (add a new `.register(readResourceFile("/schemas/ai_chat_request.schema.json"), SchemaType.DRAFT_7)` line inside the `schemas` lazy initializer).
+
+### 4.10 OpenAPI updates
+
+The OpenAPI source lives at `application/src/main/resources/openapi/openapi.yaml` and is **bundled** into `application/src/main/resources/openapi/documentation.yaml` (the latter is what Ktor serves at `/openapi`, see `App.kt:135`). **Edit `openapi.yaml`, never `documentation.yaml` by hand.**
+
+Follow the project's `openapi-schemas` skill (`.claude/skills/openapi-schemas/`) for the full authoring + validation workflow. The end-to-end shape is:
+
+- Add components `ChatRequest`, `ChatResponse`, `LlmModel` (typically as separate files under `openapi/components/` referenced via `$ref`, per existing convention — check how `ChatRequest` or `EventBudget` are organised).
+- Add paths:
+  - `POST /orgs/{orgSlug}/ai/chat`
+  - `GET /orgs/{orgSlug}/ai/models`
+- Tag both as `ai`.
+- Mark them as requiring the existing org auth scheme.
+- Run `cd server && npm run validate` (lints `openapi.yaml`) followed by `npm run bundle` (regenerates `documentation.yaml`) — both must pass and the bundled file must be checked in.
+
+### 4.11 `App.kt` changes
+
+Two edits:
+
+1. Import `aiModule` and add it to `ApplicationConfig.modules`:
+
+   ```kotlin
+   import fr.devlille.partners.connect.ai.infrastructure.bindings.aiModule
+   // ...
+   modules = listOf(
+       // ... existing modules ...
+       aiModule,
+   )
+   ```
+
+2. Import `aiRoutes` and mount it in the `routing { }` block:
+
+   ```kotlin
+   import fr.devlille.partners.connect.ai.infrastructure.api.aiRoutes
+   // ...
+   routing {
+       // ... existing ...
+       aiRoutes()
+   }
+   ```
+
+---
+
+## 5. Tests (partners-connect side)
+
+Follow `.claude/skills/integration-tests/` and `contract-tests/` skills exactly. Test root: `application/src/test/kotlin/fr/devlille/partners/connect/ai/`.
+
+### 5.1 Factories
+
+`ai/factories/Chat.factory.kt`:
+
+```kotlin
+fun createChatRequest(
+    prompt: String = "Hello",
+    model: String? = null,
+    system: String? = null,
+) = ChatRequest(prompt = prompt, model = model, system = system)
+```
+
+### 5.2 Gateway under test — fake or mock?
+
+Koog's `OllamaClient` talks to a real Ollama server. For tests, mock at the **`LlmGateway` interface level** (not the Koog level). This isolates tests from Koog and Ollama entirely.
+
+Create `ai/FakeLlmGateway.kt` in the test source root:
+
+```kotlin
+class FakeLlmGateway(
+    private val response: String = "fake response",
+    private val models: List<String> = listOf("gemma3:1b"),
+    private val throws: Throwable? = null,
+) : LlmGateway {
+    override suspend fun chat(userPrompt: String, system: String?, modelName: String) =
+        throws?.let { throw it } ?: response
+    override suspend fun listOllamaModels() =
+        throws?.let { throw it } ?: models
+}
+```
+
+Then in tests, override the Koin binding:
+
+```kotlin
+application {
+    moduleSharedDb(userId = userId)
+    GlobalContext.get().loadModules(listOf(module {
+        single<LlmGateway> { FakeLlmGateway(response = "hi from test") }
+    }))
+}
+```
+
+### 5.3 Contract tests (HTTP shape)
+
+`ai/infrastructure/api/AiChatRoutePostTest.kt`:
+- 400 when prompt is empty
+- 400 when JSON schema fails (extra field, wrong type)
+- 401 when no auth header
+- 200 with `{model, response}` shape on success
+
+`ai/infrastructure/api/AiModelsRouteGetTest.kt`:
+- 401 when no auth header
+- 200 returning a JSON array of strings
+
+### 5.4 Integration tests
+
+`ai/AiRoutesTest.kt`:
+- End-to-end: authenticated org calls `/ai/chat`, gets the fake response back.
+- 503 path — connect failure: fake gateway throws `ConnectException` → expect `503`.
+- 503 path — Ollama 5xx: fake gateway throws `ServerResponseException` → expect `503` (covers the `expectSuccess = true` translation from the shared `HttpClient`).
+- 503 path — Ollama 4xx (incl. 401): fake gateway throws `ClientRequestException` → expect `503` (Ollama's auth state must not leak through as partners-connect's 401).
+
+---
+
+## 6. Cortex workspace changes
+
+This section is for the Claude instance working in `~/Documents/workspace/cortex/`. Goal: trim the existing Ktor-scaffold workspace down to just an Ollama deployment, mirroring the partners-connect deploy pattern (GHCR + Clever Cloud + `clever-tools`).
+
+### 6.1 Files to delete from cortex
+
+- The entire `ktor-app/` directory (it was a prototype; the API now lives in partners-connect).
+- The root `docker-compose.yml` (replaced — see § 6.2).
+- `.env.example` keep (just trim to `DEFAULT_MODEL`).
+- The existing `clevercloud/README.md` keep but rewrite (see § 6.5).
+
+### 6.2 New layout
+
+```
+cortex/
+├── ollama/
+│   └── Dockerfile           # ← build-time pre-pull
+├── Dockerfile.deploy        # ← pulls from GHCR, used by Clever Cloud
+├── docker-compose.yml       # local smoke test only
+├── .env.example
+├── .github/workflows/
+│   ├── build-push-ollama.yaml
+│   └── deploy-ollama.yaml
+├── clevercloud/README.md    # deployment runbook
+└── README.md                # rewritten as: "this repo owns the Ollama deploy"
+```
+
+### 6.3 `ollama/Dockerfile`
+
+Pre-pull `gemma3:1b` at build time so Clever Cloud cold-starts don't have to download 800 MB.
+
+```dockerfile
+FROM ollama/ollama:latest
+
+ENV OLLAMA_HOST=0.0.0.0:11434
+
+# Pre-pull the default model so the image ships ready-to-serve.
+# This adds ~815 MB to the image but makes cold-start instant.
+RUN (ollama serve &) && \
+    sleep 5 && \
+    ollama pull gemma3:1b && \
+    pkill -f "ollama serve" && \
+    sleep 2
+
+EXPOSE 11434
+```
+
+> The `ollama serve &` + `sleep 5` + `pkill` dance is needed because `ollama pull` requires a running server. There is no `--build-pull` flag.
+
+### 6.4 `Dockerfile.deploy`
+
+Same pattern as `partners-connect/server/Dockerfile.deploy`:
+
+```dockerfile
+ARG TAG_VERSION=latest
+FROM ghcr.io/<owner>/<repo>-ollama:${TAG_VERSION}
+```
+
+Replace `<owner>/<repo>` to match your GHCR layout (likely mirrors what partners-connect uses: e.g. `ghcr.io/devlille/devlille/cortex-ollama`).
+
+### 6.5 `docker-compose.yml` (local smoke test only)
+
+```yaml
+services:
+  ollama:
+    build:
+      context: ./ollama
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+Local test: `docker compose up --build` then `curl http://127.0.0.1:11435/api/tags` (host port 11435 to avoid colliding with a native Ollama on 11434).
+
+### 6.6 `.github/workflows/build-push-ollama.yaml`
+
+Mirror `partners-connect/.github/workflows/ci-server.yaml`. Triggers on push to main; builds `ollama/Dockerfile` and pushes to GHCR as `ghcr.io/<owner>/<repo>-ollama:<sha>` and `:latest`.
+
+Key differences from the server CI:
+- `working-directory: ollama` instead of `server`
+- No `npm install` / OpenAPI step
+- Build time is dominated by the model pre-pull, not Gradle — expect 2-3 minutes
+
+### 6.7 `.github/workflows/deploy-ollama.yaml`
+
+**Manual trigger only** (`workflow_dispatch`) — Cortex has one Clever Cloud instance, deployed when someone clicks "Run workflow" or runs `gh workflow run`. There is no auto-deploy on tag push, no preprod auto-deploy on `workflow_run` after CI.
+
+Required GitHub Secrets (new, separate from the server ones):
+- `CLEVERCLOUD_OLLAMA_APP_ID`
+- Reuse from partners-connect: `CLEVERCLOUD_TOKEN`, `CLEVERCLOUD_SECRET`, `CC_DOCKER_LOGIN_PASSWORD`, `CC_DOCKER_LOGIN_USERNAME`
+
+Required Clever Cloud env vars set via `clever env set`:
+- `CC_DOCKERFILE=Dockerfile.deploy`
+- `CC_DOCKER_LOGIN_PASSWORD`, `CC_DOCKER_LOGIN_USERNAME`, `CC_DOCKER_LOGIN_SERVER=ghcr.io`
+- `TAG_VERSION=<sha or latest>`
+- `OLLAMA_NUM_PARALLEL=1` to cap memory use under concurrent requests
+
+### 6.8 Clever Cloud setup checklist (one-time, manual)
+
+1. Create **one** Docker app on Clever Cloud (no prod/preprod split — both partners-connect environments share this single Cortex backend).
+2. Instance size: **M or L** (need ≥ 4 GB RAM for gemma3:1b headroom; S OOMs under load).
+3. **Do NOT** attach a public domain — keep it on the internal network.
+4. Add an **FS Bucket** add-on if you plan to pull more models at runtime (so they persist across restarts). For the pre-baked model only, skip this.
+5. Create a **network group** including Cortex and every partners-connect app that needs to call it (production + preprod if present). Note the Cortex internal hostname.
+6. In every partners-connect Clever Cloud app's env, set `OLLAMA_BASE_URL=http://<cortex-internal-hostname>:8080`. Port 8080 (not Ollama's default 11434) because Clever Cloud's healthcheck polls 8080; the Cortex deploy workflow sets `OLLAMA_HOST=0.0.0.0:8080` on the Cortex app to match. Add this to `cd-server.yaml` (§ 6.9) so future deploys don't lose it.
+7. Note the new Cortex app ID and add it to GitHub Secrets per § 6.7.
+
+### 6.9 `cd-server.yaml` update on the partners-connect side
+
+Cortex has a single URL that's the same regardless of which partners-connect environment is deploying. Add **one** secret (`OLLAMA_BASE_URL`) to the partners-connect repo and pass it through unchanged.
+
+In the `Configure Clever Cloud for monorepo` step, add to the env block:
+
+```yaml
+OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+```
+
+…and in the same step's `run:` block, add:
+
+```bash
+clever env set OLLAMA_BASE_URL "$OLLAMA_BASE_URL" --app $CLEVER_APP_ID
+```
+
+No per-environment branching needed — same value for partners-connect prod and preprod, since they share the Cortex backend.
+
+---
+
+## 7. Order of operations
+
+Recommended sequence to minimise broken-state windows:
+
+1. **Partners-connect side, behind a flag:**
+   1. Add `OLLAMA_BASE_URL` to local `.env.example` (default `http://localhost:11434`).
+   2. Implement § 4 (domain, gateway, routes, Koin, schemas, OpenAPI, App.kt wiring).
+   3. Tests (§ 5).
+   4. Local validation: `./gradlew check --no-daemon` + `npm run validate` must pass.
+   5. Local smoke: with the existing `cortex` stack running (still has the prototype), point `OLLAMA_BASE_URL=http://localhost:11434` and hit `/orgs/.../ai/chat` from Bruno.
+2. **Cortex side:**
+   1. Implement § 6 (Ollama Dockerfile with pre-pull, GHCR build workflow, manual deploy workflow).
+   2. Test locally: `docker compose up --build` and `curl http://127.0.0.1:11435/api/tags`.
+   3. Merge to main → GHCR image builds and lands as `:latest` and `:<sha>`.
+   4. Set up the single Clever Cloud app (§ 6.8).
+   5. Manually trigger the deploy workflow with `image_tag=latest`.
+3. **Wire up partners-connect:**
+   1. Add the `OLLAMA_BASE_URL` secret and update `cd-server.yaml` (§ 6.9).
+   2. Deploy partners-connect to its preprod environment.
+   3. Smoke test the `/orgs/<slug>/ai/chat` route against partners-connect preprod (it talks to the same Cortex instance).
+4. **Deploy partners-connect production** after a few days of preprod stability.
+
+---
+
+## 8. Pre-merge checklist
+
+- [ ] `./gradlew ktlintCheck detekt --no-daemon` clean
+- [ ] `./gradlew test --no-daemon` clean, ≥80 % coverage on `ai/` package
+- [ ] `cd server && npm run validate` clean (OpenAPI valid)
+- [ ] `./gradlew build --no-daemon` clean
+- [ ] Local Bruno collection has working `/orgs/<slug>/ai/chat` and `/orgs/<slug>/ai/models` requests
+- [ ] `App.kt` registers `aiModule` and `aiRoutes()`
+- [ ] `SystemVarEnv.Llm.ollamaBaseUrl` reads `OLLAMA_BASE_URL`
+- [ ] `cd-server.yaml` sets `OLLAMA_BASE_URL` in Clever Cloud
+- [ ] Cortex repo: `Dockerfile`, `Dockerfile.deploy`, both workflows, README
+- [ ] New GitHub secrets exist: `CLEVERCLOUD_OLLAMA_APP_ID` (in cortex repo), `OLLAMA_BASE_URL` (in partners-connect repo)
+- [ ] (manual) Single Clever Cloud Ollama app exists, network group set up, app ID noted
+
+---
+
+## 9. Open questions / NEEDS CLARIFICATION
+
+- **Q1**: Should the chat route also accept an `Accept-Language` header and pass it to a system prompt automatically (mirroring the `sponsoring` and `partnership` routes that use it)? — Default to no for v1; the caller supplies their own `system` if they want language steering.
+- **Q2**: Should the prompt + response be persisted for audit / debugging? — Out of scope for v1 (see spec § "Out of scope"). If yes, add an `ai_chat_log/` Exposed table.

--- a/server/specs/026-llm-chat-integration/spec.md
+++ b/server/specs/026-llm-chat-integration/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Self-hosted LLM chat integration
+
+**Feature Branch**: `026-llm-chat-integration`
+**Created**: 2026-05-23
+**Status**: Draft
+**Input**: User description: "Integrate a self-hosted open-source LLM (Ollama, running as a separate Clever Cloud Docker app) into the partners-connect server via Koog (JetBrains' Kotlin AI framework), exposing chat endpoints under `/orgs/{orgSlug}/ai/...`. Default to `gemma3:1b` for cost/CPU-friendliness; allow swapping models per request."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Send a prompt and get a generated response (Priority: P1)
+
+As an organiser authenticated on a given organisation, I can `POST /orgs/{orgSlug}/ai/chat` with a prompt and get back a generated response from the self-hosted LLM. This is the minimum viable feature: a single round-trip chat call backed by Ollama.
+
+**Why this priority**: The whole feature exists to enable LLM-backed UX (drafting partner emails, summarising partnerships, etc.). Without this endpoint nothing else matters — every other story builds on it.
+
+**Independent Test**: With `OLLAMA_BASE_URL` pointing at a running Ollama instance that has `gemma3:1b` pulled, a `POST /orgs/{orgSlug}/ai/chat` with body `{"prompt":"Reply with: hello"}` returns 200 and `{"model":"gemma3:1b","response":"..."}` where the response is non-empty.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated organiser and Ollama reachable with `gemma3:1b` pulled, **When** they `POST /orgs/{orgSlug}/ai/chat` with `{"prompt":"Hello"}`, **Then** the server returns 200 with `{"model":"gemma3:1b","response":"<non-empty text>"}`.
+2. **Given** the same setup, **When** the body includes `"system":"You are terse. Answer in 1 sentence."`, **Then** the response reflects that system instruction.
+3. **Given** the same setup, **When** the body includes `"model":"llama3.2:3b"` and that model is pulled in Ollama, **Then** the response field `"model"` equals `"llama3.2:3b"`.
+4. **Given** an unauthenticated request to the same route, **When** sent, **Then** the server returns 401 (via `AuthorizedOrganisationPlugin`).
+
+---
+
+### User Story 2 - Discover available models (Priority: P2)
+
+As an organiser, I can `GET /orgs/{orgSlug}/ai/models` to know which models are currently pulled into the Ollama instance, so that I can pick a valid `"model"` value when calling `/chat`.
+
+**Why this priority**: Without this, callers have to guess model names. It's not blocking the core chat use case but it makes the API usable from a UI or Bruno collection without out-of-band knowledge.
+
+**Independent Test**: With Ollama running and at least `gemma3:1b` pulled, `GET /orgs/{orgSlug}/ai/models` returns 200 with a JSON array of model name strings that includes `"gemma3:1b"`.
+
+**Acceptance Scenarios**:
+
+1. **Given** Ollama with `gemma3:1b` and `llama3.2:3b` pulled, **When** an authenticated organiser calls `GET /orgs/{orgSlug}/ai/models`, **Then** the response is `["gemma3:1b","llama3.2:3b"]` (order not guaranteed).
+2. **Given** an empty Ollama (no models pulled), **When** the same call is made, **Then** the response is `[]`.
+
+---
+
+### Edge Cases
+
+- **Ollama unreachable** (connection refused, DNS resolution failure, timeout): return **503 Service Unavailable** with a message naming Ollama. Do not leak the internal hostname to the response body.
+- **Model not pulled in Ollama** (404 from Ollama's `/api/generate`): return **400 Bad Request** with message `"model '<name>' is not available; call GET /ai/models to list pulled models"`.
+- **Empty prompt** (`""` or whitespace-only): return **400 Bad Request**. `""` is rejected by the JSON schema (`"minLength": 1`) via `RequestBodyValidationException`; whitespace-only is rejected by an explicit `BadRequestException("prompt must not be blank")` in the route handler.
+- **Prompt exceeds context length** (Ollama returns truncation or error): for v1, do not pre-validate — let Ollama's error surface as a 503 with the Ollama-reported message. Pre-validation can come later when we have token counting.
+- **Concurrent requests from the same org**: Koog's `OllamaClient` is thread-safe; no special handling required. Ollama itself queues requests serially per model — concurrent callers will see latency stack up, which is acceptable for v1.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose `POST /orgs/{orgSlug}/ai/chat` accepting JSON body `{prompt: string, model?: string, system?: string}` and returning `200` with JSON `{model: string, response: string}`.
+- **FR-002**: System MUST expose `GET /orgs/{orgSlug}/ai/models` returning a JSON array of model name strings pulled into the Ollama instance.
+- **FR-003**: Both endpoints MUST install `AuthorizedOrganisationPlugin` so that only members of `{orgSlug}` with `canEdit` may call them.
+- **FR-004**: System MUST default the model to `gemma3:1b` when `model` is absent from the request body.
+- **FR-005**: System MUST read the Ollama base URL from env var `OLLAMA_BASE_URL`. Default for local dev is `http://localhost:11434`; in deployed environments this is the Clever Cloud internal hostname of the Ollama app.
+- **FR-007**: System MUST validate that `prompt` is non-empty after trimming. The JSON schema (FR-010) enforces `"minLength": 1` at the schema layer; whitespace-only prompts that slip past the schema MUST throw `io.ktor.server.plugins.BadRequestException("prompt must not be blank")` (→ 400 via the existing `BadRequestException` handler in `App.kt`'s `configureStatusPage()`).
+- **FR-008**: System MUST handle Ollama connectivity failures (connect timeout, refused, DNS) by throwing a new `ServiceUnavailableException` (added under `internal/infrastructure/api/`, mirroring `ConflictException`) mapped to **503 Service Unavailable** via a new handler in `App.kt`'s `configureStatusPage()`.
+- **FR-009**: System MUST log each chat call's `orgSlug`, model name, prompt length, response length, and latency in milliseconds at INFO level. The prompt and response content MUST NOT be logged.
+- **FR-010**: Request body validation MUST go through `call.receive<T>(schema = "...")` with a JSON schema in `application/src/main/resources/schemas/ai_chat_request.schema.json` (per project convention), and the schema MUST be registered in the `schemas` lazy initializer in `internal/infrastructure/ktor/ApplicationCall.ext.kt`.
+- **FR-011**: The OpenAPI source spec at `application/src/main/resources/openapi/openapi.yaml` MUST be updated to document the two new endpoints, and the bundled `application/src/main/resources/openapi/documentation.yaml` MUST be regenerated. Both `npm run validate` and `npm run bundle` MUST pass; see the `openapi-schemas` skill for the authoring workflow.
+- **FR-012**: A new Koin module `aiModule` MUST be registered in `App.kt`'s `ApplicationConfig.modules` list.
+- **FR-013**: The new top-level `Route.aiRoutes()` function MUST be mounted in `App.kt`'s `routing {}` block alongside the other `*Routes()` calls.
+- **FR-014**: All new code MUST pass `./gradlew ktlintCheck detekt test --no-daemon`.
+
+### Key Entities
+
+- **ChatRequest** (`domain/ChatRequest.kt`): represents the inbound payload. Fields: `prompt: String`, `model: String? = null`, `system: String? = null`. `@Serializable`.
+- **ChatResponse** (`domain/ChatResponse.kt`): represents the outbound payload. Fields: `model: String`, `response: String`. `@Serializable`.
+- **LlmModel** (`domain/LlmModel.kt`): wrapper for the `/ai/models` response item. Field: `name: String`. `@Serializable`.
+- **LlmGateway** (`domain/LlmGateway.kt`): the single business contract. Methods:
+  - `suspend fun chat(userPrompt: String, system: String?, modelName: String): String` — parameter is named `userPrompt` to avoid shadowing the Koog DSL builder `ai.koog.prompt.dsl.prompt(...)`.
+  - `suspend fun listOllamaModels(): List<String>`
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For `gemma3:1b` on the Clever Cloud Ollama instance, the p50 latency of `POST /ai/chat` for a 50-token prompt and a ≤200-token response is under **5 seconds** end-to-end (measured server-side, excluding network).
+- **SC-002**: All quality gates pass in CI: `./gradlew ktlintCheck detekt test --no-daemon` and `npm run validate`.
+- **SC-003**: Test coverage for the new `ai/` module is **≥ 80 %** (contract tests + integration tests + gateway unit tests).
+- **SC-004**: After deploy, an authenticated organiser can hit `https://<preprod-base-url>/orgs/<orgSlug>/ai/chat` with a sample prompt and receive a non-empty response within 10 seconds (cold-start budget included).
+- **SC-005**: The Ollama Clever Cloud app cold-starts in under **30 seconds** when the `gemma3:1b` model is pre-baked into the image (FR side: see `infrastructure.md`).
+
+## Out of scope for v1
+
+- Streaming responses (Koog supports `executeStreaming`; can be added in a follow-up).
+- Token counting / pre-validation of prompt length.
+- Agent loops (Koog's `aiAgent(strategy = reActStrategy(), ...)`) — this v1 is a single round-trip.
+- Tools / function calling.
+- Embeddings / RAG (Koog supports them; out of scope here).
+- Persistent chat history.
+- Rate limiting per org (relies on existing infrastructure; if needed, a follow-up).
+- Public/unauthenticated access — explicitly excluded; the endpoint is always `/orgs/...` scoped.
+
+## Cross-references
+
+- **Implementation plan**: see `plan.md` in this folder — contains file-by-file code structure, Koog API gotchas, dependency additions, and the deployment plan for the companion Ollama Clever Cloud app.
+- **Companion repository**: `~/Documents/workspace/cortex/` (separate workspace) — owns the Ollama Docker image, the GHCR build workflow, and the Clever Cloud deploy workflow. See `plan.md` § "Cortex workspace changes" for the exact files to create/modify.
+- **Reference prototype**: a working Koog + Ktor + Ollama prototype was built in `~/Documents/workspace/cortex/ktor-app/` (will be deleted as part of this work). It validated the Koog 0.5.1 API; see `plan.md` § "Koog 0.5.1 API gotchas" for what we learned.


### PR DESCRIPTION
## Summary

- Add `POST /orgs/{orgSlug}/ai/chat` and `GET /orgs/{orgSlug}/ai/models`, backed by a self-hosted Ollama via Koog 0.5.1 (`SingleLLMPromptExecutor` + `OllamaClient`).
- Default model `gemma3:1b`; `OLLAMA_BASE_URL` env (default `http://localhost:11434`) controls the upstream.
- All Ollama-side failures (connect / timeout / 4xx / 5xx) map to a new `ServiceUnavailableException` → 503, so the upstream's HTTP status never leaks through partners-connect's API surface.

See `server/specs/026-llm-chat-integration/spec.md` and `plan.md` for the full design and verification record (spec, key entities, FRs, edge cases, Koog 0.5.1 gotchas, local-dev setup).

## Out of scope — separate workstream

The deploy-side work (Ollama Clever Cloud app via the `cortex` repo, GHCR build/deploy workflows, network group, `OLLAMA_BASE_URL` wiring in `cd-server.yaml`) is documented in `plan.md` § 6 but lives in a separate PR. Until that ships, the feature is local-dev / preprod-manual only.

## Notable implementation notes

- `isZip64 = true` added to the `ShadowJar` task — Koog's transitive deps push the shadow jar past the 65 535-entry legacy ZIP cap. Without it `./gradlew build` fails.
- Test wiring follows the existing `FakeBillingGateway` pattern (`moduleMocked` + `moduleSharedDb` Koin overrides) rather than runtime `GlobalContext.loadModules`.
- JaCoCo is not configured in this project, so SC-003's \"≥80 % coverage on \`ai/\`\" is by-inspection rather than measured. Worth wiring JaCoCo separately if the metric needs to be enforced.

## Test plan

- [x] \`./gradlew ktlintCheck detekt --no-daemon\` clean
- [x] \`./gradlew test --no-daemon\` clean (20 new AI tests + existing suite)
- [x] \`cd server && npm run validate\` clean
- [x] \`cd server && npm run bundle\` — \`documentation.yaml\` regenerated and committed
- [x] \`./gradlew build --no-daemon\` clean
- [ ] Manual smoke test against local Ollama with \`gemma3:1b\` pulled (curl / Bruno)
- [ ] Preprod smoke test once \`OLLAMA_BASE_URL\` is wired in Clever Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)