### PR TITLE
feat(server): webhook Q&A models (WebhookQuestion/WebhookAnswer)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-webhook-qanda-models.md
+++ b/docs/superpowers/plans/2026-06-02-webhook-qanda-models.md
@@ -1,0 +1,361 @@
+# Webhook Q&A Models Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the outbound webhook its own Q&A contract (`WebhookQuestion` / `WebhookAnswer` with an explicit `order`), decoupled from the internal `QandaQuestion` domain model.
+
+> **Serialization decision:** `order` and `isCorrect` are **required** (no Kotlin defaults). kotlinx.serialization always emits non-default properties, so the webhook always carries `order` and `is_correct` (even when 0 / false) without changing the gateway's `Json` instance or any other payload field.
+
+**Architecture:** Add two `@Serializable` domain models in the `webhooks` module, a webhook-specific entity→domain mapper that derives `order` from list position, swap the `WebhookPayload.questions` type, and update `HttpWebhookGateway` to fetch questions ordered by `created_at ASC` and index them. No DB migration, no API change, no OpenAPI change.
+
+**Tech Stack:** Kotlin, Ktor, Exposed ORM (v1.3), kotlinx.serialization, kotlin.test, JUnit via Gradle.
+
+**Working directory for all commands:** `server/` (the Gradle root). Paths below are relative to the repo root.
+
+**Reference skills (consult while implementing):** `clean-architecture` (file placement), `exposed-entities` (query/order DSL), `test-factories` (factory conventions), `test-driven-development`.
+
+---
+
+### Task 1: `WebhookAnswer` and `WebhookQuestion` domain models
+
+These are the new external webhook contract. Pure data classes — tested via a serialization unit test (no DB needed) that locks the wire key names (`is_correct`, `order`) and the defaults.
+
+**Files:**
+- Create: `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookAnswer.kt`
+- Create: `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestion.kt`
+- Test: `server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestionTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestionTest.kt`:
+
+```kotlin
+package fr.devlille.partners.connect.webhooks.domain
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WebhookQuestionTest {
+    @Test
+    fun `serializes order and is_correct even at zero-or-false values`() {
+        val question = WebhookQuestion(
+            id = "q1",
+            question = "What is Kotlin?",
+            order = 0,
+            answers = listOf(
+                WebhookAnswer(id = "a1", answer = "A language", isCorrect = true, order = 0),
+                WebhookAnswer(id = "a2", answer = "A drink", isCorrect = false, order = 1),
+            ),
+        )
+
+        val json = Json.encodeToString(WebhookQuestion.serializer(), question)
+
+        // order and is_correct are required (no defaults) -> never dropped, even at 0 / false
+        assertTrue(json.contains("\"is_correct\":true"), json)
+        assertTrue(json.contains("\"is_correct\":false"), json)
+        assertTrue(json.contains("\"order\":0"), json)
+        assertTrue(json.contains("\"order\":1"), json)
+    }
+
+    @Test
+    fun `question defaults answers to empty list`() {
+        val question = WebhookQuestion(id = "q1", question = "x", order = 0)
+
+        assertEquals(emptyList(), question.answers)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && ./gradlew test --tests "fr.devlille.partners.connect.webhooks.domain.WebhookQuestionTest" --no-daemon`
+Expected: FAIL — compilation error, `WebhookQuestion` / `WebhookAnswer` unresolved.
+
+- [ ] **Step 3: Create `WebhookAnswer`**
+
+Create `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookAnswer.kt`:
+
+```kotlin
+package fr.devlille.partners.connect.webhooks.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WebhookAnswer(
+    val id: String,
+    val answer: String,
+    @SerialName("is_correct")
+    val isCorrect: Boolean,
+    val order: Int,
+)
+```
+
+- [ ] **Step 4: Create `WebhookQuestion`**
+
+Create `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestion.kt`:
+
+```kotlin
+package fr.devlille.partners.connect.webhooks.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WebhookQuestion(
+    val id: String,
+    val question: String,
+    val order: Int,
+    val answers: List<WebhookAnswer> = emptyList(),
+)
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd server && ./gradlew test --tests "fr.devlille.partners.connect.webhooks.domain.WebhookQuestionTest" --no-daemon`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookAnswer.kt \
+        server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestion.kt \
+        server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestionTest.kt
+git commit -m "feat(server): add WebhookQuestion/WebhookAnswer webhook Q&A models"
+```
+
+---
+
+### Task 2: Webhook Q&A mapper (`toWebhookQuestion` / `toWebhookAnswer`)
+
+Maps `QandaQuestionEntity`/`QandaAnswerEntity` (partnership infra) to the new webhook models. `order` for a question is passed by the caller (the gateway, by list index); `order` for answers is derived inside the mapper from the answer's position in the entity's `answers` collection.
+
+**Files:**
+- Create: `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/mappers/QandaWebhookEntity.ext.kt`
+- Test: `server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/application/QandaWebhookMapperTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/application/QandaWebhookMapperTest.kt`. It mirrors the DB setup pattern from `QandaEventQuestionsRouteGetTest` (org → event → company → pack → partnership → question → answers), triggers app/DB init with `client.get("/")`, then exercises the mapper inside a `transaction {}`:
+
+```kotlin
+package fr.devlille.partners.connect.webhooks.application
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
+import fr.devlille.partners.connect.partnership.factories.insertMockedQandaAnswer
+import fr.devlille.partners.connect.partnership.factories.insertMockedQandaQuestion
+import fr.devlille.partners.connect.partnership.infrastructure.db.QandaQuestionEntity
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
+import fr.devlille.partners.connect.webhooks.application.mappers.toWebhookQuestion
+import io.ktor.client.request.get
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QandaWebhookMapperTest {
+    @Test
+    fun `maps question fields and indexes answers, preserving is_correct`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val questionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId, name = "Acme Corp")
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                )
+                insertMockedQandaQuestion(id = questionId, partnershipId = partnershipId, question = "What is Kotlin?")
+                insertMockedQandaAnswer(questionId = questionId, answer = "A language", isCorrect = true)
+                insertMockedQandaAnswer(questionId = questionId, answer = "A drink", isCorrect = false)
+                insertMockedQandaAnswer(questionId = questionId, answer = "An island", isCorrect = false)
+            }
+        }
+        client.get("/")
+
+        transaction {
+            val result = QandaQuestionEntity[questionId].toWebhookQuestion(order = 5)
+
+            assertEquals(questionId.toString(), result.id)
+            assertEquals("What is Kotlin?", result.question)
+            assertEquals(5, result.order)
+            assertEquals(3, result.answers.size)
+            // order is derived from collection position, always 0,1,2 for three answers
+            assertEquals(listOf(0, 1, 2), result.answers.map { it.order })
+            assertEquals(1, result.answers.count { it.isCorrect })
+            assertEquals("A language", result.answers.single { it.isCorrect }.answer)
+            assertEquals(setOf("A language", "A drink", "An island"), result.answers.map { it.answer }.toSet())
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && ./gradlew test --tests "fr.devlille.partners.connect.webhooks.application.QandaWebhookMapperTest" --no-daemon`
+Expected: FAIL — compilation error, `toWebhookQuestion` unresolved.
+
+- [ ] **Step 3: Create the mapper**
+
+Create `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/mappers/QandaWebhookEntity.ext.kt`:
+
+```kotlin
+package fr.devlille.partners.connect.webhooks.application.mappers
+
+import fr.devlille.partners.connect.partnership.infrastructure.db.QandaAnswerEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.QandaQuestionEntity
+import fr.devlille.partners.connect.webhooks.domain.WebhookAnswer
+import fr.devlille.partners.connect.webhooks.domain.WebhookQuestion
+
+fun QandaQuestionEntity.toWebhookQuestion(order: Int): WebhookQuestion = WebhookQuestion(
+    id = id.value.toString(),
+    question = question,
+    order = order,
+    answers = answers.mapIndexed { index, answer -> answer.toWebhookAnswer(index) },
+)
+
+fun QandaAnswerEntity.toWebhookAnswer(order: Int): WebhookAnswer = WebhookAnswer(
+    id = id.value.toString(),
+    answer = answer,
+    isCorrect = isCorrect,
+    order = order,
+)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd server && ./gradlew test --tests "fr.devlille.partners.connect.webhooks.application.QandaWebhookMapperTest" --no-daemon`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/mappers/QandaWebhookEntity.ext.kt \
+        server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/application/QandaWebhookMapperTest.kt
+git commit -m "feat(server): add QandaQuestionEntity->WebhookQuestion mapper"
+```
+
+---
+
+### Task 3: Wire the new models into `WebhookPayload` and `HttpWebhookGateway`
+
+Swap the payload's `questions` type to the new model and update the gateway to fetch questions ordered by `created_at ASC` (consistent with `QandaRepositoryExposed`) and assign `order` by index.
+
+**Files:**
+- Modify: `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookPayload.kt`
+- Modify: `server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/infrastructure/gateways/HttpWebhookGateway.kt`
+
+- [ ] **Step 1: Change the `WebhookPayload.questions` type**
+
+In `WebhookPayload.kt`:
+- Remove the import line: `import fr.devlille.partners.connect.partnership.domain.QandaQuestion`
+- Change the field `val questions: List<QandaQuestion>,` to `val questions: List<WebhookQuestion>,`
+
+`WebhookQuestion` is in the same package (`webhooks.domain`), so no new import is required. Resulting file:
+
+```kotlin
+package fr.devlille.partners.connect.webhooks.domain
+
+import fr.devlille.partners.connect.agenda.domain.Speaker
+import fr.devlille.partners.connect.companies.domain.Company
+import fr.devlille.partners.connect.companies.domain.JobOffer
+import fr.devlille.partners.connect.events.domain.EventSummary
+import fr.devlille.partners.connect.partnership.domain.BoothActivity
+import fr.devlille.partners.connect.partnership.domain.PartnershipDetail
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WebhookPayload(
+    val eventType: WebhookEventType,
+    val partnership: PartnershipDetail,
+    val company: Company,
+    val event: EventSummary,
+    val jobs: List<JobOffer>,
+    val activities: List<BoothActivity>,
+    val questions: List<WebhookQuestion>,
+    val speakers: List<Speaker>,
+    val supportVideoUrl: String? = null,
+    val timestamp: String,
+)
+```
+
+- [ ] **Step 2: Update the gateway's questions fetch**
+
+In `HttpWebhookGateway.kt`, add two imports (keep alphabetical ktlint order):
+- `import fr.devlille.partners.connect.webhooks.application.mappers.toWebhookQuestion`
+- `import org.jetbrains.exposed.v1.core.SortOrder`
+
+Then replace the questions block (currently):
+
+```kotlin
+            val questions = QandaQuestionEntity
+                .find { QandaQuestionsTable.partnershipId eq partnershipId }
+                .map { it.toDomain() }
+```
+
+with:
+
+```kotlin
+            val questions = QandaQuestionEntity
+                .find { QandaQuestionsTable.partnershipId eq partnershipId }
+                .orderBy(QandaQuestionsTable.createdAt to SortOrder.ASC)
+                .mapIndexed { index, entity -> entity.toWebhookQuestion(index) }
+```
+
+Do NOT remove the existing `import fr.devlille.partners.connect.partnership.application.mappers.toDomain` — it is still used by `BoothActivityEntity.toDomain()` (and pack mapping) in the same file.
+
+- [ ] **Step 3: Format and verify the gateway/payload compile**
+
+Run: `cd server && ./gradlew ktlintFormat --no-daemon && ./gradlew compileKotlin --no-daemon`
+Expected: BUILD SUCCESSFUL. If ktlint reordered the new imports, that is fine.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookPayload.kt \
+        server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/infrastructure/gateways/HttpWebhookGateway.kt
+git commit -m "feat(server): send webhook Q&A via WebhookQuestion ordered by created_at"
+```
+
+---
+
+### Task 4: Full verification
+
+Run the complete server gate (lint + detekt + tests + build) to confirm nothing else referenced the old `WebhookPayload.questions` shape and everything is green.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full check**
+
+Run: `cd server && ./gradlew ktlintCheck detekt test build --no-daemon`
+Expected: BUILD SUCCESSFUL. All tests pass (including the two new tests from Tasks 1–2).
+
+- [ ] **Step 2: If green, no commit needed**
+
+If any step fails, fix inline (most likely a ktlint import-order nit or an unused import) and re-run. Do not claim completion until this command is green — see `superpowers:verification-before-completion`.
+
+---
+
+## Notes / accepted limitations
+
+- **Answer order is collection-position, not authored order.** Answers have no timestamp/order column and `QandaRepositoryExposed.update()` recreates them with random UUID PKs. The mapper assigns `order` by the entity collection's read position. Persisting true order was the rejected "Persist in DB" option.
+- **Gateway-level ordering is not unit-tested in isolation** (no webhook-integration factory exists; building one is out of scope). It reuses the proven `orderBy(QandaQuestionsTable.createdAt to SortOrder.ASC)` pattern plus `mapIndexed`, and is covered by compilation + the mapper test. This is an accepted, low-risk gap.
+- **No OpenAPI / migration / front-end / partnership-API changes** — confirmed out of scope in the design.

--- a/docs/superpowers/specs/2026-06-02-webhook-qanda-models-design.md
+++ b/docs/superpowers/specs/2026-06-02-webhook-qanda-models-design.md
@@ -1,0 +1,112 @@
+# Design: Webhook Q&A models (`WebhookQuestion` / `WebhookAnswer`)
+
+**Date**: 2026-06-02
+**Area**: `server` — `webhooks` domain
+**Status**: Approved (pending spec review)
+
+## Goal
+
+Give the outbound webhook its own Q&A contract so the wire format no longer
+reuses the internal `QandaQuestion` domain model. The webhook should carry the
+questions and answers entered ("encoded") by the partner using two dedicated,
+leaner models that add an explicit `order`:
+
+```kotlin
+@Serializable
+data class WebhookQuestion(
+    val id: String,
+    val question: String,
+    val order: Int = 0,
+    val answers: List<WebhookAnswer> = emptyList(),
+)
+
+@Serializable
+data class WebhookAnswer(
+    val id: String,
+    val answer: String,
+    @SerialName("is_correct")
+    val isCorrect: Boolean = false,
+    val order: Int = 0,
+)
+```
+
+## Why a dedicated model
+
+Today `WebhookPayload.questions` is typed `List<QandaQuestion>`. `QandaQuestion`
+is the internal partnership-domain model and leaks `partnership_id` and
+`created_at` into the webhook wire format, and lacks `order`. Decoupling the
+external contract from the internal model lets each evolve independently and
+makes the rendering order explicit for the receiving system.
+
+## Components
+
+### 1. New domain models — `webhooks/domain/`
+- `WebhookQuestion.kt`
+- `WebhookAnswer.kt`
+
+Placed alongside `WebhookPayload` because they are part of the webhook contract.
+
+### 2. New mapper — webhooks module (`application/mappers`)
+- `QandaQuestionEntity.toWebhookQuestion(order: Int): WebhookQuestion`
+  - maps `id`, `question`, the passed `order`, and
+    `answers.mapIndexed { i, a -> a.toWebhookAnswer(i) }`
+- `QandaAnswerEntity.toWebhookAnswer(order: Int): WebhookAnswer`
+  - maps `id`, `answer`, `isCorrect`, and the passed `order`
+
+The existing `partnership/application/mappers/QandaEntity.ext.kt` (`toDomain()`)
+is left untouched — the partnership Q&A REST API keeps using `QandaQuestion`.
+
+### 3. `WebhookPayload` change
+- `questions: List<QandaQuestion>` → `questions: List<WebhookQuestion>`
+  (replace, not duplicate — the payload already carries `partnership`).
+
+### 4. `HttpWebhookGateway` change
+The questions fetch becomes ordered and indexed:
+
+```kotlin
+val questions = QandaQuestionEntity
+    .find { QandaQuestionsTable.partnershipId eq partnershipId }
+    .orderBy(QandaQuestionsTable.createdAt to SortOrder.ASC) // deterministic, app-consistent
+    .mapIndexed { index, entity -> entity.toWebhookQuestion(index) }
+```
+
+This also fixes an inconsistency: the gateway previously fetched questions
+unordered, whereas `QandaRepositoryExposed` always orders by `createdAt ASC`.
+
+## Data flow
+
+`sendWebhook` (per partnership) → fetch `QandaQuestionEntity` rows for the
+partnership, ordered by `createdAt ASC` → `mapIndexed` to `WebhookQuestion`
+(order = list index) → each question maps its `answers` to `WebhookAnswer`
+(order = collection index) → serialized into `WebhookPayload` → POSTed to the
+configured webhook URL.
+
+## Order derivation (the key decision)
+
+`order` is **derived from list position**, not persisted:
+- **Questions**: ordered by `createdAt ASC`, `order` = index (0, 1, 2, …).
+- **Answers**: `order` = position in the entity's `answers` collection.
+
+No DB migration, no API/request changes — contained to the webhook module.
+
+### Known limitation
+Answer order cannot reflect the partner's original input order: answers have no
+timestamp/order column and `QandaRepositoryExposed.update()` deletes and
+recreates them with random UUID primary keys. `order` for answers therefore
+reflects the collection read order, not authored order. Persisting true order
+was the rejected "Persist in DB" alternative.
+
+## Testing
+
+Add a focused test using the existing `insertMockedQandaQuestion` /
+`insertMockedQandaAnswer` factories within a DB transaction, asserting:
+- questions receive `order` 0, 1, 2 … in `createdAt` order;
+- answers receive `order` by position;
+- JSON encoding of `WebhookQuestion` produces wire keys `is_correct` and
+  `order` (serialization contract).
+
+## Out of scope / no change
+- OpenAPI spec — the webhook is an outbound POST, not a documented endpoint.
+- DB migrations.
+- The partnership Q&A REST API (`QandaRepositoryExposed`, `QandaQuestion`).
+- The front end.

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/mappers/QandaWebhookEntity.ext.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/application/mappers/QandaWebhookEntity.ext.kt
@@ -1,0 +1,20 @@
+package fr.devlille.partners.connect.webhooks.application.mappers
+
+import fr.devlille.partners.connect.partnership.infrastructure.db.QandaAnswerEntity
+import fr.devlille.partners.connect.partnership.infrastructure.db.QandaQuestionEntity
+import fr.devlille.partners.connect.webhooks.domain.WebhookAnswer
+import fr.devlille.partners.connect.webhooks.domain.WebhookQuestion
+
+fun QandaQuestionEntity.toWebhookQuestion(order: Int): WebhookQuestion = WebhookQuestion(
+    id = id.value.toString(),
+    question = question,
+    order = order,
+    answers = answers.mapIndexed { index, answer -> answer.toWebhookAnswer(index) },
+)
+
+fun QandaAnswerEntity.toWebhookAnswer(order: Int): WebhookAnswer = WebhookAnswer(
+    id = id.value.toString(),
+    answer = answer,
+    isCorrect = isCorrect,
+    order = order,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookAnswer.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookAnswer.kt
@@ -1,0 +1,13 @@
+package fr.devlille.partners.connect.webhooks.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WebhookAnswer(
+    val id: String,
+    val answer: String,
+    @SerialName("is_correct")
+    val isCorrect: Boolean,
+    val order: Int,
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookPayload.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookPayload.kt
@@ -6,7 +6,6 @@ import fr.devlille.partners.connect.companies.domain.JobOffer
 import fr.devlille.partners.connect.events.domain.EventSummary
 import fr.devlille.partners.connect.partnership.domain.BoothActivity
 import fr.devlille.partners.connect.partnership.domain.PartnershipDetail
-import fr.devlille.partners.connect.partnership.domain.QandaQuestion
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -17,7 +16,7 @@ data class WebhookPayload(
     val event: EventSummary,
     val jobs: List<JobOffer>,
     val activities: List<BoothActivity>,
-    val questions: List<QandaQuestion>,
+    val questions: List<WebhookQuestion>,
     val speakers: List<Speaker>,
     val supportVideoUrl: String? = null,
     val timestamp: String,

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestion.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestion.kt
@@ -1,0 +1,11 @@
+package fr.devlille.partners.connect.webhooks.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WebhookQuestion(
+    val id: String,
+    val question: String,
+    val order: Int,
+    val answers: List<WebhookAnswer> = emptyList(),
+)

--- a/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/infrastructure/gateways/HttpWebhookGateway.kt
+++ b/server/application/src/main/kotlin/fr/devlille/partners/connect/webhooks/infrastructure/gateways/HttpWebhookGateway.kt
@@ -23,6 +23,7 @@ import fr.devlille.partners.connect.partnership.infrastructure.db.QandaQuestions
 import fr.devlille.partners.connect.partnership.infrastructure.db.SpeakerPartnershipEntity
 import fr.devlille.partners.connect.partnership.infrastructure.db.SpeakerPartnershipTable
 import fr.devlille.partners.connect.partnership.infrastructure.db.validatedPack
+import fr.devlille.partners.connect.webhooks.application.mappers.toWebhookQuestion
 import fr.devlille.partners.connect.webhooks.domain.WebhookEventType
 import fr.devlille.partners.connect.webhooks.domain.WebhookGateway
 import fr.devlille.partners.connect.webhooks.domain.WebhookPayload
@@ -36,6 +37,7 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.server.plugins.NotFoundException
 import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
@@ -83,7 +85,8 @@ class HttpWebhookGateway(
                 .map { it.toDomain() }
             val questions = QandaQuestionEntity
                 .find { QandaQuestionsTable.partnershipId eq partnershipId }
-                .map { it.toDomain() }
+                .orderBy(QandaQuestionsTable.createdAt to SortOrder.ASC)
+                .mapIndexed { index, entity -> entity.toWebhookQuestion(index) }
             val speakers = SpeakerPartnershipEntity
                 .find { SpeakerPartnershipTable.partnershipId eq partnershipId }
                 .map { association ->

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/application/QandaWebhookMapperTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/application/QandaWebhookMapperTest.kt
@@ -1,0 +1,66 @@
+package fr.devlille.partners.connect.webhooks.application
+
+import fr.devlille.partners.connect.companies.factories.insertMockedCompany
+import fr.devlille.partners.connect.events.factories.insertMockedFutureEvent
+import fr.devlille.partners.connect.internal.moduleSharedDb
+import fr.devlille.partners.connect.organisations.factories.insertMockedOrganisationEntity
+import fr.devlille.partners.connect.partnership.factories.insertMockedPartnership
+import fr.devlille.partners.connect.partnership.factories.insertMockedQandaAnswer
+import fr.devlille.partners.connect.partnership.factories.insertMockedQandaQuestion
+import fr.devlille.partners.connect.partnership.infrastructure.db.QandaQuestionEntity
+import fr.devlille.partners.connect.sponsoring.factories.insertMockedSponsoringPack
+import fr.devlille.partners.connect.webhooks.application.mappers.toWebhookQuestion
+import io.ktor.client.request.get
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QandaWebhookMapperTest {
+    @Test
+    fun `maps question fields and indexes answers, preserving is_correct`() = testApplication {
+        val userId = UUID.randomUUID()
+        val orgId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val packId = UUID.randomUUID()
+        val companyId = UUID.randomUUID()
+        val partnershipId = UUID.randomUUID()
+        val questionId = UUID.randomUUID()
+
+        application {
+            moduleSharedDb(userId)
+            transaction {
+                insertMockedOrganisationEntity(orgId)
+                insertMockedFutureEvent(eventId, orgId = orgId)
+                insertMockedCompany(companyId, name = "Acme Corp")
+                insertMockedSponsoringPack(packId, eventId)
+                insertMockedPartnership(
+                    id = partnershipId,
+                    eventId = eventId,
+                    companyId = companyId,
+                    selectedPackId = packId,
+                )
+                insertMockedQandaQuestion(id = questionId, partnershipId = partnershipId, question = "What is Kotlin?")
+                insertMockedQandaAnswer(questionId = questionId, answer = "A language", isCorrect = true)
+                insertMockedQandaAnswer(questionId = questionId, answer = "A drink", isCorrect = false)
+                insertMockedQandaAnswer(questionId = questionId, answer = "An island", isCorrect = false)
+            }
+        }
+        client.get("/")
+
+        transaction {
+            val result = QandaQuestionEntity[questionId].toWebhookQuestion(order = 5)
+
+            assertEquals(questionId.toString(), result.id)
+            assertEquals("What is Kotlin?", result.question)
+            assertEquals(5, result.order)
+            assertEquals(3, result.answers.size)
+            // order is derived from collection position, always 0,1,2 for three answers
+            assertEquals(listOf(0, 1, 2), result.answers.map { it.order })
+            assertEquals(1, result.answers.count { it.isCorrect })
+            assertEquals("A language", result.answers.single { it.isCorrect }.answer)
+            assertEquals(setOf("A language", "A drink", "An island"), result.answers.map { it.answer }.toSet())
+        }
+    }
+}

--- a/server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestionTest.kt
+++ b/server/application/src/test/kotlin/fr/devlille/partners/connect/webhooks/domain/WebhookQuestionTest.kt
@@ -1,0 +1,36 @@
+package fr.devlille.partners.connect.webhooks.domain
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WebhookQuestionTest {
+    @Test
+    fun `serializes order and is_correct even at zero-or-false values`() {
+        val question = WebhookQuestion(
+            id = "q1",
+            question = "What is Kotlin?",
+            order = 0,
+            answers = listOf(
+                WebhookAnswer(id = "a1", answer = "A language", isCorrect = true, order = 0),
+                WebhookAnswer(id = "a2", answer = "A drink", isCorrect = false, order = 1),
+            ),
+        )
+
+        val json = Json.encodeToString(WebhookQuestion.serializer(), question)
+
+        // order and is_correct are required (no defaults) -> never dropped, even at 0 / false
+        assertTrue(json.contains("\"is_correct\":true"), json)
+        assertTrue(json.contains("\"is_correct\":false"), json)
+        assertTrue(json.contains("\"order\":0"), json)
+        assertTrue(json.contains("\"order\":1"), json)
+    }
+
+    @Test
+    fun `question defaults answers to empty list`() {
+        val question = WebhookQuestion(id = "q1", question = "x", order = 0)
+
+        assertEquals(emptyList(), question.answers)
+    }
+}


### PR DESCRIPTION
## Summary

Gives the outbound webhook its own Q&A contract, decoupled from the internal `QandaQuestion` domain model.

- Adds `WebhookQuestion` / `WebhookAnswer` domain models (`webhooks/domain`) with an explicit `order`. `order` and `is_correct` are **required** (no Kotlin defaults) so kotlinx.serialization always emits them on the wire — even at `0` / `false`.
- Adds `QandaQuestionEntity.toWebhookQuestion(order)` mapper (`webhooks/application/mappers`) deriving `order` from list position; answers are indexed by their collection position.
- Retypes `WebhookPayload.questions` from `List<QandaQuestion>` → `List<WebhookQuestion>`, dropping the internal `partnership_id` / `created_at` from the wire format.
- `HttpWebhookGateway` now fetches questions ordered by `created_at ASC` (consistent with `QandaRepositoryExposed`; previously unordered) and assigns `order` via `mapIndexed`.

No DB migration, no OpenAPI change, no front-end change, and the partnership Q&A REST API is untouched.

### Known limitation
Answer `order` reflects the entity collection's read position, not the partner's authored order — answers have no timestamp/order column and `update()` recreates them with random UUID PKs. Persisting true order was intentionally out of scope.

## Test Plan
- [x] `WebhookQuestionTest` — serialization keeps `order` and `is_correct` even at `0` / `false`; `answers` defaults to empty list
- [x] `QandaWebhookMapperTest` — DB-backed: maps fields, indexes answers `0,1,2`, preserves `is_correct`
- [x] Full gate green: `./gradlew ktlintCheck detekt test build` — 667 tests, 0 failures/errors

> Note: the branch also commits the design + implementation plan under `docs/superpowers/`. Drop those commits if your repo prefers specs under `server/specs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)