### PR TITLE
feat(server): per-user favorite events (/users/me/favorite-events)

### DIFF
--- a/server/.claude/skills/clean-architecture/SKILL.md
+++ b/server/.claude/skills/clean-architecture/SKILL.md
@@ -203,6 +203,8 @@ private fun Route.orgsPackRoutes() {
 | Entity class | `<Name>Entity.kt` | `CompanyEntity.kt`, `SponsoringPackEntity.kt` |
 | Join table | `<Name>Table.kt` (extends `Table`) | `PackOptionsTable.kt` |
 
+> **Imports**: Exposed 1.3.0 + kotlinx-datetime 0.8 changed several package paths. See `exposed-entities` § 0 "Canonical Imports" for the exact paths to use (`UUIDTable` lives in `.java.`; DSL operators like `eq`/`and` are top-level functions; `Clock` moved from `kotlinx.datetime` to `kotlin.time`).
+
 #### Table rules
 
 - **Extend `UUIDTable`** (or `Table` for join tables without their own UUID).

--- a/server/.claude/skills/exposed-entities/SKILL.md
+++ b/server/.claude/skills/exposed-entities/SKILL.md
@@ -11,6 +11,73 @@ All database access uses JetBrains Exposed ORM with the DAO (Entity) API. Tables
 
 ---
 
+## 0 — Canonical Imports (Exposed 1.3.0+)
+
+This codebase runs **Exposed 1.3.0** on Kotlin 2.3+. Two recent breaking changes from earlier Exposed versions are easy to get wrong because the *old* import paths still resolve — they just resolve to the wrong thing (or to deprecated APIs). Always copy from these exact paths.
+
+### 0.1 Table / Entity / EntityClass — use the `.java.` subpackage
+
+The unsuffixed names (`UUIDTable`, `UUIDEntity`, `UUIDEntityClass`) now target Kotlin's `kotlin.uuid.Uuid`. This project uses `java.util.UUID` everywhere (foreign keys, factory parameters, route handlers), so we always import the **`.java.`** variants:
+
+```kotlin
+// In <Name>Table.kt files:
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+
+// In <Name>Entity.kt files:
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import java.util.UUID
+```
+
+The same rule applies to the non-UUID variants when you need a custom-PK entity: prefer the `.java.` subpackage when you intend to interoperate with `java.util.UUID` foreign keys.
+
+### 0.2 DSL operators — top-level functions on `org.jetbrains.exposed.v1.core.*`
+
+`eq`, `neq`, `and`, `or`, `like`, `inList`, `less`, `greaterEq`, etc. **are no longer infix methods on the `SqlExpressionBuilder` receiver** — they are top-level functions in `org.jetbrains.exposed.v1.core`. Every entity companion and repository must explicitly import each operator it uses:
+
+```kotlin
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.and
+// add more (neq, or, like, inList, less, greaterEq, ...) as the predicate grows
+```
+
+Symptom of the old-style usage: `find { Table.col eq value }` compiles only if `eq` is in scope as a top-level import; otherwise you get `Unresolved reference: eq`.
+
+### 0.3 UUID column type — `javaUUID(...)` for `java.util.UUID` columns
+
+`uuid("...")` (the unsuffixed function on `Table`) now produces a `kotlin.uuid.Uuid` column. To declare a `java.util.UUID` column (which is what foreign keys to `UUIDTable.id` expect), use `javaUUID("...")`. The unsuffixed `uuid(...)` is now reserved for the rare cases where you genuinely want a Kotlin `Uuid` column.
+
+### 0.4 Transactions, JDBC helpers, `SizedIterable`
+
+These paths did **not** move and are stable:
+
+```kotlin
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils         // for migrations
+import org.jetbrains.exposed.v1.jdbc.SizedIterable       // for SizedIterable<E> return types
+```
+
+### 0.5 Time — `kotlin.time.Clock`, not `kotlinx.datetime.Clock`
+
+Since the `kotlinx-datetime 0.8.0` upgrade, `Clock` and `Instant` come from `kotlin.time`. `LocalDateTime`, `TimeZone`, and `toLocalDateTime` still live in `kotlinx.datetime`:
+
+```kotlin
+import kotlin.time.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+```
+
+Use `Clock.System.now().toLocalDateTime(TimeZone.UTC)` for `clientDefault` blocks.
+
+### 0.6 When in doubt
+
+Open any live entity or table file as a reference — for example `events/infrastructure/db/EventsTable.kt`, `events/infrastructure/db/EventEntity.kt`, or `users/infrastructure/db/OrganisationPermissionEntity.kt`. These are kept current with the codebase; copy their import block verbatim.
+
+---
+
 ## 1 — Table Definitions
 
 Tables define the database schema. They live in `<domain>/infrastructure/db/<Name>Table.kt`.

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/App.kt
@@ -15,6 +15,7 @@ import fr.devlille.partners.connect.events.infrastructure.api.eventBoothPlanRout
 import fr.devlille.partners.connect.events.infrastructure.api.eventBudgetRoutes
 import fr.devlille.partners.connect.events.infrastructure.api.eventExternalLinkRoutes
 import fr.devlille.partners.connect.events.infrastructure.api.eventRoutes
+import fr.devlille.partners.connect.events.infrastructure.api.favoriteEventRoutes
 import fr.devlille.partners.connect.events.infrastructure.bindings.eventModule
 import fr.devlille.partners.connect.integrations.infrastructure.api.integrationRoutes
 import fr.devlille.partners.connect.integrations.infrastructure.bindings.integrationModule
@@ -148,6 +149,7 @@ fun Application.module(config: ApplicationConfig = ApplicationConfig()) {
         eventExternalLinkRoutes()
         eventBudgetRoutes()
         userRoutes()
+        favoriteEventRoutes()
         sponsoringRoutes()
         partnershipRoutes()
         partnershipEmailDraftRoutes()

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/EventRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/EventRepositoryExposed.kt
@@ -1,5 +1,6 @@
 package fr.devlille.partners.connect.events.application
 
+import fr.devlille.partners.connect.events.application.mappers.toEventSummary
 import fr.devlille.partners.connect.events.domain.Contact
 import fr.devlille.partners.connect.events.domain.CreateEventExternalLinkRequest
 import fr.devlille.partners.connect.events.domain.Event
@@ -245,16 +246,7 @@ class EventRepositoryExposed(
                 EventsTable.organisationId eq permission.organisation.id
             }
             orgEvents.forEach { event ->
-                events.add(
-                    EventSummary(
-                        slug = event.slug,
-                        name = event.name,
-                        startTime = event.startTime,
-                        endTime = event.endTime,
-                        submissionStartTime = event.submissionStartTime,
-                        submissionEndTime = event.submissionEndTime,
-                    ),
-                )
+                events.add(event.toEventSummary())
             }
         }
         events

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/FavoriteEventRepositoryExposed.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/FavoriteEventRepositoryExposed.kt
@@ -1,0 +1,64 @@
+package fr.devlille.partners.connect.events.application
+
+import fr.devlille.partners.connect.events.application.mappers.toEventSummary
+import fr.devlille.partners.connect.events.domain.EventSummary
+import fr.devlille.partners.connect.events.domain.FavoriteEventRepository
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.findBySlug
+import fr.devlille.partners.connect.events.infrastructure.db.listByUserOrderByEventStartTime
+import fr.devlille.partners.connect.events.infrastructure.db.singleFavorite
+import fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException
+import fr.devlille.partners.connect.users.infrastructure.db.OrganisationPermissionEntity
+import fr.devlille.partners.connect.users.infrastructure.db.UserEntity
+import fr.devlille.partners.connect.users.infrastructure.db.hasPermission
+import fr.devlille.partners.connect.users.infrastructure.db.singleUserByEmail
+import io.ktor.server.plugins.NotFoundException
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class FavoriteEventRepositoryExposed : FavoriteEventRepository {
+    override fun listByUserEmail(userEmail: String): List<EventSummary> = transaction {
+        val user = UserEntity.singleUserByEmail(userEmail)
+            ?: throw NotFoundException("User with email $userEmail not found")
+        FavoriteEventEntity
+            .listByUserOrderByEventStartTime(user.id.value)
+            .filter { favorite ->
+                OrganisationPermissionEntity.hasPermission(
+                    organisationId = favorite.event.organisation.id.value,
+                    userId = user.id.value,
+                )
+            }
+            .map { it.event.toEventSummary() }
+    }
+
+    override fun addFavorite(userEmail: String, eventSlug: String): Boolean = transaction {
+        val user = UserEntity.singleUserByEmail(userEmail)
+            ?: throw NotFoundException("User with email $userEmail not found")
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event $eventSlug not found")
+        if (!OrganisationPermissionEntity.hasPermission(event.organisation.id.value, user.id.value)) {
+            throw ForbiddenException("You are not allowed to favorite this event")
+        }
+        if (FavoriteEventEntity.singleFavorite(user.id.value, event.id.value) != null) {
+            return@transaction false
+        }
+        FavoriteEventEntity.new {
+            this.user = user
+            this.event = event
+        }
+        true
+    }
+
+    override fun removeFavorite(userEmail: String, eventSlug: String): Boolean = transaction {
+        val user = UserEntity.singleUserByEmail(userEmail)
+            ?: throw NotFoundException("User with email $userEmail not found")
+        val event = EventEntity.findBySlug(eventSlug) ?: return@transaction false
+        if (!OrganisationPermissionEntity.hasPermission(event.organisation.id.value, user.id.value)) {
+            throw ForbiddenException("You are not allowed to manage favorites for this event")
+        }
+        val favorite = FavoriteEventEntity.singleFavorite(user.id.value, event.id.value)
+            ?: return@transaction false
+        favorite.delete()
+        true
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/mappers/Event.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/application/mappers/Event.ext.kt
@@ -1,0 +1,13 @@
+package fr.devlille.partners.connect.events.application.mappers
+
+import fr.devlille.partners.connect.events.domain.EventSummary
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+
+internal fun EventEntity.toEventSummary(): EventSummary = EventSummary(
+    slug = slug,
+    name = name,
+    startTime = startTime,
+    endTime = endTime,
+    submissionStartTime = submissionStartTime,
+    submissionEndTime = submissionEndTime,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt
@@ -1,0 +1,22 @@
+package fr.devlille.partners.connect.events.domain
+
+interface FavoriteEventRepository {
+    /**
+     * @return the caller's favorites, ordered by event start_time ascending. Favorites whose
+     *   event belongs to an organisation the caller has no permission on are filtered out.
+     */
+    fun listByUserEmail(userEmail: String): List<EventSummary>
+
+    /**
+     * @return true if a new favorite row was inserted, false if it already existed.
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.NotFoundException if the event slug is unknown.
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event belongs to an org the caller has no permission on.
+     */
+    fun addFavorite(userEmail: String, eventSlug: String): Boolean
+
+    /**
+     * @return true if a favorite row was deleted, false if no favorite existed (covers both unknown event and known-but-not-favorited).
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event exists but belongs to an org the caller has no permission on.
+     */
+    fun removeFavorite(userEmail: String, eventSlug: String): Boolean
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt
@@ -10,13 +10,16 @@ interface FavoriteEventRepository {
     /**
      * @return true if a new favorite row was inserted, false if it already existed.
      * @throws io.ktor.server.plugins.NotFoundException if the event slug is unknown.
-     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event belongs to an org the caller has no permission on.
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException
+     *   if the event belongs to an org the caller has no permission on.
      */
     fun addFavorite(userEmail: String, eventSlug: String): Boolean
 
     /**
-     * @return true if a favorite row was deleted, false if no favorite existed (covers both unknown event and known-but-not-favorited).
-     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event exists but belongs to an org the caller has no permission on.
+     * @return true if a favorite row was deleted, false if no favorite existed
+     *   (covers both unknown event and known-but-not-favorited).
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException
+     *   if the event exists but belongs to an org the caller has no permission on.
      */
     fun removeFavorite(userEmail: String, eventSlug: String): Boolean
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt
@@ -9,7 +9,7 @@ interface FavoriteEventRepository {
 
     /**
      * @return true if a new favorite row was inserted, false if it already existed.
-     * @throws fr.devlille.partners.connect.internal.infrastructure.api.NotFoundException if the event slug is unknown.
+     * @throws io.ktor.server.plugins.NotFoundException if the event slug is unknown.
      * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event belongs to an org the caller has no permission on.
      */
     fun addFavorite(userEmail: String, eventSlug: String): Boolean

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutes.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutes.kt
@@ -1,0 +1,45 @@
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.auth.domain.AuthRepository
+import fr.devlille.partners.connect.events.domain.FavoriteEventRepository
+import fr.devlille.partners.connect.internal.infrastructure.api.ConflictException
+import fr.devlille.partners.connect.internal.infrastructure.api.token
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.NotFoundException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.inject
+
+fun Route.favoriteEventRoutes() {
+    val authRepository by inject<AuthRepository>()
+    val favoriteRepository by inject<FavoriteEventRepository>()
+
+    route("/users/me/favorite-events") {
+        get {
+            val userInfo = authRepository.getUserInfo(call.token)
+            call.respond(HttpStatusCode.OK, favoriteRepository.listByUserEmail(userInfo.email))
+        }
+        put("/{eventSlug}") {
+            val userInfo = authRepository.getUserInfo(call.token)
+            val eventSlug = call.parameters.eventSlug
+            val added = favoriteRepository.addFavorite(userInfo.email, eventSlug)
+            if (!added) {
+                throw ConflictException("Event $eventSlug is already in your favorites")
+            }
+            call.respond(HttpStatusCode.Created)
+        }
+        delete("/{eventSlug}") {
+            val userInfo = authRepository.getUserInfo(call.token)
+            val eventSlug = call.parameters.eventSlug
+            val removed = favoriteRepository.removeFavorite(userInfo.email, eventSlug)
+            if (!removed) {
+                throw NotFoundException("Event $eventSlug is not in your favorites")
+            }
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/bindings/EventModule.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/bindings/EventModule.kt
@@ -4,10 +4,12 @@ import fr.devlille.partners.connect.events.application.EventBudgetRepositoryExpo
 import fr.devlille.partners.connect.events.application.EventRepositoryExposed
 import fr.devlille.partners.connect.events.application.EventStatsRepositoryExposed
 import fr.devlille.partners.connect.events.application.EventStorageRepositoryGoogleStorage
+import fr.devlille.partners.connect.events.application.FavoriteEventRepositoryExposed
 import fr.devlille.partners.connect.events.domain.EventBudgetRepository
 import fr.devlille.partners.connect.events.domain.EventRepository
 import fr.devlille.partners.connect.events.domain.EventStatsRepository
 import fr.devlille.partners.connect.events.domain.EventStorageRepository
+import fr.devlille.partners.connect.events.domain.FavoriteEventRepository
 import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
 import org.koin.dsl.module
 
@@ -24,4 +26,5 @@ val eventModule = module {
     single<EventBudgetRepository> {
         EventBudgetRepositoryExposed()
     }
+    single<FavoriteEventRepository> { FavoriteEventRepositoryExposed() }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventEntity.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventEntity.kt
@@ -1,0 +1,30 @@
+package fr.devlille.partners.connect.events.infrastructure.db
+
+import fr.devlille.partners.connect.users.infrastructure.db.UserEntity
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import java.util.UUID
+
+class FavoriteEventEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<FavoriteEventEntity>(FavoriteEventsTable)
+
+    var user by UserEntity referencedOn FavoriteEventsTable.userId
+    var event by EventEntity referencedOn FavoriteEventsTable.eventId
+    var favoritedAt by FavoriteEventsTable.favoritedAt
+}
+
+fun UUIDEntityClass<FavoriteEventEntity>.singleFavorite(
+    userId: UUID,
+    eventId: UUID,
+): FavoriteEventEntity? = this.find {
+    (FavoriteEventsTable.userId eq userId) and (FavoriteEventsTable.eventId eq eventId)
+}.singleOrNull()
+
+fun UUIDEntityClass<FavoriteEventEntity>.listByUserOrderByEventStartTime(
+    userId: UUID,
+): List<FavoriteEventEntity> = this
+    .find { FavoriteEventsTable.userId eq userId }
+    .sortedBy { it.event.startTime }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventsTable.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventsTable.kt
@@ -1,0 +1,20 @@
+package fr.devlille.partners.connect.events.infrastructure.db
+
+import fr.devlille.partners.connect.users.infrastructure.db.UsersTable
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.datetime.datetime
+import kotlin.time.Clock
+
+object FavoriteEventsTable : UUIDTable("favorite_events") {
+    val userId = reference("user_id", UsersTable)
+    val eventId = reference("event_id", EventsTable)
+    val favoritedAt = datetime("favorited_at").clientDefault {
+        Clock.System.now().toLocalDateTime(TimeZone.UTC)
+    }
+
+    init {
+        uniqueIndex(userId, eventId)
+    }
+}

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
@@ -5,6 +5,7 @@ import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddCompanyStatusColumnMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddEventExternalLinksMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddEventWebhooksMigration
+import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddFavoriteEventsTableMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddFlyerTemplateColumnsToSponsoringPacksMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddHealthUrlColumnMigration
 import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddIntegrationCreatedAtMigration
@@ -63,6 +64,7 @@ object MigrationRegistry {
         AddSpeakerSourceColumnMigration,
         CreatePartnershipSupportVideosTableMigration,
         AddFlyerTemplateColumnsToSponsoringPacksMigration,
+        AddFavoriteEventsTableMigration,
     )
 
     /**

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/AddFavoriteEventsTableMigration.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/AddFavoriteEventsTableMigration.kt
@@ -1,0 +1,20 @@
+package fr.devlille.partners.connect.internal.infrastructure.migrations.versions
+
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventsTable
+import fr.devlille.partners.connect.internal.infrastructure.migrations.Migration
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+
+object AddFavoriteEventsTableMigration : Migration {
+    override val id = "20260524_add_favorite_events"
+    override val description = "Add favorite_events join table linking users to events they have starred"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(FavoriteEventsTable)
+    }
+
+    override fun down() {
+        throw UnsupportedOperationException(
+            "Rollback not supported for this migration - would require dropping table with potential data loss",
+        )
+    }
+}

--- a/server/application/src/main/resources/openapi/documentation.yaml
+++ b/server/application/src/main/resources/openapi/documentation.yaml
@@ -5970,6 +5970,96 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/organisation_item.schema'
+  /users/me/favorite-events:
+    get:
+      summary: List the authenticated user's favorite events
+      operationId: getUsersMeFavoriteEvents
+      description: Returns the caller's favorite events ordered by start_time ascending. Favorites whose event belongs to an organisation the caller no longer has permission on are filtered out.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/event_summary.schema'
+        '401':
+          description: Unauthorized - Missing or invalid authentication token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+  /users/me/favorite-events/{eventSlug}:
+    parameters:
+      - name: eventSlug
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Event slug to favorite or un-favorite
+    put:
+      summary: Add an event to the authenticated user's favorites
+      operationId: putUsersMeFavoriteEvent
+      description: Idempotent at the HTTP level only insofar as repeating the call surfaces a 409 Conflict; otherwise creates one row in favorite_events.
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Created
+        '401':
+          description: Unauthorized - Missing or invalid authentication token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '403':
+          description: Forbidden - The event exists but belongs to an organisation the caller has no permission on
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - Unknown event slug
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '409':
+          description: Conflict - The caller has already favorited this event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+    delete:
+      summary: Remove an event from the authenticated user's favorites
+      operationId: deleteUsersMeFavoriteEvent
+      description: Returns 204 on success. Returns 404 for both an unknown event slug and a known event that is not in the caller's favorites.
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: No Content - Favorite removed
+        '401':
+          description: Unauthorized - Missing or invalid authentication token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '403':
+          description: Forbidden - The event exists but belongs to an organisation the caller has no permission on
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
+        '404':
+          description: Not Found - The event is not in the caller's favorites (or the slug is unknown)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response.schema'
 components:
   securitySchemes:
     bearerAuth:

--- a/server/application/src/main/resources/openapi/openapi.yaml
+++ b/server/application/src/main/resources/openapi/openapi.yaml
@@ -5950,6 +5950,96 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/OrganisationItem"
+  /users/me/favorite-events:
+    get:
+      summary: "List the authenticated user's favorite events"
+      operationId: "getUsersMeFavoriteEvents"
+      description: "Returns the caller's favorite events ordered by start_time ascending. Favorites whose event belongs to an organisation the caller no longer has permission on are filtered out."
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/EventSummary"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /users/me/favorite-events/{eventSlug}:
+    parameters:
+      - name: "eventSlug"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: "Event slug to favorite or un-favorite"
+    put:
+      summary: "Add an event to the authenticated user's favorites"
+      operationId: "putUsersMeFavoriteEvent"
+      description: "Idempotent at the HTTP level only insofar as repeating the call surfaces a 409 Conflict; otherwise creates one row in favorite_events."
+      security:
+        - bearerAuth: []
+      responses:
+        "201":
+          description: "Created"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: "Forbidden - The event exists but belongs to an organisation the caller has no permission on"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Unknown event slug"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - The caller has already favorited this event"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: "Remove an event from the authenticated user's favorites"
+      operationId: "deleteUsersMeFavoriteEvent"
+      description: "Returns 204 on success. Returns 404 for both an unknown event slug and a known event that is not in the caller's favorites."
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: "No Content - Favorite removed"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: "Forbidden - The event exists but belongs to an organisation the caller has no permission on"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - The event is not in the caller's favorites (or the slug is unknown)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   securitySchemes:
     bearerAuth:

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/events/FavoriteEventCrossOrgRoutesTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/events/FavoriteEventCrossOrgRoutesTest.kt
@@ -1,0 +1,105 @@
+package fr.devlille.partners.connect.events
+
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventsTable
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventCrossOrgRoutesTest {
+    @Test
+    @Suppress("LongMethod")
+    fun `user A can favorite own org event, cannot favorite other org event, isolated from user B`() = testApplication {
+        val userAId = UUID.randomUUID()
+        val userBId = UUID.randomUUID()
+        val orgAId = UUID.randomUUID()
+        val orgBId = UUID.randomUUID()
+        val eventAId = UUID.randomUUID()
+        val eventBId = UUID.randomUUID()
+        val eventASlug = "event-org-a"
+        val eventBSlug = "event-org-b"
+
+        // The mock OAuth engine resolves "Bearer valid" to userAId here.
+        application {
+            moduleSharedDb(userId = userAId)
+            transaction {
+                insertMockedUser(userAId)
+                insertMockedUser(userBId)
+                insertMockedOrganisationEntity(orgAId)
+                insertMockedOrganisationEntity(orgBId)
+                insertMockedOrgaPermission(orgAId, userId = userAId)
+                insertMockedOrgaPermission(orgBId, userId = userBId)
+                insertMockedFutureEventWithSlug(id = eventAId, slug = eventASlug, orgId = orgAId)
+                insertMockedFutureEventWithSlug(id = eventBId, slug = eventBSlug, orgId = orgBId)
+            }
+        }
+
+        // Step 1: user A favorites event-A → 201
+        val addAResp = client.put("/users/me/favorite-events/$eventASlug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.Created, addAResp.status)
+
+        // Step 2: user A lists favorites → contains event-A only
+        val listResp = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, listResp.status)
+        val items = Json.parseToJsonElement(listResp.bodyAsText()).jsonArray
+        assertEquals(1, items.size)
+        assertEquals(eventASlug, items[0].jsonObject["slug"]?.jsonPrimitive?.content)
+
+        // Step 3: user A tries to favorite event-B (org B, no permission) → 403
+        val crossOrgResp = client.put("/users/me/favorite-events/$eventBSlug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.Forbidden, crossOrgResp.status)
+
+        // Step 4: user B's favorites are isolated from user A's — verified at the DB layer
+        //         (the mock OAuth engine is fixed to userAId; we can't switch identity mid-test,
+        //         so we assert state directly).
+        transaction {
+            val rowsForUserB = FavoriteEventEntity
+                .find { FavoriteEventsTable.userId eq userBId }
+                .count()
+            assertEquals(0, rowsForUserB, "User B should have zero favorites")
+
+            val rowsForUserA = FavoriteEventEntity
+                .find { FavoriteEventsTable.userId eq userAId }
+                .count()
+            assertEquals(1, rowsForUserA, "User A should have exactly one favorite")
+        }
+
+        // Step 5: user A removes their favorite → 204
+        val deleteResp = client.delete("/users/me/favorite-events/$eventASlug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.NoContent, deleteResp.status)
+
+        // Step 6: user A lists favorites again → empty
+        val finalListResp = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, finalListResp.status)
+        assertEquals("[]", finalListResp.bodyAsText())
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/events/factories/FavoriteEventEntity.factory.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/events/factories/FavoriteEventEntity.factory.kt
@@ -1,0 +1,14 @@
+package fr.devlille.partners.connect.events.factories
+
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventEntity
+import fr.devlille.partners.connect.users.infrastructure.db.UserEntity
+import java.util.UUID
+
+fun insertMockedFavoriteEvent(
+    userId: UUID,
+    eventId: UUID,
+): FavoriteEventEntity = FavoriteEventEntity.new {
+    this.user = UserEntity[userId]
+    this.event = EventEntity[eventId]
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt
@@ -1,0 +1,118 @@
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.events.factories.insertMockedFavoriteEvent
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventRouteDeleteTest {
+    @Test
+    fun `DELETE returns 204 when favorite exists`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-to-delete"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+                insertMockedFavoriteEvent(userId = userId, eventId = eventId)
+            }
+        }
+
+        val response = client.delete("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        application { moduleSharedDb(userId) }
+
+        val response = client.delete("/users/me/favorite-events/anything")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 404 when event slug is unknown`() = testApplication {
+        val userId = UUID.randomUUID()
+        application {
+            moduleSharedDb(userId)
+            transaction { insertMockedUser(userId) }
+        }
+
+        val response = client.delete("/users/me/favorite-events/does-not-exist") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 404 when event exists but is not in the caller's favorites`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-not-favorited"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+                // NO insertMockedFavoriteEvent
+            }
+        }
+
+        val response = client.delete("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 403 when event belongs to an org the caller has no permission on`() = testApplication {
+        val userId = UUID.randomUUID()
+        val ownerOrgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-other-org"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(ownerOrgId)
+                // NO insertMockedOrgaPermission for userId on ownerOrgId
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = ownerOrgId)
+            }
+        }
+
+        val response = client.delete("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt
@@ -97,7 +97,7 @@ class FavoriteEventRouteDeleteTest {
         val userId = UUID.randomUUID()
         val ownerOrgId = UUID.randomUUID()
         val eventId = UUID.randomUUID()
-        val slug = "event-other-org"
+        val slug = "event-other-org-delete"
 
         application {
             moduleSharedDb(userId)

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteGetTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteGetTest.kt
@@ -1,0 +1,93 @@
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.events.factories.insertMockedFavoriteEvent
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventRouteGetTest {
+    @Test
+    fun `GET returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        application { moduleSharedDb(userId) }
+
+        val response = client.get("/users/me/favorite-events")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET returns 200 with empty array when caller has no favorites`() = testApplication {
+        val userId = UUID.randomUUID()
+        application {
+            moduleSharedDb(userId)
+            transaction { insertMockedUser(userId) }
+        }
+
+        val response = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("[]", response.bodyAsText())
+    }
+
+    @Test
+    fun `GET returns favorites in two orgs ordered by start_time ascending`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgAId = UUID.randomUUID()
+        val orgBId = UUID.randomUUID()
+        val laterEventId = UUID.randomUUID()
+        val earlierEventId = UUID.randomUUID()
+        val laterSlug = "event-later"
+        val earlierSlug = "event-earlier"
+        val laterStart = LocalDateTime.parse("2030-12-01T00:00:00")
+        val earlierStart = LocalDateTime.parse("2030-06-01T00:00:00")
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgAId)
+                insertMockedOrganisationEntity(orgBId)
+                insertMockedOrgaPermission(orgAId, userId = userId)
+                insertMockedOrgaPermission(orgBId, userId = userId)
+                insertMockedFutureEventWithSlug(id = laterEventId, slug = laterSlug, orgId = orgAId).apply {
+                    startTime = laterStart
+                }
+                insertMockedFutureEventWithSlug(id = earlierEventId, slug = earlierSlug, orgId = orgBId).apply {
+                    startTime = earlierStart
+                }
+                insertMockedFavoriteEvent(userId = userId, eventId = laterEventId)
+                insertMockedFavoriteEvent(userId = userId, eventId = earlierEventId)
+            }
+        }
+
+        val response = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val items = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(2, items.size)
+        assertEquals(earlierSlug, items[0].jsonObject["slug"]?.jsonPrimitive?.content)
+        assertEquals(laterSlug, items[1].jsonObject["slug"]?.jsonPrimitive?.content)
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutePutTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutePutTest.kt
@@ -1,0 +1,119 @@
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.events.factories.insertMockedFavoriteEvent
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventRoutePutTest {
+    @Test
+    fun `PUT returns 201 on first add`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-a"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+    }
+
+    @Test
+    fun `PUT returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        application { moduleSharedDb(userId) }
+
+        val response = client.put("/users/me/favorite-events/anything")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 when event slug is unknown`() = testApplication {
+        val userId = UUID.randomUUID()
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/does-not-exist") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `PUT returns 403 when event belongs to an org the caller has no permission on`() = testApplication {
+        val userId = UUID.randomUUID()
+        val ownerOrgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-other-org"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(ownerOrgId)
+                // NO insertMockedOrgaPermission for userId on ownerOrgId
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = ownerOrgId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `PUT returns 409 when caller has already favorited this event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-already-favorited"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+                insertMockedFavoriteEvent(userId = userId, eventId = eventId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+}

--- a/server/specs/027-favorite-events/plan.md
+++ b/server/specs/027-favorite-events/plan.md
@@ -1,0 +1,1300 @@
+# Implementation Plan: 027-favorite-events
+
+This plan is the technical companion to [`spec.md`](./spec.md). Read the spec first.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three endpoints (`GET`, `PUT`, `DELETE`) under `/users/me/favorite-events` so an authenticated organiser can star, list, and un-star events that belong to organisations they have permission on.
+
+**Architecture:** New `favorite_events` table joins `users` ↔ `events` with a unique pair. Clean-architecture layering: `domain/` interface + Exposed `application/` repository + Ktor `infrastructure/api/` route. Mounted on the existing `/users/me/...` pattern (bearer-token email resolution, no `AuthorizedOrganisationPlugin`). Repository enforces per-event org permission via the existing `OrganisationPermissionEntity.hasPermission` helper.
+
+**Tech Stack:** Kotlin, Ktor, Exposed v1 ORM, Koin DI, kotlinx-serialization, kotlinx-datetime. Tests: kotlin.test + Ktor `testApplication` + H2 in-memory DB via `moduleSharedDb`.
+
+---
+
+## 1. Architecture summary
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ partners-connect/server  (Ktor app, this workspace)          │
+│                                                              │
+│ App.kt                                                       │
+│  └── routing { … favoriteEventRoutes() … }   ← new mount     │
+│                                                              │
+│ fr.devlille.partners.connect.events/                         │
+│  ├── domain/                                                 │
+│  │   └── FavoriteEventRepository.kt          ← new           │
+│  ├── application/                                            │
+│  │   ├── FavoriteEventRepositoryExposed.kt   ← new           │
+│  │   └── mappers/                                            │
+│  │       └── Event.ext.kt                    ← new (mapper)  │
+│  └── infrastructure/                                         │
+│      ├── api/                                                │
+│      │   └── FavoriteEventRoutes.kt          ← new           │
+│      ├── db/                                                 │
+│      │   ├── FavoriteEventsTable.kt          ← new           │
+│      │   └── FavoriteEventEntity.kt          ← new           │
+│      └── bindings/                                           │
+│          └── EventModule.kt                  ← edited        │
+│                                                              │
+│ internal/infrastructure/migrations/versions/                 │
+│  └── AddFavoriteEventsTableMigration.kt      ← new           │
+│ internal/infrastructure/migrations/                          │
+│  └── MigrationRegistry.kt                    ← edited        │
+│                                                              │
+│ resources/openapi/openapi.yaml               ← edited        │
+│ resources/openapi/documentation.yaml         ← regenerated   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+No new Koin module. No new JSON schemas. No new exception classes. `App.kt`'s existing `configureStatusPage()` already maps `UnauthorizedException → 401`, `ForbiddenException → 403`, `NotFoundException → 404`, `ConflictException → 409`.
+
+---
+
+## 2. File-by-file responsibilities
+
+| File | Responsibility |
+|---|---|
+| `events/infrastructure/db/FavoriteEventsTable.kt` | Schema: `(user_id, event_id, favorited_at)` + `uniqueIndex(userId, eventId)` |
+| `events/infrastructure/db/FavoriteEventEntity.kt` | DAO mapping + companion-object query helpers: `singleFavorite(userId, eventId)`, `listByUserOrderByEventStartTime(userId)` |
+| `events/application/mappers/Event.ext.kt` | `fun EventEntity.toEventSummary(): EventSummary` — extracted from the inline mapping currently in `EventRepositoryExposed.findByUserEmail` |
+| `events/domain/FavoriteEventRepository.kt` | Interface: `listByUserEmail`, `addFavorite`, `removeFavorite` (boolean returns for existence-collision paths) |
+| `events/application/FavoriteEventRepositoryExposed.kt` | Exposed impl. Each method runs inside a single `transaction { }`. Uses existing helpers `UserEntity.singleUserByEmail`, `EventEntity.findBySlug`, `OrganisationPermissionEntity.hasPermission`. |
+| `events/infrastructure/api/FavoriteEventRoutes.kt` | `fun Route.favoriteEventRoutes()` mounting `/users/me/favorite-events`. Resolves email from bearer token, delegates to repo, maps booleans → HTTP status codes (`true` → 201/204; `false` → 409/404). |
+| `events/infrastructure/bindings/EventModule.kt` | Add `single<FavoriteEventRepository> { FavoriteEventRepositoryExposed() }` |
+| `internal/infrastructure/migrations/versions/AddFavoriteEventsTableMigration.kt` | `SchemaUtils.createMissingTablesAndColumns(FavoriteEventsTable)` |
+| `internal/infrastructure/migrations/MigrationRegistry.kt` | Append `AddFavoriteEventsTableMigration` to `allMigrations` |
+| `App.kt` | Add `import …favoriteEventRoutes` + call `favoriteEventRoutes()` in `routing { }` right after `userRoutes()` |
+| `events/application/EventRepositoryExposed.kt` | Replace the inline `EventEntity → EventSummary` literal (lines 249–256) with `event.toEventSummary()` |
+| `resources/openapi/openapi.yaml` | Add three paths under the existing `/users/me/...` block, inline status codes referencing `#/components/schemas/EventSummary` and `#/components/schemas/ErrorResponse` |
+| **Tests** | |
+| `test/events/factories/FavoriteEventEntity.factory.kt` | `insertMockedFavoriteEvent(userId, eventId)` |
+| `test/events/infrastructure/api/FavoriteEventRoutePutTest.kt` | PUT contract tests: 201, 401, 403, 404, 409 |
+| `test/events/infrastructure/api/FavoriteEventRouteGetTest.kt` | GET contract tests: 200 empty, 200 with two favorites ordered by start_time, 401 |
+| `test/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt` | DELETE contract tests: 204, 401, 403, 404 |
+| `test/events/FavoriteEventCrossOrgRoutesTest.kt` | One integration test exercising the full add → list → cross-org-403 → delete workflow across two users in two orgs |
+
+---
+
+## 3. Helper references (existing code the plan calls)
+
+These already exist; the plan only **uses** them. Listed here so reviewers and implementers don't have to grep.
+
+- `UserEntity.singleUserByEmail(email: String): UserEntity?` — `users/infrastructure/db/UserEntity.kt:17`
+- `EventEntity.findBySlug(slug: String): EventEntity?` — `events/infrastructure/db/EventEntity.kt:29`
+- `OrganisationPermissionEntity.hasPermission(orgId: UUID, userId: UUID): Boolean` — `users/infrastructure/db/OrganisationPermissionEntity.kt:36`
+- `EventSummary` data class — `events/domain/EventSummary.kt`
+- `call.token` (extension on `ApplicationCall`) — `internal/infrastructure/api/`
+- `call.parameters.eventSlug` (extension on `StringValues`) — `events/infrastructure/api/StringValues.ext.kt:8`
+- `AuthRepository.getUserInfo(token): UserInfo` — `auth/domain/AuthRepository.kt`
+- `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `ConflictException` — `internal/infrastructure/api/*Exception.kt`
+- Test factories: `insertMockedUser(userId)`, `insertMockedOrganisationEntity(orgId)`, `insertMockedOrgaPermission(orgId, userId)`, `insertMockedFutureEventWithSlug(slug = ..., orgId = ...)` — see `test/.../factories/`
+- Test harness: `moduleSharedDb(userId)` — see `test/internal/ApplicationMock.kt:46`. Sends `Authorization: Bearer valid` and the mock OAuth engine resolves to `UserEntity[userId]`.
+
+---
+
+## 4. Tasks
+
+Each task is self-contained: it lists the files it touches, shows complete code (no placeholders), and ends with a commit. Tests are written before the code they exercise where practical, but Task 1 (pure scaffolding) and Task 2 (refactor) come first so the type signatures exist when the first test compiles.
+
+---
+
+### Task 1: Database scaffold — table, entity, migration
+
+**Files:**
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventsTable.kt`
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventEntity.kt`
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/AddFavoriteEventsTableMigration.kt`
+- Modify: `application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt`
+
+- [ ] **Step 1: Create the table file**
+
+```kotlin
+// FavoriteEventsTable.kt
+package fr.devlille.partners.connect.events.infrastructure.db
+
+import fr.devlille.partners.connect.users.infrastructure.db.UsersTable
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.datetime.datetime
+import kotlin.time.Clock
+
+object FavoriteEventsTable : UUIDTable("favorite_events") {
+    val userId = reference("user_id", UsersTable)
+    val eventId = reference("event_id", EventsTable)
+    val favoritedAt = datetime("favorited_at").clientDefault {
+        Clock.System.now().toLocalDateTime(TimeZone.UTC)
+    }
+
+    init {
+        uniqueIndex(userId, eventId)
+    }
+}
+```
+
+- [ ] **Step 2: Create the entity file with query helpers**
+
+```kotlin
+// FavoriteEventEntity.kt
+package fr.devlille.partners.connect.events.infrastructure.db
+
+import fr.devlille.partners.connect.users.infrastructure.db.UserEntity
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import java.util.UUID
+
+class FavoriteEventEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<FavoriteEventEntity>(FavoriteEventsTable)
+
+    var user by UserEntity referencedOn FavoriteEventsTable.userId
+    var event by EventEntity referencedOn FavoriteEventsTable.eventId
+    var favoritedAt by FavoriteEventsTable.favoritedAt
+}
+
+fun UUIDEntityClass<FavoriteEventEntity>.singleFavorite(
+    userId: UUID,
+    eventId: UUID,
+): FavoriteEventEntity? = this.find {
+    (FavoriteEventsTable.userId eq userId) and (FavoriteEventsTable.eventId eq eventId)
+}.singleOrNull()
+
+fun UUIDEntityClass<FavoriteEventEntity>.listByUserOrderByEventStartTime(
+    userId: UUID,
+): List<FavoriteEventEntity> = this
+    .find { FavoriteEventsTable.userId eq userId }
+    .sortedBy { it.event.startTime }
+```
+
+- [ ] **Step 3: Create the migration**
+
+```kotlin
+// AddFavoriteEventsTableMigration.kt
+package fr.devlille.partners.connect.internal.infrastructure.migrations.versions
+
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventsTable
+import fr.devlille.partners.connect.internal.infrastructure.migrations.Migration
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+
+object AddFavoriteEventsTableMigration : Migration {
+    override val id = "20260524_add_favorite_events"
+    override val description = "Add favorite_events join table linking users to events they have starred"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(FavoriteEventsTable)
+    }
+
+    override fun down() {
+        throw UnsupportedOperationException(
+            "Rollback not supported for this migration - would require dropping table with potential data loss",
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Register the migration in `MigrationRegistry.kt`**
+
+Add the import alphabetically with the other `versions.*` imports, then append the entry to `allMigrations` (last position is fine — `MigrationManager` sorts by id at apply time, so chronological order is enforced by the date prefix in the id):
+
+```kotlin
+import fr.devlille.partners.connect.internal.infrastructure.migrations.versions.AddFavoriteEventsTableMigration
+```
+
+```kotlin
+val allMigrations: List<Migration> = listOf(
+    // … existing entries unchanged …
+    AddFlyerTemplateColumnsToSponsoringPacksMigration,
+    AddFavoriteEventsTableMigration,
+)
+```
+
+- [ ] **Step 5: Compile-only sanity check**
+
+Run: `./gradlew :application:compileKotlin --no-daemon`
+Expected: BUILD SUCCESSFUL — no symbol-resolution errors. (Nothing functional to test yet; the entity and table are unreferenced by route code at this point.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventsTable.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/db/FavoriteEventEntity.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/versions/AddFavoriteEventsTableMigration.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/migrations/MigrationRegistry.kt
+git commit -m "feat(server): add favorite_events table and migration"
+```
+
+---
+
+### Task 2: Extract `EventEntity → EventSummary` mapper
+
+**Files:**
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/events/application/mappers/Event.ext.kt`
+- Modify: `application/src/main/kotlin/fr/devlille/partners/connect/events/application/EventRepositoryExposed.kt` (lines 249–256)
+
+- [ ] **Step 1: Create the mapper file**
+
+```kotlin
+// Event.ext.kt
+package fr.devlille.partners.connect.events.application.mappers
+
+import fr.devlille.partners.connect.events.domain.EventSummary
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+
+fun EventEntity.toEventSummary(): EventSummary = EventSummary(
+    slug = slug,
+    name = name,
+    startTime = startTime,
+    endTime = endTime,
+    submissionStartTime = submissionStartTime,
+    submissionEndTime = submissionEndTime,
+)
+```
+
+- [ ] **Step 2: Replace the inline literal in `EventRepositoryExposed.findByUserEmail`**
+
+In `EventRepositoryExposed.kt`, replace the block starting at line ~247:
+
+```kotlin
+            orgEvents.forEach { event ->
+                events.add(
+                    EventSummary(
+                        slug = event.slug,
+                        name = event.name,
+                        startTime = event.startTime,
+                        endTime = event.endTime,
+                        submissionStartTime = event.submissionStartTime,
+                        submissionEndTime = event.submissionEndTime,
+                    ),
+                )
+            }
+```
+
+with:
+
+```kotlin
+            orgEvents.forEach { event ->
+                events.add(event.toEventSummary())
+            }
+```
+
+Add the import at the top of the file:
+
+```kotlin
+import fr.devlille.partners.connect.events.application.mappers.toEventSummary
+```
+
+- [ ] **Step 3: Verify existing tests still pass**
+
+Run: `./gradlew :application:test --tests "*ListUserEventsRoute*" --no-daemon`
+Expected: BUILD SUCCESSFUL — the existing `/users/me/events` tests must keep passing because the mapper is a pure refactor.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add application/src/main/kotlin/fr/devlille/partners/connect/events/application/mappers/Event.ext.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/events/application/EventRepositoryExposed.kt
+git commit -m "refactor(server): extract EventEntity#toEventSummary mapper"
+```
+
+---
+
+### Task 3: Domain interface + empty Exposed repository
+
+**Files:**
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt`
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/events/application/FavoriteEventRepositoryExposed.kt`
+- Modify: `application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/bindings/EventModule.kt`
+
+- [ ] **Step 1: Create the domain interface**
+
+```kotlin
+// FavoriteEventRepository.kt
+package fr.devlille.partners.connect.events.domain
+
+interface FavoriteEventRepository {
+    fun listByUserEmail(userEmail: String): List<EventSummary>
+
+    /**
+     * @return true if a new favorite row was inserted, false if it already existed.
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.NotFoundException if the event slug is unknown.
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event belongs to an org the caller has no permission on.
+     */
+    fun addFavorite(userEmail: String, eventSlug: String): Boolean
+
+    /**
+     * @return true if a favorite row was deleted, false if no favorite existed (covers both unknown event and known-but-not-favorited).
+     * @throws fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException if the event exists but belongs to an org the caller has no permission on.
+     */
+    fun removeFavorite(userEmail: String, eventSlug: String): Boolean
+}
+```
+
+- [ ] **Step 2: Create the Exposed implementation**
+
+```kotlin
+// FavoriteEventRepositoryExposed.kt
+package fr.devlille.partners.connect.events.application
+
+import fr.devlille.partners.connect.events.application.mappers.toEventSummary
+import fr.devlille.partners.connect.events.domain.EventSummary
+import fr.devlille.partners.connect.events.domain.FavoriteEventRepository
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.findBySlug
+import fr.devlille.partners.connect.events.infrastructure.db.listByUserOrderByEventStartTime
+import fr.devlille.partners.connect.events.infrastructure.db.singleFavorite
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.internal.infrastructure.api.ForbiddenException
+import fr.devlille.partners.connect.users.infrastructure.db.OrganisationPermissionEntity
+import fr.devlille.partners.connect.users.infrastructure.db.UserEntity
+import fr.devlille.partners.connect.users.infrastructure.db.hasPermission
+import fr.devlille.partners.connect.users.infrastructure.db.singleUserByEmail
+import io.ktor.server.plugins.NotFoundException
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class FavoriteEventRepositoryExposed : FavoriteEventRepository {
+    override fun listByUserEmail(userEmail: String): List<EventSummary> = transaction {
+        val user = UserEntity.singleUserByEmail(userEmail)
+            ?: throw NotFoundException("User with email $userEmail not found")
+        FavoriteEventEntity
+            .listByUserOrderByEventStartTime(user.id.value)
+            .filter { favorite ->
+                OrganisationPermissionEntity.hasPermission(
+                    organisationId = favorite.event.organisation.id.value,
+                    userId = user.id.value,
+                )
+            }
+            .map { it.event.toEventSummary() }
+    }
+
+    override fun addFavorite(userEmail: String, eventSlug: String): Boolean = transaction {
+        val user = UserEntity.singleUserByEmail(userEmail)
+            ?: throw NotFoundException("User with email $userEmail not found")
+        val event = EventEntity.findBySlug(eventSlug)
+            ?: throw NotFoundException("Event $eventSlug not found")
+        if (!OrganisationPermissionEntity.hasPermission(event.organisation.id.value, user.id.value)) {
+            throw ForbiddenException("You are not allowed to favorite this event")
+        }
+        if (FavoriteEventEntity.singleFavorite(user.id.value, event.id.value) != null) {
+            return@transaction false
+        }
+        FavoriteEventEntity.new {
+            this.user = user
+            this.event = event
+        }
+        true
+    }
+
+    override fun removeFavorite(userEmail: String, eventSlug: String): Boolean = transaction {
+        val user = UserEntity.singleUserByEmail(userEmail)
+            ?: throw NotFoundException("User with email $userEmail not found")
+        val event = EventEntity.findBySlug(eventSlug) ?: return@transaction false
+        if (!OrganisationPermissionEntity.hasPermission(event.organisation.id.value, user.id.value)) {
+            throw ForbiddenException("You are not allowed to manage favorites for this event")
+        }
+        val favorite = FavoriteEventEntity.singleFavorite(user.id.value, event.id.value)
+            ?: return@transaction false
+        favorite.delete()
+        true
+    }
+}
+```
+
+Notes on the implementation:
+- `listByUserEmail` filters by current org permission (FR-010): a favorite whose underlying event belongs to an org the user has been revoked from is silently hidden.
+- `addFavorite` throws `NotFoundException` for unknown event (FR-006); `removeFavorite` returns `false` for unknown event so the route surfaces the uniform "not in your favorites" 404 (FR-009).
+- Both writes check permission *before* the favorite-existence check, so cross-org attempts always return 403 even when there is no favorite row to consider.
+- `import io.ktor.server.plugins.NotFoundException` matches the existing project usage (e.g. `EventRepositoryExposed.kt:227`); `ForbiddenException` is the internal one at `internal/infrastructure/api/ForbiddenException.kt`.
+
+- [ ] **Step 3: Register the repository in `EventModule.kt`**
+
+Add the imports and the `single<FavoriteEventRepository>` block:
+
+```kotlin
+import fr.devlille.partners.connect.events.application.FavoriteEventRepositoryExposed
+import fr.devlille.partners.connect.events.domain.FavoriteEventRepository
+```
+
+```kotlin
+val eventModule = module {
+    single<EventRepository> { EventRepositoryExposed(EventEntity) }
+    single<EventStorageRepository> { EventStorageRepositoryGoogleStorage(get()) }
+    single<EventStatsRepository> { EventStatsRepositoryExposed() }
+    single<EventBudgetRepository> { EventBudgetRepositoryExposed() }
+    single<FavoriteEventRepository> { FavoriteEventRepositoryExposed() }
+}
+```
+
+- [ ] **Step 4: Compile-only sanity check**
+
+Run: `./gradlew :application:compileKotlin --no-daemon`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add application/src/main/kotlin/fr/devlille/partners/connect/events/domain/FavoriteEventRepository.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/events/application/FavoriteEventRepositoryExposed.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/bindings/EventModule.kt
+git commit -m "feat(server): add FavoriteEventRepository (domain + Exposed impl)"
+```
+
+---
+
+### Task 4: Ktor route + mount in `App.kt`
+
+**Files:**
+- Create: `application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutes.kt`
+- Modify: `application/src/main/kotlin/fr/devlille/partners/connect/App.kt`
+
+- [ ] **Step 1: Create the route file**
+
+```kotlin
+// FavoriteEventRoutes.kt
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.auth.domain.AuthRepository
+import fr.devlille.partners.connect.events.domain.FavoriteEventRepository
+import fr.devlille.partners.connect.internal.infrastructure.api.ConflictException
+import fr.devlille.partners.connect.internal.infrastructure.api.token
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.NotFoundException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.inject
+
+fun Route.favoriteEventRoutes() {
+    val authRepository by inject<AuthRepository>()
+    val favoriteRepository by inject<FavoriteEventRepository>()
+
+    route("/users/me/favorite-events") {
+        get {
+            val userInfo = authRepository.getUserInfo(call.token)
+            call.respond(HttpStatusCode.OK, favoriteRepository.listByUserEmail(userInfo.email))
+        }
+        put("/{eventSlug}") {
+            val userInfo = authRepository.getUserInfo(call.token)
+            val eventSlug = call.parameters.eventSlug
+            val added = favoriteRepository.addFavorite(userInfo.email, eventSlug)
+            if (!added) {
+                throw ConflictException("Event $eventSlug is already in your favorites")
+            }
+            call.respond(HttpStatusCode.Created)
+        }
+        delete("/{eventSlug}") {
+            val userInfo = authRepository.getUserInfo(call.token)
+            val eventSlug = call.parameters.eventSlug
+            val removed = favoriteRepository.removeFavorite(userInfo.email, eventSlug)
+            if (!removed) {
+                throw NotFoundException("Event $eventSlug is not in your favorites")
+            }
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}
+```
+
+`call.parameters.eventSlug` is the extension at `events/infrastructure/api/StringValues.ext.kt:8` — already in this package.
+
+- [ ] **Step 2: Mount in `App.kt`**
+
+Add the import (alphabetically near the other `events.infrastructure.api.*` imports):
+
+```kotlin
+import fr.devlille.partners.connect.events.infrastructure.api.favoriteEventRoutes
+```
+
+In the `routing { … }` block, add the call directly after `userRoutes()` so favorites sit with the other `/users/me/...` routes (find `userRoutes()` at `App.kt:150`):
+
+```kotlin
+        userRoutes()
+        favoriteEventRoutes()
+```
+
+- [ ] **Step 3: Build to confirm the route compiles and mounts**
+
+Run: `./gradlew :application:compileKotlin --no-daemon`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add application/src/main/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutes.kt \
+        application/src/main/kotlin/fr/devlille/partners/connect/App.kt
+git commit -m "feat(server): add /users/me/favorite-events GET/PUT/DELETE routes"
+```
+
+---
+
+### Task 5: Test factory for favorites
+
+**Files:**
+- Create: `application/src/test/kotlin/fr/devlille/partners/connect/events/factories/FavoriteEventEntity.factory.kt`
+
+- [ ] **Step 1: Create the factory**
+
+```kotlin
+// FavoriteEventEntity.factory.kt
+package fr.devlille.partners.connect.events.factories
+
+import fr.devlille.partners.connect.events.infrastructure.db.EventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventEntity
+import fr.devlille.partners.connect.users.infrastructure.db.UserEntity
+import java.util.UUID
+
+fun insertMockedFavoriteEvent(
+    userId: UUID,
+    eventId: UUID,
+): FavoriteEventEntity = FavoriteEventEntity.new {
+    this.user = UserEntity[userId]
+    this.event = EventEntity[eventId]
+}
+```
+
+The `favoritedAt` column defaults to `Clock.System.now()` via `clientDefault` on the table.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add application/src/test/kotlin/fr/devlille/partners/connect/events/factories/FavoriteEventEntity.factory.kt
+git commit -m "test(server): add insertMockedFavoriteEvent factory"
+```
+
+---
+
+### Task 6: PUT contract tests (TDD — write first, then verify)
+
+**Files:**
+- Create: `application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutePutTest.kt`
+
+The route handler from Task 4 already implements all the PUT paths. These tests verify each documented status code.
+
+- [ ] **Step 1: Write the test class with all five PUT cases**
+
+```kotlin
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.events.factories.insertMockedFavoriteEvent
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventRoutePutTest {
+    @Test
+    fun `PUT returns 201 on first add`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-a"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+    }
+
+    @Test
+    fun `PUT returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        application { moduleSharedDb(userId) }
+
+        val response = client.put("/users/me/favorite-events/anything")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `PUT returns 404 when event slug is unknown`() = testApplication {
+        val userId = UUID.randomUUID()
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/does-not-exist") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `PUT returns 403 when event belongs to an org the caller has no permission on`() = testApplication {
+        val userId = UUID.randomUUID()
+        val ownerOrgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-other-org"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(ownerOrgId)
+                // NO insertMockedOrgaPermission for userId on ownerOrgId
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = ownerOrgId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `PUT returns 409 when caller has already favorited this event`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-already-favorited"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+                insertMockedFavoriteEvent(userId = userId, eventId = eventId)
+            }
+        }
+
+        val response = client.put("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `./gradlew :application:test --tests "*FavoriteEventRoutePutTest" --no-daemon`
+Expected: BUILD SUCCESSFUL with 5 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRoutePutTest.kt
+git commit -m "test(server): contract tests for PUT /users/me/favorite-events/{eventSlug}"
+```
+
+---
+
+### Task 7: GET contract tests
+
+**Files:**
+- Create: `application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteGetTest.kt`
+
+- [ ] **Step 1: Write the test class with three GET cases**
+
+```kotlin
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.events.factories.insertMockedFavoriteEvent
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventRouteGetTest {
+    @Test
+    fun `GET returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        application { moduleSharedDb(userId) }
+
+        val response = client.get("/users/me/favorite-events")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET returns 200 with empty array when caller has no favorites`() = testApplication {
+        val userId = UUID.randomUUID()
+        application {
+            moduleSharedDb(userId)
+            transaction { insertMockedUser(userId) }
+        }
+
+        val response = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("[]", response.bodyAsText())
+    }
+
+    @Test
+    fun `GET returns favorites in two orgs ordered by start_time ascending`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgAId = UUID.randomUUID()
+        val orgBId = UUID.randomUUID()
+        val laterEventId = UUID.randomUUID()
+        val earlierEventId = UUID.randomUUID()
+        val laterSlug = "event-later"
+        val earlierSlug = "event-earlier"
+        // Pick start_times explicitly so the ordering assertion is deterministic.
+        // insertMockedFutureEventWithSlug uses default start_time = next-year Dec 1; override via the wrapper for the earlier event.
+        val laterStart = LocalDateTime.parse("2030-12-01T00:00:00")
+        val earlierStart = LocalDateTime.parse("2030-06-01T00:00:00")
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgAId)
+                insertMockedOrganisationEntity(orgBId)
+                insertMockedOrgaPermission(orgAId, userId = userId)
+                insertMockedOrgaPermission(orgBId, userId = userId)
+                insertMockedFutureEventWithSlug(id = laterEventId, slug = laterSlug, orgId = orgAId).apply {
+                    startTime = laterStart
+                }
+                insertMockedFutureEventWithSlug(id = earlierEventId, slug = earlierSlug, orgId = orgBId).apply {
+                    startTime = earlierStart
+                }
+                insertMockedFavoriteEvent(userId = userId, eventId = laterEventId)
+                insertMockedFavoriteEvent(userId = userId, eventId = earlierEventId)
+            }
+        }
+
+        val response = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val items = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(2, items.size)
+        assertEquals(earlierSlug, items[0].jsonObject["slug"]?.jsonPrimitive?.content)
+        assertEquals(laterSlug, items[1].jsonObject["slug"]?.jsonPrimitive?.content)
+    }
+}
+```
+
+Mutating `startTime` after `insertMockedFutureEventWithSlug` works because the factory returns the `EventEntity` and Exposed DAO writes are flushed at transaction commit. This avoids extending the factory just to express two test events with two different start times.
+
+- [ ] **Step 2: Run the tests**
+
+Run: `./gradlew :application:test --tests "*FavoriteEventRouteGetTest" --no-daemon`
+Expected: BUILD SUCCESSFUL with 3 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteGetTest.kt
+git commit -m "test(server): contract tests for GET /users/me/favorite-events"
+```
+
+---
+
+### Task 8: DELETE contract tests
+
+**Files:**
+- Create: `application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt`
+
+- [ ] **Step 1: Write the test class with four DELETE cases**
+
+```kotlin
+package fr.devlille.partners.connect.events.infrastructure.api
+
+import fr.devlille.partners.connect.events.factories.insertMockedFavoriteEvent
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventRouteDeleteTest {
+    @Test
+    fun `DELETE returns 204 when favorite exists`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-to-delete"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+                insertMockedFavoriteEvent(userId = userId, eventId = eventId)
+            }
+        }
+
+        val response = client.delete("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 401 when Authorization header is missing`() = testApplication {
+        val userId = UUID.randomUUID()
+        application { moduleSharedDb(userId) }
+
+        val response = client.delete("/users/me/favorite-events/anything")
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 404 when event slug is unknown`() = testApplication {
+        val userId = UUID.randomUUID()
+        application {
+            moduleSharedDb(userId)
+            transaction { insertMockedUser(userId) }
+        }
+
+        val response = client.delete("/users/me/favorite-events/does-not-exist") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 404 when event exists but is not in the caller's favorites`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-not-favorited"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(orgId)
+                insertMockedOrgaPermission(orgId, userId = userId)
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = orgId)
+                // NO insertMockedFavoriteEvent
+            }
+        }
+
+        val response = client.delete("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `DELETE returns 403 when event belongs to an org the caller has no permission on`() = testApplication {
+        val userId = UUID.randomUUID()
+        val ownerOrgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val slug = "event-other-org"
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedUser(userId)
+                insertMockedOrganisationEntity(ownerOrgId)
+                // NO insertMockedOrgaPermission for userId on ownerOrgId
+                insertMockedFutureEventWithSlug(id = eventId, slug = slug, orgId = ownerOrgId)
+            }
+        }
+
+        val response = client.delete("/users/me/favorite-events/$slug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `./gradlew :application:test --tests "*FavoriteEventRouteDeleteTest" --no-daemon`
+Expected: BUILD SUCCESSFUL with 5 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application/src/test/kotlin/fr/devlille/partners/connect/events/infrastructure/api/FavoriteEventRouteDeleteTest.kt
+git commit -m "test(server): contract tests for DELETE /users/me/favorite-events/{eventSlug}"
+```
+
+---
+
+### Task 9: Cross-org integration test
+
+**Files:**
+- Create: `application/src/test/kotlin/fr/devlille/partners/connect/events/FavoriteEventCrossOrgRoutesTest.kt`
+
+Per the `integration-tests` skill, integration tests live at the feature root (not under `infrastructure/api/`), use plural "RoutesTest" naming, and chain multiple HTTP calls in a single workflow.
+
+The test below uses two users (A and B) in two orgs (A and B). The mock OAuth engine only resolves `"Bearer valid"` to the *one* `userId` passed to `moduleSharedDb`. To exercise user-B's perspective, restart `testApplication { }` is not needed — we instead make B's check a database-level assertion: after A favorites their event, query the table directly to assert no row exists for B. The cross-org 403 case is exercised via the HTTP route by having A try to favorite B's event.
+
+- [ ] **Step 1: Write the integration test**
+
+```kotlin
+package fr.devlille.partners.connect.events
+
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEventWithSlug
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventEntity
+import fr.devlille.partners.connect.events.infrastructure.db.FavoriteEventsTable
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.users.factories.insertMockedOrgaPermission
+import fr.devlille.partners.connect.users.factories.insertMockedUser
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteEventCrossOrgRoutesTest {
+    @Test
+    @Suppress("LongMethod")
+    fun `user A can favorite own org event, cannot favorite other org event, isolated from user B`() = testApplication {
+        val userAId = UUID.randomUUID()
+        val userBId = UUID.randomUUID()
+        val orgAId = UUID.randomUUID()
+        val orgBId = UUID.randomUUID()
+        val eventAId = UUID.randomUUID()
+        val eventBId = UUID.randomUUID()
+        val eventASlug = "event-org-a"
+        val eventBSlug = "event-org-b"
+
+        // The mock OAuth engine resolves "Bearer valid" to userAId here.
+        application {
+            moduleSharedDb(userId = userAId)
+            transaction {
+                insertMockedUser(userAId)
+                insertMockedUser(userBId)
+                insertMockedOrganisationEntity(orgAId)
+                insertMockedOrganisationEntity(orgBId)
+                insertMockedOrgaPermission(orgAId, userId = userAId)
+                insertMockedOrgaPermission(orgBId, userId = userBId)
+                insertMockedFutureEventWithSlug(id = eventAId, slug = eventASlug, orgId = orgAId)
+                insertMockedFutureEventWithSlug(id = eventBId, slug = eventBSlug, orgId = orgBId)
+            }
+        }
+
+        // Step 1: user A favorites event-A → 201
+        val addAResp = client.put("/users/me/favorite-events/$eventASlug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.Created, addAResp.status)
+
+        // Step 2: user A lists favorites → contains event-A only
+        val listResp = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, listResp.status)
+        val items = Json.parseToJsonElement(listResp.bodyAsText()).jsonArray
+        assertEquals(1, items.size)
+        assertEquals(eventASlug, items[0].jsonObject["slug"]?.jsonPrimitive?.content)
+
+        // Step 3: user A tries to favorite event-B (org B, no permission) → 403
+        val crossOrgResp = client.put("/users/me/favorite-events/$eventBSlug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.Forbidden, crossOrgResp.status)
+
+        // Step 4: user B's favorites are isolated from user A's — verified at the DB layer
+        //         (the mock OAuth engine is fixed to userAId; we can't switch identity mid-test,
+        //         so we assert state directly).
+        transaction {
+            val rowsForUserB = FavoriteEventEntity
+                .find { FavoriteEventsTable.userId eq userBId }
+                .count()
+            assertEquals(0, rowsForUserB, "User B should have zero favorites")
+
+            val rowsForUserA = FavoriteEventEntity
+                .find { FavoriteEventsTable.userId eq userAId }
+                .count()
+            assertEquals(1, rowsForUserA, "User A should have exactly one favorite")
+        }
+
+        // Step 5: user A removes their favorite → 204
+        val deleteResp = client.delete("/users/me/favorite-events/$eventASlug") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.NoContent, deleteResp.status)
+
+        // Step 6: user A lists favorites again → empty
+        val finalListResp = client.get("/users/me/favorite-events") {
+            header(HttpHeaders.Authorization, "Bearer valid")
+        }
+        assertEquals(HttpStatusCode.OK, finalListResp.status)
+        assertEquals("[]", finalListResp.bodyAsText())
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `./gradlew :application:test --tests "*FavoriteEventCrossOrgRoutesTest" --no-daemon`
+Expected: BUILD SUCCESSFUL with 1 passing test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application/src/test/kotlin/fr/devlille/partners/connect/events/FavoriteEventCrossOrgRoutesTest.kt
+git commit -m "test(server): integration test for favorite-events cross-org isolation"
+```
+
+---
+
+### Task 10: OpenAPI documentation
+
+**Files:**
+- Modify: `application/src/main/resources/openapi/openapi.yaml`
+- Modify: `application/src/main/resources/openapi/documentation.yaml` (regenerated via `npm run bundle`)
+
+- [ ] **Step 1: Add three paths to `openapi.yaml`**
+
+Locate the existing `/users/me/orgs:` block (around line 5937) and append the three new paths *immediately after* it, before the `components:` block (around line 5953). Use the inline-status-code style with `$ref: "#/components/schemas/ErrorResponse"` for failure bodies, mirroring `/orgs/{orgSlug}/ai/chat`.
+
+```yaml
+  /users/me/favorite-events:
+    get:
+      summary: "List the authenticated user's favorite events"
+      operationId: "getUsersMeFavoriteEvents"
+      description: "Returns the caller's favorite events ordered by start_time ascending. Favorites whose event belongs to an organisation the caller no longer has permission on are filtered out."
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/EventSummary"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /users/me/favorite-events/{eventSlug}:
+    parameters:
+      - name: "eventSlug"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: "Event slug to favorite or un-favorite"
+    put:
+      summary: "Add an event to the authenticated user's favorites"
+      operationId: "putUsersMeFavoriteEvent"
+      description: "Idempotent at the HTTP level only insofar as repeating the call surfaces a 409 Conflict; otherwise creates one row in favorite_events."
+      security:
+        - bearerAuth: []
+      responses:
+        "201":
+          description: "Created"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: "Forbidden - The event exists but belongs to an organisation the caller has no permission on"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Unknown event slug"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict - The caller has already favorited this event"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: "Remove an event from the authenticated user's favorites"
+      operationId: "deleteUsersMeFavoriteEvent"
+      description: "Returns 204 on success. Returns 404 for both an unknown event slug and a known event that is not in the caller's favorites."
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: "No Content - Favorite removed"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: "Forbidden - The event exists but belongs to an organisation the caller has no permission on"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - The event is not in the caller's favorites (or the slug is unknown)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+```
+
+- [ ] **Step 2: Validate the OpenAPI source**
+
+Run: `npm run validate`
+Expected: passes with no errors. (Run from `application/src/main/resources/openapi/` if that's where `package.json` lives; otherwise from the project root — see existing scripts.)
+
+- [ ] **Step 3: Bundle the OpenAPI**
+
+Run: `npm run bundle`
+Expected: regenerates `documentation.yaml`. The diff should show three new path entries under `/users/me/favorite-events*`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add application/src/main/resources/openapi/openapi.yaml \
+        application/src/main/resources/openapi/documentation.yaml
+git commit -m "docs(server): document /users/me/favorite-events endpoints in OpenAPI"
+```
+
+---
+
+### Task 11: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full Gradle quality gate**
+
+Run: `./gradlew ktlintCheck detekt test --no-daemon`
+Expected: BUILD SUCCESSFUL with all tests passing.
+
+- [ ] **Step 2: Re-run the OpenAPI tooling**
+
+Run: `npm run validate && npm run bundle`
+Expected: both commands pass, no diff in `documentation.yaml` (already committed in Task 10).
+
+- [ ] **Step 3: Manually verify the migration applied to a fresh DB**
+
+Start the server locally (`./gradlew :application:run` or via the project's standard `docker compose` command) and check the migrations log for the line:
+
+```
+Applying migration: 20260524_add_favorite_events - Add favorite_events join table linking users to events they have starred
+```
+
+Then connect to the DB and confirm:
+
+```sql
+SELECT migration_id FROM applied_migrations WHERE migration_id = '20260524_add_favorite_events';
+\d favorite_events
+```
+
+Expected: the migration row exists; the `favorite_events` table has columns `id`, `user_id`, `event_id`, `favorited_at` plus the unique index on `(user_id, event_id)`.
+
+No commit for this task — verification only.
+
+---
+
+## 5. Spec coverage cross-check
+
+| Spec item | Implemented in |
+|---|---|
+| FR-001 (GET endpoint, EventSummary, ordered ascending, empty=`[]`) | Tasks 3 (repo), 4 (route), 7 (tests) |
+| FR-002 (PUT 201 / 409) | Tasks 3, 4, 6 |
+| FR-003 (DELETE 204) | Tasks 3, 4, 8 |
+| FR-004 (no `AuthorizedOrganisationPlugin`, bearer-only) | Task 4 |
+| FR-005 (missing/invalid token → 401) | Tasks 6, 7, 8 (the `Authorization missing` tests) |
+| FR-006 (PUT 404 on unknown slug) | Task 3 (repo throw), Task 6 (test) |
+| FR-007 (403 on cross-org via `hasPermission`) | Task 3 (repo throw), Tasks 6, 8 (tests) |
+| FR-008 (409 on duplicate; existence-check via `singleFavorite`) | Task 3 (repo), Task 6 (test) |
+| FR-009 (DELETE 404 collapsed) | Task 3 (repo returns false), Task 4 (route throws 404), Task 8 (test covers both branches) |
+| FR-010 (live filter of revoked-org favorites in GET) | Task 3 (repo `.filter { hasPermission }`) |
+| FR-011 (OpenAPI updated, no new JSON schemas) | Task 10 |
+| FR-012 (route mounted in `App.kt`) | Task 4 |
+| FR-013 (`FavoriteEventRepository` registered in `EventModule.kt`, no new Koin module) | Task 3 |
+| FR-014 (`ktlintCheck detekt test` pass) | Task 11 |
+| Key entity: `FavoriteEventsTable` | Task 1 |
+| Key entity: `FavoriteEventEntity` + helpers | Task 1 |
+| Key entity: `FavoriteEventRepository` | Task 3 |
+| Key entity: `FavoriteEventRepositoryExposed` | Task 3 |
+| Key entity: `Route.favoriteEventRoutes()` | Task 4 |
+| Key entity: `EventEntity.toEventSummary()` extracted mapper | Task 2 |
+| SC-001 (12 documented status-code paths exercised) | Tasks 6+7+8 (5+3+5 = 13 contract tests, covers all 12 rows from the spec table) |
+| SC-002 (CI gates pass) | Task 11 |
+| SC-003 (contract-test coverage) | Tasks 6, 7, 8 |
+| SC-004 (cross-user/cross-org integration coverage) | Task 9 |
+| SC-005 (post-deploy smoke test) | Out-of-band; covered by deploying the feature and running the documented happy path |
+
+No spec requirement is unaccounted for. No task references a type, method, or factory that has not been defined earlier in this plan or in the existing codebase.

--- a/server/specs/027-favorite-events/spec.md
+++ b/server/specs/027-favorite-events/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Per-user favorite events
+
+**Feature Branch**: `027-favorite-events`
+**Created**: 2026-05-24
+**Status**: Draft
+**Input**: User description: "I would like to work on 3 new endpoints: put an event in favorite, delete a favorite and get list of favorite events. This should be protected for organisers only. Event should be part in one organisers where they have access."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Add an event to my favorites (Priority: P1)
+
+As an authenticated organiser, I can `PUT /users/me/favorite-events/{eventSlug}` to add an event I have access to (i.e. an event belonging to one of my organisations) to my personal favorites list.
+
+**Why this priority**: This is the gateway action — without it, no favorites can exist and the list/remove endpoints are meaningless. It is also the endpoint that exercises every cross-cutting concern (auth, cross-org check, uniqueness).
+
+**Independent Test**: With an organiser-permissioned user on org A and an event `event-A` belonging to org A, a `PUT /users/me/favorite-events/event-A` returns 201 Created and a follow-up `GET /users/me/favorite-events` returns a list containing `event-A`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated organiser of org A and an event `event-A` belonging to org A, **When** they `PUT /users/me/favorite-events/event-A` for the first time, **Then** the server returns 201 Created with an empty body.
+2. **Given** the same setup with `event-A` already favorited by the caller, **When** they `PUT /users/me/favorite-events/event-A` again, **Then** the server returns 409 Conflict with a message naming the event.
+3. **Given** an authenticated organiser of org A and an event `event-B` belonging to org B (caller has no permission on org B), **When** they `PUT /users/me/favorite-events/event-B`, **Then** the server returns 403 Forbidden.
+4. **Given** an authenticated organiser and an event slug that does not exist, **When** they `PUT /users/me/favorite-events/unknown`, **Then** the server returns 404 Not Found.
+5. **Given** an unauthenticated request, **When** they `PUT /users/me/favorite-events/event-A`, **Then** the server returns 401 Unauthorized.
+
+---
+
+### User Story 2 - List my favorite events (Priority: P1)
+
+As an authenticated organiser, I can `GET /users/me/favorite-events` to retrieve all the events I have favorited across every organisation I belong to, ordered by event `start_time` ascending.
+
+**Why this priority**: Listing is the second indispensable half of the feature — the favorite action is only useful if the caller can later see what they favorited. Together with User Story 1, this story constitutes the minimum viable feature.
+
+**Independent Test**: With an organiser who has favorited `event-A` (start 2026-06-15) and `event-C` (start 2026-04-10) across two organisations they belong to, `GET /users/me/favorite-events` returns 200 OK and a JSON array of `EventSummary` objects in this order: `event-C` then `event-A`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated organiser with no favorites, **When** they `GET /users/me/favorite-events`, **Then** the server returns 200 OK with an empty JSON array `[]`.
+2. **Given** an authenticated organiser with two favorited events in two different organisations, **When** they `GET /users/me/favorite-events`, **Then** the server returns 200 OK with a JSON array of two `EventSummary` objects ordered by `start_time` ascending.
+3. **Given** two different organisers (user A and user B) where user A has favorited `event-A`, **When** user B calls `GET /users/me/favorite-events`, **Then** the server returns 200 OK with `[]` (user B does not see user A's favorites).
+4. **Given** an unauthenticated request, **When** the route is called, **Then** the server returns 401 Unauthorized.
+
+---
+
+### User Story 3 - Remove an event from my favorites (Priority: P2)
+
+As an authenticated organiser, I can `DELETE /users/me/favorite-events/{eventSlug}` to remove an event from my personal favorites.
+
+**Why this priority**: P2 because the list and add stories are independently shippable; removal is the natural cleanup but the feature is not unusable without it for a first iteration. It is still expected to ship in the same PR — the priority is only about story ordering, not scope.
+
+**Independent Test**: With an organiser who has previously favorited `event-A`, `DELETE /users/me/favorite-events/event-A` returns 204 No Content and a follow-up `GET /users/me/favorite-events` no longer contains `event-A`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated organiser who has `event-A` in their favorites, **When** they `DELETE /users/me/favorite-events/event-A`, **Then** the server returns 204 No Content with an empty body.
+2. **Given** an authenticated organiser whose favorites do **not** include `event-A` (event exists in one of their orgs), **When** they `DELETE /users/me/favorite-events/event-A`, **Then** the server returns 404 Not Found.
+3. **Given** an authenticated organiser and an event slug that does not exist, **When** they call DELETE on that slug, **Then** the server returns 404 Not Found (same response as the "known but not favorited" case — see FR-009).
+4. **Given** an authenticated organiser of org A and an event `event-B` belonging to org B (caller has no permission on org B), **When** they `DELETE /users/me/favorite-events/event-B`, **Then** the server returns 403 Forbidden.
+5. **Given** an unauthenticated request, **When** they call DELETE on any slug, **Then** the server returns 401 Unauthorized.
+
+---
+
+### Edge Cases
+
+- **Caller has no organiser permission anywhere**: any of the three endpoints called by a user who has zero rows in `organisation_permissions` returns 200 OK with `[]` for GET, and 403 Forbidden for PUT/DELETE on any concrete event slug (because the event resolves to an org the caller has no permission on). The route does not pre-emptively refuse based on "is the caller any kind of organiser" — the per-event org check is sufficient.
+- **Concurrent PUT of the same favorite**: the unique index on `(user_id, event_id)` makes one of the inserts fail at the DB layer. The repository's `singleFavorite` check is a best-effort fast path; the `ExposedSQLException` on duplicate insert is caught and surfaced as a 409 Conflict to keep the contract uniform.
+- **Event is deleted after being favorited**: the `event_id` foreign key uses Exposed's default `ON DELETE RESTRICT`, so an event with active favorites cannot be deleted until the favorites are cleared. This is consistent with how the rest of the codebase handles event references (no cascading deletes). Out of scope: a follow-up could decide to cascade.
+- **User is revoked from an org while having favorites in it**: existing favorites remain in the table but become **invisible** in the GET response — the implementation filters by the caller's current org permissions, so revoked-org favorites are silently hidden. They can be re-revealed if the user is re-granted. The PUT/DELETE on such an event would then return 403. This avoids implicit data loss on revoke and matches how `/users/me/events` already behaves.
+- **Empty event slug** (e.g. trailing slash `PUT /users/me/favorite-events/`): Ktor returns 404 Not Found from the routing layer; no special handling needed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose `GET /users/me/favorite-events` returning a JSON array of `EventSummary` objects, ordered by event `start_time` ascending. The empty case MUST return `[]`, not 404.
+- **FR-002**: System MUST expose `PUT /users/me/favorite-events/{eventSlug}` that adds an event to the caller's favorites and returns 201 Created with an empty body on first add, 409 Conflict if the caller has already favorited the event.
+- **FR-003**: System MUST expose `DELETE /users/me/favorite-events/{eventSlug}` that removes an event from the caller's favorites and returns 204 No Content on success.
+- **FR-004**: All three endpoints MUST identify the caller from the bearer token via `AuthRepository.getUserInfo(token)` (same pattern used by `/users/me/events` and `/users/me/orgs`). They MUST NOT install `AuthorizedOrganisationPlugin` because the routes are not scoped to a single organisation.
+- **FR-005**: Missing or invalid bearer token MUST result in 401 Unauthorized, raised by the existing `AuthRepository` failure path (`UnauthorizedException` → 401 via `App.kt`'s `configureStatusPage()`).
+- **FR-006**: For PUT, when the event slug does not exist in the database, the system MUST throw `NotFoundException` ("Event \<slug\> not found"), mapped to 404 Not Found via `App.kt`. The DELETE behavior for unknown slugs is covered by FR-009 (collapsed into the uniform "not in your favorites" 404).
+- **FR-007**: For PUT and DELETE, when the event exists but belongs to an organisation the caller has no permission on, the system MUST throw `ForbiddenException` (existing class under `internal/infrastructure/api/`) mapped to 403 Forbidden via `App.kt`. Permission is checked with the existing `OrganisationPermissionEntity.hasPermission(orgId, userId)` helper.
+- **FR-008**: PUT MUST return 409 Conflict (via `ConflictException`) when a favorite already exists for `(caller, eventSlug)`. The repository SHOULD detect this via a `singleFavorite` lookup before insert; concurrent inserts that bypass the lookup MUST also be surfaced as 409 (catch and translate `ExposedSQLException` on the unique-index violation).
+- **FR-009**: DELETE MUST return 404 Not Found when no favorite exists for `(caller, eventSlug)`. This collapses two cases into one response — "event slug unknown" and "event slug known but caller has not favorited it" — to keep the contract uniform.
+- **FR-010**: The list endpoint MUST filter out favorites whose underlying event belongs to an organisation the caller no longer has permission on. Permission status is read live at request time (not snapshotted at favorite-creation time).
+- **FR-011**: The OpenAPI source spec at `application/src/main/resources/openapi/openapi.yaml` MUST be updated to document the three new endpoints. The bundled `application/src/main/resources/openapi/documentation.yaml` MUST be regenerated via `npm run bundle`. Both `npm run validate` and `npm run bundle` MUST pass. The endpoints MUST reuse the existing `EventSummary` schema component for the GET response, and the existing shared `ErrorResponse` schema component for 4xx response bodies, mirroring the inline-status-code style used by `/orgs/{orgSlug}/ai/chat` (the project does not define `components/responses`; each path documents its status codes inline with `description:` and a `$ref` to `ErrorResponse`). **No new `*.schema.json` files** are added under `application/src/main/resources/schemas/` — PUT and DELETE have no request body and GET has no body either.
+- **FR-012**: The new route function `Route.favoriteEventRoutes()` MUST be mounted in `App.kt`'s `routing { }` block alongside the other `*Routes()` calls.
+- **FR-013**: The new `FavoriteEventRepositoryExposed` MUST be registered as `FavoriteEventRepository` in the existing `events/infrastructure/bindings/EventModule.kt` — no new top-level Koin module is created.
+- **FR-014**: All new code MUST pass `./gradlew ktlintCheck detekt test --no-daemon`.
+
+### Key Entities
+
+- **`FavoriteEventsTable`** (`events/infrastructure/db/FavoriteEventsTable.kt`): `UUIDTable("favorite_events")` with columns `user_id` (reference to `UsersTable`), `event_id` (reference to `EventsTable`), `favorited_at` (datetime, defaulted to `Clock.System.now()` in UTC via `clientDefault`). `init { uniqueIndex(userId, eventId) }`. `favorited_at` is stored but not exposed in the API; it preserves the option to switch ordering or surface "recently favorited" in a follow-up without a migration.
+- **`FavoriteEventEntity`** (`events/infrastructure/db/FavoriteEventEntity.kt`): `UUIDEntity` mapping with `var user by UserEntity referencedOn FavoriteEventsTable.userId`, `var event by EventEntity referencedOn FavoriteEventsTable.eventId`, `var favoritedAt by FavoriteEventsTable.favoritedAt`. Companion-object query helpers, as extension functions on `UUIDEntityClass<FavoriteEventEntity>`, are colocated in the same file:
+  - `fun singleFavorite(userId: UUID, eventId: UUID): FavoriteEventEntity?` — used by PUT (409 detection) and DELETE (404 detection).
+  - `fun listByUserOrderByEventStartTime(userId: UUID): List<FavoriteEventEntity>` — used by GET. Eager-loads `event` via `.with(FavoriteEventEntity::event)` and sorts client-side by `event.startTime`.
+- **`FavoriteEventRepository`** (`events/domain/FavoriteEventRepository.kt`): the single business contract. Methods:
+  - `fun listByUserEmail(userEmail: String): List<EventSummary>` — throws `NotFoundException` if no user matches the email (defensive; should not happen in practice because the bearer-token flow upserts the user).
+  - `fun addFavorite(userEmail: String, eventSlug: String): Boolean` — returns `true` if a new row was inserted, `false` if the favorite already existed (caller maps `false` to 409). Throws `NotFoundException` on unknown event, `ForbiddenException` on cross-org.
+  - `fun removeFavorite(userEmail: String, eventSlug: String): Boolean` — returns `true` if a row was deleted, `false` if no favorite existed (caller maps `false` to 404). Throws `ForbiddenException` on cross-org. Unknown-event deletion is also surfaced as `false` so that the route returns the uniform 404 from FR-009.
+- **`FavoriteEventRepositoryExposed`** (`events/application/FavoriteEventRepositoryExposed.kt`): the Exposed-backed implementation. Each method runs inside a single `transaction { }`. Uses `UserEntity.singleUserByEmail`, `EventEntity.singleEventBySlug`, and `OrganisationPermissionEntity.hasPermission` (all existing helpers).
+- **`Route.favoriteEventRoutes()`** (`events/infrastructure/api/FavoriteEventRoutes.kt`): the Ktor route. Mounts under `/users/me/favorite-events`. Each handler resolves the email from the bearer token then delegates to the repository. The handler translates the repository's `Boolean` returns into HTTP status codes (201 vs 409 for PUT, 204 vs 404 for DELETE).
+- **`EventEntity.toEventSummary()`** (`events/application/mappers/Event.ext.kt`, **new file**): small mapper extracted from the inline mapping already used in `EventRepositoryExposed.findByUserEmail` (`EventRepositoryExposed.kt:249-256`). Shared between the existing `findByUserEmail` and the new `listByUserEmail` so the two endpoints stay in lockstep.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All three endpoints are reachable on a running server and return the documented status codes for the twelve cases enumerated in the testing plan (see `plan.md`).
+- **SC-002**: All quality gates pass in CI: `./gradlew ktlintCheck detekt test --no-daemon` and `npm run validate`.
+- **SC-003**: Contract-test coverage for the new `FavoriteEventRoutes` is **100 % of documented status codes** — one test per row of the response semantics table (twelve tests total).
+- **SC-004**: One integration test verifies cross-user / cross-org isolation end-to-end (user A's favorites are invisible to user B; user A cannot favorite an event belonging to org B if they lack permission on B).
+- **SC-005**: After deploy, an authenticated organiser can `PUT /users/me/favorite-events/<eventSlug>`, then `GET /users/me/favorite-events`, then `DELETE /users/me/favorite-events/<eventSlug>` against the preprod server and observe the documented response codes (201 → 200 with the event → 204 → 200 with `[]`).
+
+## Out of scope for v1
+
+- **Bulk operations** (PUT/DELETE multiple favorites in one call). The current scope is one event per call.
+- **Pagination of the list endpoint**. Mirrors `/users/me/events`, which is also non-paginated; favorites are expected to be a small set (≤ tens).
+- **Exposing `favorited_at` in the response payload**. The field is stored for future use only.
+- **"Recently favorited" ordering**. Picked `start_time` ascending; can be revisited once UX feedback lands without a schema change.
+- **Per-organisation favorites view** (e.g. `/orgs/{orgSlug}/users/me/favorite-events`). Favorites are user-global; if a per-org filter is needed later it can be a query parameter on the existing endpoint.
+- **Shared / team favorites** (favorites visible to all members of an org). The current model is strictly per-user; a team-favorites feature would be a separate spec with a different table shape.
+- **Cascading delete of favorites when an event is deleted**. Existing project convention is `ON DELETE RESTRICT` for event references; revisit in a follow-up if event deletion ever becomes a routine operation.
+- **OpenAPI tagging** (the three endpoints are added without a `tags:` section, matching the convention the user requested for this feature).
+
+## Cross-references
+
+- **Implementation plan**: see `plan.md` in this folder — contains the file-by-file structure (table, entity, repository, route, Koin wiring, mapper extraction), the contract-test enumeration, and the integration-test workflow.
+- **Related routes**: `/users/me/events` and `/users/me/orgs` in `users/infrastructure/api/UserRoutes.kt` — the new endpoints follow the same auth pattern (bearer-token email resolution, no `AuthorizedOrganisationPlugin`).
+- **Permission helper**: `OrganisationPermissionEntity.hasPermission(orgId, userId)` in `users/infrastructure/db/OrganisationPermissionEntity.kt:36-42` — reused as-is for the cross-org check on PUT and DELETE.
+- **Error mapping**: `App.kt`'s `configureStatusPage()` already maps `UnauthorizedException` → 401, `ForbiddenException` → 403, `NotFoundException` → 404, `ConflictException` → 409. No new exception classes or handlers are needed.


### PR DESCRIPTION
## Summary

Adds three endpoints letting an authenticated organiser star, list, and un-star events that belong to organisations they have permission on. Spec & plan in `server/specs/027-favorite-events/`.

```
GET    /users/me/favorite-events                 → 200 / 401
PUT    /users/me/favorite-events/{eventSlug}     → 201 / 401 / 403 / 404 / 409
DELETE /users/me/favorite-events/{eventSlug}     → 204 / 401 / 403 / 404
```

Per-user scope (each organiser has their own list). Favorites can span any orgs the caller has `canEdit` permission on; revoked-org favorites are silently filtered out at list time (FR-010). PUT is strict (201 → 409 on duplicate). DELETE collapses "unknown slug" and "known-but-not-favorited" into a uniform 404 (FR-009). Cross-org writes always surface 403 (permission check runs before favorite-existence check).

## Architecture

- **New table** `favorite_events(user_id, event_id, favorited_at)` with `uniqueIndex(user_id, event_id)`. Migration `20260524_add_favorite_events`. `favorited_at` is stored for future use but not exposed in the API.
- **Clean-architecture layering**: `events/domain/FavoriteEventRepository.kt` (interface) + `events/application/FavoriteEventRepositoryExposed.kt` (impl) + `events/infrastructure/api/FavoriteEventRoutes.kt` (route). Registered in the existing `eventModule` Koin module — no new top-level module.
- **Auth model**: `/users/me/...` pattern. Bearer-token email resolution via `AuthRepository.getUserInfo`. No `AuthorizedOrganisationPlugin` — per-event org permission is enforced inside the repo via the existing `OrganisationPermissionEntity.hasPermission` helper.
- **Repository contract**: returns `Boolean` on collision paths (already favorited / not favorited) so the route maps to 201/409 and 204/404 respectively; throws for "real errors" (unknown event → Ktor's `NotFoundException`; cross-org → internal `ForbiddenException`).
- **Small refactor**: `EventEntity.toEventSummary()` extracted into `events/application/mappers/Event.ext.kt` (mirrors sibling `EventBudget.ext.kt`), replacing an inline literal in `EventRepositoryExposed.findByUserEmail`. Same mapper used by the new repo.

## Commit structure (review in order)

The plan has 11 tasks; commits map 1:1 (with two small follow-up amendments for review feedback):

1. `docs(server): spec, plan, and skill updates for 027-favorite-events` — spec, plan, and a new "Canonical Imports (Exposed 1.3.0+)" section in `.claude/skills/exposed-entities/SKILL.md` capturing the post-migration package moves (`.java.` subpackage for UUID*, top-level `eq`/`and` operators, `kotlin.time.Clock`).
2. `feat(server): add favorite_events table and migration` — DB scaffold.
3. `refactor(server): extract EventEntity#toEventSummary mapper` — mapper extraction.
4. `feat(server): add FavoriteEventRepository (domain + Exposed impl)` — repository layer.
5. `feat(server): add /users/me/favorite-events GET/PUT/DELETE routes` — route + mount in `App.kt`.
6. `docs(server): fix KDoc on FavoriteEventRepository.addFavorite` — review fix: `@throws` referenced a non-existent internal `NotFoundException`; the impl actually throws Ktor's.
7. `test(server): add insertMockedFavoriteEvent factory`.
8. `test(server): contract tests for PUT /users/me/favorite-events/{eventSlug}` — 5 cases.
9. `test(server): contract tests for GET /users/me/favorite-events` — 3 cases.
10. `test(server): contract tests for DELETE /users/me/favorite-events/{eventSlug}` — 5 cases (incl. both 404 sub-branches of FR-009).
11. `test(server): integration test for favorite-events cross-org isolation` — full add → list → cross-org-403 → DB-level user-B isolation → delete → empty-list workflow.
12. `docs(server): document /users/me/favorite-events endpoints in OpenAPI` — three paths in `openapi.yaml` with inline status codes referencing `ErrorResponse`, plus regenerated `documentation.yaml`.
13. `fix(server): wrap long KDoc lines and de-collide DELETE 403 test slug` — final-gate fixes: detekt MaxLineLength on KDoc, and a slug collision between PUT and DELETE 403 tests (both used `event-other-org` and `moduleSharedDb` shares a single in-memory H2 instance across the JVM).

## Test coverage

13 contract tests + 1 integration test, covering all 12 documented status-code paths from the spec:

- `FavoriteEventRoutePutTest` — 201, 401, 403, 404, 409
- `FavoriteEventRouteGetTest` — 401, 200 (empty), 200 (cross-org, ordered by `start_time` ascending)
- `FavoriteEventRouteDeleteTest` — 204, 401, 404 (unknown slug), 404 (known but not favorited), 403
- `FavoriteEventCrossOrgRoutesTest` — full workflow with DB-level user-B isolation assertion

## Verified

- ✓ `./gradlew ktlintCheck detekt test --no-daemon` — 661 tests passing
- ✓ `npm run validate` (OpenAPI source)
- ✓ `npm run bundle` (regenerates `documentation.yaml`)

## Test plan

- [x] Local build + lint + full test suite
- [x] OpenAPI validates and bundles cleanly
- [ ] After merge & deploy: hit `PUT /users/me/favorite-events/<slug>` against preprod, then `GET /users/me/favorite-events`, then `DELETE /users/me/favorite-events/<slug>` — observe documented response codes (201 → 200 with the event → 204 → 200 with `[]`)
- [ ] After merge & deploy: regenerate `front/utils/api.ts` against production URL (one-shot `npx orval`) — three new functions appear: `getUsersMeFavoriteEvents`, `putUsersMeFavoriteEvent`, `deleteUsersMeFavoriteEvent`. Already verified locally against the bundled spec (+42 lines, no existing exports modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)