### PR TITLE
fix(front): hydrate booth plan image from server on mount

### DIFF
--- a/front/pages/orgs/[slug]/events/[eventSlug]/booth-plan.vue
+++ b/front/pages/orgs/[slug]/events/[eventSlug]/booth-plan.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-import { postOrgsEventsBoothPlan } from "~/utils/api";
+import { getEventBySlug, postOrgsEventsBoothPlan } from "~/utils/api";
 import { useBoothPlanStore } from "~/stores/boothPlan";
 import { useBoothSponsors } from "~/composables/useBoothSponsors";
 import BoothLocationsList from "~/components/booth/BoothLocationsList.vue";
@@ -116,6 +116,18 @@ const isUploading = ref(false);
 const uploadError = ref<string | null>(null);
 
 const boothPlanUrl = computed(() => boothPlanStore.getUrl(eventSlug.value));
+
+onMounted(async () => {
+  try {
+    const response = await getEventBySlug(eventSlug.value);
+    const url = response.data.event.booth_plan_image_url;
+    if (url) {
+      boothPlanStore.setUrl(eventSlug.value, url);
+    }
+  } catch (err) {
+    console.error("Failed to load booth plan image url:", err);
+  }
+});
 
 function handleFileChange(event: Event) {
   const target = event.target as HTMLInputElement;


### PR DESCRIPTION
## Summary
- The booth-plan management page (`/orgs/{org}/events/{event}/booth-plan`) showed the image right after upload but lost it on refresh — the `useBoothPlanStore` was localStorage-only and never queried the server.
- Added an `onMounted` that calls `getEventBySlug` and seeds the store from `event.booth_plan_image_url`, mirroring the pattern already used in `sponsors/[sponsorId]/booth.vue:147-153`.

## Test plan
- [ ] Upload a booth plan from the management page, hard-refresh, confirm the image still shows.
- [ ] Clear localStorage, refresh, confirm a fresh `GET /events/{slug}` hydrates the image.
- [ ] In a brand-new browser session, navigate directly to the booth-plan page, confirm the existing plan is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)