### PR TITLE
feat(server): pin mail-draft endpoint to qwen2.5:3b

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipEmailDraftRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipEmailDraftRoutes.kt
@@ -18,6 +18,8 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import org.koin.ktor.ext.inject
 
+private const val MAIL_DRAFT_MODEL = "qwen2.5:3b"
+
 fun Route.partnershipEmailDraftRoutes() {
     val partnershipRepository by inject<PartnershipRepository>()
     val llmRepository by inject<LlmRepository>()
@@ -35,6 +37,7 @@ fun Route.partnershipEmailDraftRoutes() {
             val draft = llmRepository.chat(
                 ChatRequest(
                     prompt = request.prompt,
+                    model = MAIL_DRAFT_MODEL,
                     system = buildSystemPrompt(contexts),
                 ),
             )


### PR DESCRIPTION
## Summary
- `POST /orgs/{orgSlug}/events/{eventSlug}/partnerships/email/draft` previously sent its `ChatRequest` without a `model`, falling through to the global `DEFAULT_MODEL = "gemma3:1b"` in `LlmRepositoryDefault`.
- Pin the mail-draft use case to `qwen2.5:3b` via a `MAIL_DRAFT_MODEL` constant in `PartnershipEmailDraftRoutes.kt`. The global default is left untouched so ad-hoc `POST /orgs/{orgSlug}/ai/chat` callers still hit the existing default.
- Assumes `qwen2.5:3b` is pulled on the target Ollama host(s).

## Test plan
- [x] `./gradlew :application:test --tests "...PartnershipEmailDraftRoutesTest"`
- [x] `./gradlew :application:ktlintCheck`
- [ ] Post-deploy: verify Ollama logs show `qwen2.5:3b` being invoked when the email draft endpoint is hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)