### PR TITLE
fix(server): exclude already-communicated partnerships from digest flyer list

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/application/DigestRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/digest/application/DigestRepositoryExposed.kt
@@ -14,6 +14,8 @@ import fr.devlille.partners.connect.internal.infrastructure.db.PromotionStatus
 import fr.devlille.partners.connect.internal.infrastructure.system.SystemVarEnv
 import fr.devlille.partners.connect.organisations.application.mappers.toItemDomain
 import fr.devlille.partners.connect.partnership.infrastructure.db.BillingEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.CommunicationPlanEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.CommunicationPlansTable
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipEntity
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipSupportVideoEntity
 import fr.devlille.partners.connect.partnership.infrastructure.db.PartnershipsTable
@@ -22,6 +24,8 @@ import fr.devlille.partners.connect.sponsoring.infrastructure.db.hasFlyerTemplat
 import io.ktor.server.plugins.NotFoundException
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.isNotNull
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
 
@@ -115,12 +119,21 @@ class DigestRepositoryExposed : DigestRepository {
             .listByEventAndStatus(eventId, PromotionStatus.PENDING)
             .map { DigestEntry(it.partnership.company.name, buildLink(eventSlug, it.partnership.id.value)) }
 
-    private fun queryFlyerEligible(eventId: UUID, eventSlug: String): List<DigestEntry> =
-        PartnershipEntity
+    private fun queryFlyerEligible(eventId: UUID, eventSlug: String): List<DigestEntry> {
+        val partnershipsWithPlanSupport = CommunicationPlanEntity
+            .find {
+                (CommunicationPlansTable.eventId eq eventId) and
+                    CommunicationPlansTable.supportUrl.isNotNull()
+            }
+            .mapNotNull { it.partnership?.id?.value }
+            .toSet()
+        return PartnershipEntity
             .find { PartnershipsTable.eventId eq eventId }
             .filter { partnership ->
                 partnership.communicationSupportUrl == null &&
+                    partnership.id.value !in partnershipsWithPlanSupport &&
                     partnership.validatedPack()?.hasFlyerTemplate() == true
             }
             .map { DigestEntry(it.company.name, buildLink(eventSlug, it.id.value)) }
+    }
 }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/digest/application/DigestFlyerEligibilityTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/digest/application/DigestFlyerEligibilityTest.kt
@@ -4,6 +4,7 @@ import fr.devlille.partners.connect.companies.factories.insertMockedCompany
 import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
 import fr.devlille.partners.connect.internal.moduleSharedDb
 import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.factories.insertMockedCommunicationPlan
 import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
 import fr.devlille.partners.connect.partnership.factories.insertMockedValidatedPartnership
 import fr.devlille.partners.connect.sponsoring.factories.insertMockedFlyerEnabledPack
@@ -31,10 +32,12 @@ class DigestFlyerEligibilityTest {
         val plainPackId = UUID.randomUUID()
         val eligibleCompanyId = UUID.randomUUID()
         val alreadyGeneratedCompanyId = UUID.randomUUID()
+        val alreadyCommunicatedCompanyId = UUID.randomUUID()
         val plainPackCompanyId = UUID.randomUUID()
         val notValidatedCompanyId = UUID.randomUUID()
         val eligiblePartnershipId = UUID.randomUUID()
         val alreadyGeneratedPartnershipId = UUID.randomUUID()
+        val alreadyCommunicatedPartnershipId = UUID.randomUUID()
         val plainPackPartnershipId = UUID.randomUUID()
         val notValidatedPartnershipId = UUID.randomUUID()
 
@@ -46,6 +49,7 @@ class DigestFlyerEligibilityTest {
                 insertMockedFutureEventWithSlug(eventId, slug = eventSlug, orgId = orgId)
                 insertMockedCompany(eligibleCompanyId)
                 insertMockedCompany(alreadyGeneratedCompanyId)
+                insertMockedCompany(alreadyCommunicatedCompanyId)
                 insertMockedCompany(plainPackCompanyId)
                 insertMockedCompany(notValidatedCompanyId)
                 insertMockedFlyerEnabledPack(packId = flyerPackId, eventId = eventId)
@@ -62,6 +66,17 @@ class DigestFlyerEligibilityTest {
                     companyId = alreadyGeneratedCompanyId,
                     selectedPackId = flyerPackId,
                 ).apply { communicationSupportUrl = "https://example.com/flyer.jpg" }
+                insertMockedValidatedPartnership(
+                    id = alreadyCommunicatedPartnershipId,
+                    eventId = eventId,
+                    companyId = alreadyCommunicatedCompanyId,
+                    selectedPackId = flyerPackId,
+                )
+                insertMockedCommunicationPlan(
+                    eventId = eventId,
+                    partnershipId = alreadyCommunicatedPartnershipId,
+                    supportUrl = "https://example.com/communication-support.jpg",
+                )
                 insertMockedValidatedPartnership(
                     id = plainPackPartnershipId,
                     eventId = eventId,


### PR DESCRIPTION
## Summary
- The digest's `queryFlyerEligible` only checked the legacy `partnerships.communication_support_url` column, so partnerships whose communication support was uploaded via the new `CommunicationPlanEntity` flow (`PUT /communication/support`, `PUT /communication/publication`) still appeared as "flyer to generate".
- Now also exclude partnerships that have any `CommunicationPlanEntity` row with a non-null `supportUrl` for the event — mirroring the "support URL present at either level" semantics already used by `PartnershipCommunicationRepositoryExposed`.
- Added a fifth fixture (`alreadyCommunicatedPartnership`) to `DigestFlyerEligibilityTest` covering the new exclusion path.

## Test plan
- [x] `./gradlew :application:test --tests "fr.devlille.partners.connect.digest.*"`
- [x] `./gradlew :application:ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)