### PR TITLE
ci(server): propagate OLLAMA_BASE_URL to preprod Clever Cloud env

### DIFF
--- a/.github/workflows/cd-server.yaml
+++ b/.github/workflows/cd-server.yaml
@@ -81,6 +81,7 @@ jobs:
             echo "postgres_user=${{ secrets.EXPOSED_DB_USER_PP }}" >> $GITHUB_OUTPUT
             echo "postgres_password=${{ secrets.EXPOSED_DB_PASSWORD_PP }}" >> $GITHUB_OUTPUT
             echo "qonto_base_url=https://thirdparty-sandbox.staging.qonto.co" >> $GITHUB_OUTPUT
+            echo "ollama_base_url=${{ secrets.OLLAMA_BASE_URL }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Install Clever Tools


### PR DESCRIPTION
## Summary
- The preprod branch of `.github/workflows/cd-server.yaml` (step `Set Clever Cloud App ID`) never wrote `ollama_base_url` to `$GITHUB_OUTPUT`, even though the downstream `Configure Clever Cloud for monorepo` step unconditionally reads it and runs `clever env set OLLAMA_BASE_URL "$OLLAMA_BASE_URL"`.
- Every preprod deploy (triggered by a successful build on `main`) was therefore overwriting `OLLAMA_BASE_URL` on the preprod Clever Cloud app with an empty string.
- Fix: reuse the existing `OLLAMA_BASE_URL` secret in the preprod branch as well (preprod points at the same Ollama instance as production).

## Test plan
- [ ] After merge, the next preprod deploy logs should show `clever env set OLLAMA_BASE_URL "<non-empty>"`.
- [ ] `clever env --app $PREPROD_APP_ID | grep OLLAMA_BASE_URL` returns the expected URL on Clever Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)