### PR TITLE
fix(server): avoid OOM on company logo upload

### DIFF
--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyImageProcessingRepositoryDefault.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyImageProcessingRepositoryDefault.kt
@@ -9,19 +9,25 @@ class CompanyImageProcessingRepositoryDefault : CompanyImageProcessingRepository
     override fun processSvg(bytes: ByteArray): MediaBinary = MediaBinary(
         mimeType = MimeType.SVG,
         original = bytes,
-        png1000 = ImageProcessor.resizeSvg(bytes, width = 1000) ?: error("Failed to resize SVG to 1000px"),
-        png500 = ImageProcessor.resizeSvg(bytes, width = 500) ?: error("Failed to resize SVG to 500px"),
-        png250 = ImageProcessor.resizeSvg(bytes, width = 250) ?: error("Failed to resize SVG to 250px"),
+        png1000 = ImageProcessor.resizeSvg(bytes, width = WIDTH_LARGE) ?: error("Failed to resize SVG to 1000px"),
+        png500 = ImageProcessor.resizeSvg(bytes, width = WIDTH_MEDIUM) ?: error("Failed to resize SVG to 500px"),
+        png250 = ImageProcessor.resizeSvg(bytes, width = WIDTH_SMALL) ?: error("Failed to resize SVG to 250px"),
     )
 
     override fun processImage(bytes: ByteArray): MediaBinary {
-        val resized = ImageProcessor.resizeImageToWidths(bytes, listOf(1000, 500, 250))
+        val resized = ImageProcessor.resizeImageToWidths(bytes, listOf(WIDTH_LARGE, WIDTH_MEDIUM, WIDTH_SMALL))
         return MediaBinary(
             mimeType = MimeType.PNG,
             original = bytes,
-            png1000 = resized.getValue(1000),
-            png500 = resized.getValue(500),
-            png250 = resized.getValue(250),
+            png1000 = resized.getValue(WIDTH_LARGE),
+            png500 = resized.getValue(WIDTH_MEDIUM),
+            png250 = resized.getValue(WIDTH_SMALL),
         )
+    }
+
+    companion object {
+        private const val WIDTH_LARGE = 1000
+        private const val WIDTH_MEDIUM = 500
+        private const val WIDTH_SMALL = 250
     }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyImageProcessingRepositoryDefault.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/companies/application/CompanyImageProcessingRepositoryDefault.kt
@@ -14,11 +14,14 @@ class CompanyImageProcessingRepositoryDefault : CompanyImageProcessingRepository
         png250 = ImageProcessor.resizeSvg(bytes, width = 250) ?: error("Failed to resize SVG to 250px"),
     )
 
-    override fun processImage(bytes: ByteArray): MediaBinary = MediaBinary(
-        mimeType = MimeType.PNG,
-        original = bytes,
-        png1000 = ImageProcessor.resizeImage(bytes, width = 1000) ?: error("Failed to resize image to 1000px"),
-        png500 = ImageProcessor.resizeImage(bytes, width = 500) ?: error("Failed to resize image to 500px"),
-        png250 = ImageProcessor.resizeImage(bytes, width = 250) ?: error("Failed to resize image to 250px"),
-    )
+    override fun processImage(bytes: ByteArray): MediaBinary {
+        val resized = ImageProcessor.resizeImageToWidths(bytes, listOf(1000, 500, 250))
+        return MediaBinary(
+            mimeType = MimeType.PNG,
+            original = bytes,
+            png1000 = resized.getValue(1000),
+            png500 = resized.getValue(500),
+            png250 = resized.getValue(250),
+        )
+    }
 }

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/image/ImageProcessor.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/internal/infrastructure/image/ImageProcessor.kt
@@ -1,6 +1,6 @@
 package fr.devlille.partners.connect.internal.infrastructure.image
 
-import kotlinx.io.IOException
+import fr.devlille.partners.connect.internal.infrastructure.api.PayloadTooLargeException
 import org.apache.batik.transcoder.SVGAbstractTranscoder
 import org.apache.batik.transcoder.TranscoderInput
 import org.apache.batik.transcoder.TranscoderOutput
@@ -12,6 +12,8 @@ import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 
 object ImageProcessor {
+    private const val MAX_IMAGE_DIMENSION = 10_000
+
     fun resizeSvg(bytes: ByteArray, width: Int): ByteArray? {
         val input = TranscoderInput(ByteArrayInputStream(bytes))
         val transcoder = PNGTranscoder().apply {
@@ -28,14 +30,37 @@ object ImageProcessor {
         }
     }
 
-    fun resizeImage(bytes: ByteArray, width: Int): ByteArray? {
-        val resized = Scalr.resize(ImageIO.read(bytes.inputStream()), width)
-        try {
-            val stream = ByteArrayOutputStream()
-            ImageIO.write(resized, "png", stream)
-            return stream.toByteArray()
-        } catch (_: IOException) {
-            return null
+    fun resizeImageToWidths(bytes: ByteArray, widths: List<Int>): Map<Int, ByteArray> {
+        require(widths.isNotEmpty()) { "widths must not be empty" }
+        val maxOut = widths.max()
+        return ImageIO.createImageInputStream(ByteArrayInputStream(bytes)).use { iis ->
+            val reader = ImageIO.getImageReaders(iis).asSequence().firstOrNull()
+                ?: error("No image reader available for uploaded bytes")
+            try {
+                reader.input = iis
+                val srcWidth = reader.getWidth(0)
+                val srcHeight = reader.getHeight(0)
+                if (srcWidth > MAX_IMAGE_DIMENSION || srcHeight > MAX_IMAGE_DIMENSION) {
+                    throw PayloadTooLargeException(
+                        "Image dimensions ${srcWidth}x$srcHeight exceed maximum of " +
+                            "${MAX_IMAGE_DIMENSION}x$MAX_IMAGE_DIMENSION",
+                    )
+                }
+                val subsample = (minOf(srcWidth, srcHeight) / (maxOut * 2)).coerceAtLeast(1)
+                val param = reader.defaultReadParam.apply {
+                    setSourceSubsampling(subsample, subsample, 0, 0)
+                }
+                val decoded = reader.read(0, param)
+                widths.associateWith { width ->
+                    val resized = Scalr.resize(decoded, width)
+                    ByteArrayOutputStream().use { out ->
+                        ImageIO.write(resized, "png", out)
+                        out.toByteArray()
+                    }
+                }
+            } finally {
+                reader.dispose()
+            }
         }
     }
 }

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/infrastructure/image/ImageProcessorTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/internal/infrastructure/image/ImageProcessorTest.kt
@@ -1,0 +1,90 @@
+package fr.devlille.partners.connect.internal.infrastructure.image
+
+import fr.devlille.partners.connect.internal.infrastructure.api.PayloadTooLargeException
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.zip.CRC32
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ImageProcessorTest {
+    @Test
+    fun `resizes a PNG to all requested widths`() {
+        val bytes = pngBytes(width = 200, height = 100, color = Color.RED)
+
+        val resized = ImageProcessor.resizeImageToWidths(bytes, listOf(100, 50, 25))
+
+        assertEquals(setOf(100, 50, 25), resized.keys)
+        resized.forEach { (width, png) ->
+            val decoded = ImageIO.read(png.inputStream())
+            assertEquals(width, decoded.width)
+        }
+    }
+
+    @Test
+    fun `throws PayloadTooLargeException when declared dimensions exceed cap`() {
+        val bytes = craftPngHeaderOnly(width = 20_000, height = 20_000)
+
+        assertFailsWith<PayloadTooLargeException> {
+            ImageProcessor.resizeImageToWidths(bytes, listOf(1000))
+        }
+    }
+
+    private fun pngBytes(width: Int, height: Int, color: Color): ByteArray {
+        val src = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val g = src.createGraphics()
+        g.color = color
+        g.fillRect(0, 0, width, height)
+        g.dispose()
+        return ByteArrayOutputStream().use { out ->
+            ImageIO.write(src, "png", out)
+            out.toByteArray()
+        }
+    }
+
+    // A minimal valid PNG signature + IHDR chunk with crafted dimensions. Enough for
+    // ImageReader.getWidth/getHeight to succeed without allocating a raster.
+    private fun craftPngHeaderOnly(width: Int, height: Int): ByteArray {
+        val signature = byteArrayOf(
+            0x89.toByte(),
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,
+        )
+        val ihdrType = "IHDR".toByteArray()
+        val ihdrData = ByteArrayOutputStream().apply {
+            writeIntBe(width)
+            writeIntBe(height)
+            write(8)
+            write(6)
+            write(0)
+            write(0)
+            write(0)
+        }.toByteArray()
+        val crc = CRC32().apply {
+            update(ihdrType)
+            update(ihdrData)
+        }.value
+        return ByteArrayOutputStream().apply {
+            write(signature)
+            writeIntBe(ihdrData.size)
+            write(ihdrType)
+            write(ihdrData)
+            writeIntBe(crc.toInt())
+        }.toByteArray()
+    }
+
+    private fun ByteArrayOutputStream.writeIntBe(value: Int) {
+        write((value ushr 24) and 0xFF)
+        write((value ushr 16) and 0xFF)
+        write((value ushr 8) and 0xFF)
+        write(value and 0xFF)
+    }
+}


### PR DESCRIPTION
## Summary
- Decode uploaded PNG once via `ImageReader` with subsampling instead of three full `ImageIO.read` calls — peak heap drops from ~3× source raster to a bounded fraction
- Reject images above 10000×10000 upfront with `PayloadTooLargeException` (→ 413) by reading IHDR dimensions before allocating the raster
- New `ImageProcessorTest` covers happy path + dimension cap (header-only crafted PNG, no full-size raster needed in tests)

## Test plan
- [x] `./gradlew :application:test --tests ImageProcessorTest`
- [x] `./gradlew :application:ktlintMainSourceSetCheck :application:ktlintTestSourceSetCheck`
- [x] Manually re-uploaded the Holberton logo via the front — succeeds without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)