### PR TITLE
fix(server): tighten mail-draft system prompt for email output

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipEmailDraftRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/partnership/infrastructure/api/PartnershipEmailDraftRoutes.kt
@@ -53,10 +53,20 @@ internal fun buildSystemPrompt(contexts: List<PartnershipDraftContext>): String 
     }
     return """
         |You are an email-drafting assistant for an event organiser.
-        |The organiser is composing one email body that will be sent to the following partners:
-        |$partnersBlock
         |
         |Follow the organiser's instructions in the user prompt. Output only the email body —
         |no subject line, no greeting/signature placeholders, no surrounding commentary.
+        |
+        |Formatting rules:
+        |- Plain text only. The output is sent as an email body, so do NOT use Markdown:
+        |  no **bold**, no *italics*, no `code`, no # headers, no Markdown bullet characters.
+        |- Use real line breaks. Separate paragraphs with a blank line. When listing items,
+        |  put each item on its own line (a plain "1." / "2." prefix is fine; no "- ").
+        |
+        |The following partners may be recipients of this email. Treat the list as background
+        |context only — do not enumerate them or address each one by name in the output unless
+        |the user prompt explicitly asks for it. Use the listed languages to pick the right
+        |output language when the user prompt does not specify one:
+        |$partnersBlock
         """.trimMargin()
 }


### PR DESCRIPTION
## Summary
Three observed issues in the output of `POST /partnerships/email/draft`:
1. The model emitted Markdown (`**bold**`, `1.` list with bold headings). The draft is rendered as an email body, so Markdown shouldn't be used.
2. No real line breaks — the output came back as one wrapped paragraph because nothing told the model to use `\n` between paragraphs/list items.
3. The partner list in the system prompt was framed as "the email will be sent to the following partners," which the model interpreted as "address each one explicitly." It should be background context only.

This commit reworks `buildSystemPrompt` to:
- Ban Markdown explicitly (no `**bold**`, `*italics*`, `` `code` ``, `#` headers, or `- ` bullets).
- Require real line breaks: blank line between paragraphs, one item per line for lists.
- Reframe the partner block as background context ("may be recipients … do not enumerate them by name unless the user prompt asks for it") and note that the listed `language` field is what should drive output language selection.

## Test plan
- [x] `./gradlew :application:test --tests "...PartnershipEmailDraftRoutesTest"`
- [x] `./gradlew :application:ktlintCheck`
- [ ] Manual: hit `POST /partnerships/email/draft` with a French user prompt and confirm the output is plain text with real `\n` between paragraphs, and does not enumerate the partner names.

## Note
Prompt tuning is empirical. If `gemini-2.5-flash` still slips Markdown into the output after this, a one-shot example (a sample plain-text email) in the system prompt is the next dial to turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)